### PR TITLE
feat: reduce lint time at CI workflow

### DIFF
--- a/.changeset/nervous-waves-help.md
+++ b/.changeset/nervous-waves-help.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/plugin-jarvis": patch
+---
+
+feat: provide a way to eslint changed files only

--- a/.github/workflows/lint-Windows.yml
+++ b/.github/workflows/lint-Windows.yml
@@ -20,7 +20,8 @@ jobs:
       matrix:
         node-version: [14.x]
         os: [windows-latest] # ubuntu-latest
-
+    env:
+      LINT_CHANGED_FILES: true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Setup Node.js ${{ matrix.node-version }}
@@ -30,6 +31,15 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - run: git fetch
+#      - name: Fetch origin main branch
+#        run: |
+#            git fetch --no-tags --depth=1 origin main
+#            git checkout -b main
+#            git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Init
         run: npm install -g pnpm && pnpm run setup
@@ -38,4 +48,4 @@ jobs:
         run: pnpm run prepare --filter ./packages
 
       - name: Lint
-        run: pnpm run lint
+        run: pnpm run lint:check

--- a/.github/workflows/lint-macOS.yml
+++ b/.github/workflows/lint-macOS.yml
@@ -20,7 +20,8 @@ jobs:
       matrix:
         node-version: [14.x, 16.x]
         os: [macos-latest] # ubuntu-latest
-
+    env:
+      LINT_CHANGED_FILES: true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Setup Node.js ${{ matrix.node-version }}
@@ -30,6 +31,15 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - run: git fetch
+#      - name: Fetch origin main branch
+#        run: |
+#          git fetch --no-tags --depth=1 origin main
+#          git checkout -b main
+#          git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Init
         run: npm install -g pnpm && pnpm run setup
@@ -38,4 +48,4 @@ jobs:
         run: pnpm run prepare --filter ./packages
 
       - name: Lint
-        run: pnpm run lint
+        run: pnpm run lint:check

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "pnpm run test --filter ./packages",
     "prepare": "pnpm run prepare --filter ./packages",
     "lint": "modern lint",
+    "lint:check": "modern lint --no-fix",
     "change": "modern change",
     "clear": "modern clear",
     "deploy": "modern deploy",

--- a/packages/cli/plugin-jarvis/src/lint.ts
+++ b/packages/cli/plugin-jarvis/src/lint.ts
@@ -35,7 +35,13 @@ export default () => {
     rawArgs.push(...ensureOption(args, 'ignore-pattern', pattern));
   });
 
-  if (args?._?.length) {
+  // To speed up eslint, develop can set LINT_CHANGED_FILES=true
+  // to activate eslint only works on changed files compared to origin/main branch
+  if (process.env.LINT_CHANGED_FILES) {
+    rawArgs.push(
+      `--no-error-on-unmatched-pattern $(git diff --name-only origin/main...HEAD | xargs)`,
+    );
+  } else if (args?._?.length) {
     rawArgs.push(...args._);
   } else {
     rawArgs.push('./');


### PR DESCRIPTION
As now eslint process will cover all files in projects, and it took too much time, we aim to reduce lint time by only lint changed files compared to origin/main branch