### PR TITLE
feat: change default branch main

### DIFF
--- a/.changeset/honest-dogs-refuse.md
+++ b/.changeset/honest-dogs-refuse.md
@@ -1,0 +1,6 @@
+---
+"@modern-js/changeset-generator": patch
+"@modern-js/create": patch
+---
+
+feat: change initial repo default branch

--- a/packages/generator/generators/changeset-generator/src/index.ts
+++ b/packages/generator/generators/changeset-generator/src/index.ts
@@ -2,8 +2,13 @@ import { GeneratorContext, GeneratorCore } from '@modern-js/codesmith';
 import { AppAPI } from '@modern-js/codesmith-api-app';
 import { i18n } from '@modern-js/generator-common';
 
-const handleTemplateFile = async (appApi: AppAPI) => {
-  await appApi.forgeTemplate('templates/**/*');
+const handleTemplateFile = async (
+  appApi: AppAPI,
+  context: GeneratorContext,
+) => {
+  await appApi.forgeTemplate('templates/**/*', undefined, undefined, {
+    defaultBranch: context.config.defaultBranch || 'master',
+  });
 };
 
 export default async (context: GeneratorContext, generator: GeneratorCore) => {
@@ -22,7 +27,7 @@ export default async (context: GeneratorContext, generator: GeneratorCore) => {
   generator.logger.debug(`context=${JSON.stringify(context)}`);
   generator.logger.debug(`context.data=${JSON.stringify(context.data)}`);
 
-  await handleTemplateFile(appApi);
+  await handleTemplateFile(appApi, context);
 
   generator.logger.debug(`forge @modern-js/changeset-generator succeed `);
 };

--- a/packages/generator/generators/changeset-generator/templates/.changeset/config.json
+++ b/packages/generator/generators/changeset-generator/templates/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "restricted",
-  "baseBranch": "master",
+  "baseBranch": "{{ defaultBranch }}",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/packages/toolkit/create/src/createAction.ts
+++ b/packages/toolkit/create/src/createAction.ts
@@ -60,6 +60,8 @@ function getDefaultConfing(options: Options, logger: Logger) {
     initialConfig.distTag = distTag;
   }
 
+  initialConfig.defaultBranch = initialConfig.defaultBranch || 'main';
+
   return initialConfig;
 }
 


### PR DESCRIPTION
codesmith 执行 git init 时，获取 context 上的 defaultBranch 配置，并切换到 defaultBranch 对应分支

https://github.com/modern-js-dev/codesmith/pull/23

在 Modern.js 中，默认使用 main 分支作为默认分支，如果需要修改默认分支，可以在 --config 参数中增加 defaultBranch 配置。