### PR TITLE
fix(changeset-generator): changeset default branch should be `main`

### DIFF
--- a/packages/generator/generators/changeset-generator/templates/.changeset/config.json
+++ b/packages/generator/generators/changeset-generator/templates/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "restricted",
-  "baseBranch": "master",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []
 }


### PR DESCRIPTION
Branch in some setting should be `main` by default for github open source project