### PR TITLE
fix(server): fix spa route matched 404

### DIFF
--- a/packages/server/server/src/libs/route/matcher.ts
+++ b/packages/server/server/src/libs/route/matcher.ts
@@ -60,6 +60,7 @@ export class RouteMatcher {
       if (urlWithoutSlash.startsWith(this.urlPath)) {
         // avoid /abcd match /a
         if (
+          this.urlPath !== '/' &&
           urlWithoutSlash.length > this.urlPath.length &&
           !urlWithoutSlash.startsWith(`${this.urlPath}/`)
         ) {


### PR DESCRIPTION
fix follow case:

When spa enable. baseUrl is `/`, and user request '/' is okay, but requests '/abc' will respond 404 from server