### PR TITLE
fix: fix language detect in Windows

### DIFF
--- a/.changeset/six-experts-stare.md
+++ b/.changeset/six-experts-stare.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/i18n-cli-language-detector": patch
+---
+
+fix locale detect in Windows

--- a/packages/cli/i18n-cli-language-detector/src/index.ts
+++ b/packages/cli/i18n-cli-language-detector/src/index.ts
@@ -11,7 +11,9 @@ class I18CLILanguageDetector {
       // Get `en_US` part from `en_US.UTF-8`
       .split('.')[0]
       // Slice en_US to en
-      .split('_')[0];
+      .split('_')[0]
+      // slice en-US to en
+      .split('-')[0];
 
     if (LC === 'C') {
       return '';
@@ -25,7 +27,8 @@ class I18CLILanguageDetector {
       process.env.LC_ALL ??
       process.env.LC_MESSAGES ??
       process.env.LANG ??
-      process.env.LANGUAGE;
+      process.env.LANGUAGE ??
+      Intl.DateTimeFormat().resolvedOptions().locale;
 
     return this.formatShellLocale(shellLocale);
   }


### PR DESCRIPTION
For some unknown reasons, process.env.LC_ALL || process.env.LC_MESSAGES || process.env.LANG || process.env.LANGUAGE gets 'undefined' at Windows Node enviorment, so we add  Intl.DateTimeFormat().resolvedOptions().locale methods for detecting user locale.

reference:
1. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
2. https://stackoverflow.com/questions/46072248/node-js-how-to-detect-user-language 