### PR TITLE
Fix webpack peerdeps

### DIFF
--- a/packages/cli/plugin-storybook/src/features/utils/generate.ts
+++ b/packages/cli/plugin-storybook/src/features/utils/generate.ts
@@ -44,9 +44,16 @@ export type PreviewOptions = {
 };
 
 const PREVIEW_TEMPLATE = path.join(STORYBOOK_TEMPLATE_DIR, 'preview.tmpl');
+const USER_PREVIEW_TEMPLATE = path.join(
+  STORYBOOK_TEMPLATE_DIR,
+  'user-preview.tmpl',
+);
 
 export const generatePreview = (options: PreviewOptions) => {
-  const previewTemplate = fs.readFileSync(PREVIEW_TEMPLATE, 'utf-8');
+  const previewTemplate = fs.readFileSync(
+    options.userPreviewPath ? USER_PREVIEW_TEMPLATE : PREVIEW_TEMPLATE,
+    'utf-8',
+  );
   const injects: Record<string, string> = {
     userPreviewPath: options.userPreviewPath || '',
     runtime: JSON.stringify(options.runtime || {}),

--- a/packages/cli/plugin-storybook/template/preview.tmpl
+++ b/packages/cli/plugin-storybook/template/preview.tmpl
@@ -1,33 +1,8 @@
-const userPreviewPath = '<%= userPreviewPath %>'
-const isUserMode = !!userPreviewPath
+const parameters = {
+    modernConfigRuntime: <%= runtime %>,
+    modernConfigDesignToken: <%= designToken %>
+};
 
-if (isUserMode) {
-    const userPreview = require('<%= userPreviewPath %>');
-
-    const decorators = [...(userPreview.decorators || [])];
-
-    const parameters = {
-        ...(userPreview.parameters || {}),
-        modernConfigRuntime: <%= runtime %>,
-        modernConfigDesignToken: <%= designToken %>
-    };
-
-    const globalTypes = {
-        ...(userPreview.globalTypes || {}),
-    };
-
-    module.exports = {
-        decorators,
-        parameters,
-        globalTypes,
-    };
-} else {
-    const parameters = {
-        modernConfigRuntime: <%= runtime %>,
-        modernConfigDesignToken: <%= designToken %>
-    };
-
-    module.exports = {
-        parameters,
-    };
-}
+module.exports = {
+    parameters,
+};

--- a/packages/cli/plugin-storybook/template/user-preview.tmpl
+++ b/packages/cli/plugin-storybook/template/user-preview.tmpl
@@ -1,0 +1,19 @@
+const userPreview = require('<%= userPreviewPath %>');
+
+const decorators = [...(userPreview.decorators || [])];
+
+const parameters = {
+    ...(userPreview.parameters || {}),
+    modernConfigRuntime: <%= runtime %>,
+    modernConfigDesignToken: <%= designToken %>
+};
+
+const globalTypes = {
+    ...(userPreview.globalTypes || {}),
+};
+
+module.exports = {
+    decorators,
+    parameters,
+    globalTypes,
+};

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -51,6 +51,7 @@
     "@modern-js/server": "workspace:^1.1.0",
     "@modern-js/utils": "workspace:^1.1.0",
     "@modern-js/webpack": "workspace:^1.1.0",
+    "esbuild": "^0.13.13",
     "webpack": "^5.54.0"
   },
   "devDependencies": {


### PR DESCRIPTION
由于 webpack peerDeps esbuild，因此在使用 app-tools的时候需要安装 esbuild，这样也解决了其他模块依赖webpack，并且没有安装esbuild的情况。目前用户项目下可能因为这个原因出现相同版本两个webpack的情况，一个名字是 webpack@xxx，另一个名字是 webpack@xxx_esbuild@xx。这样导致运行时候可能出现问题，目前是storybook调试运行出现问题。

补充 webpack 不是直接 peerDeps esbuild，webpack因为依赖了 terser-webpack-plugin,terser-webpack-plugin peerOptionalDeps esbuild，导致 webpack也具有 peerOptionalDeps。