### PR TITLE
feat: show lint error in CI console

### DIFF
--- a/.changeset/thin-insects-promise.md
+++ b/.changeset/thin-insects-promise.md
@@ -1,0 +1,5 @@
+---
+"@modern-js-app/eslint-config": patch
+---
+
+fix crlf problem in windows lint

--- a/.github/workflows/lint-Windows.yml
+++ b/.github/workflows/lint-Windows.yml
@@ -47,4 +47,4 @@ jobs:
 
       - name: Lint
         if: ${{steps.docs-change.outputs.DOCS_CHANGE != 'docs only change'}}
-        run: pnpm run lint -- --no-fix
+        run: npm run lint -- --no-fix

--- a/.github/workflows/lint-Windows.yml
+++ b/.github/workflows/lint-Windows.yml
@@ -51,4 +51,4 @@ jobs:
 
       - name: Lint
         if: ${{steps.docs-change.outputs.DOCS_CHANGE != 'docs only change'}}
-        run: npm run lint -- --no-fix
+        run: pnpm run lint "--" --no-fix

--- a/.github/workflows/lint-Windows.yml
+++ b/.github/workflows/lint-Windows.yml
@@ -47,4 +47,4 @@ jobs:
 
       - name: Lint
         if: ${{steps.docs-change.outputs.DOCS_CHANGE != 'docs only change'}}
-        run: pnpm run lint
+        run: pnpm run lint -- --no-fix

--- a/packages/cli/plugin-i18n/src/index.ts
+++ b/packages/cli/plugin-i18n/src/index.ts
@@ -1,5 +1,5 @@
 import { get } from 'lodash';
-import { getObjKeyMap } from './utils/index';
+import { getObjKeyMap } from './utils';
 
 type Language = string;
 

--- a/packages/cli/plugin-ssg/src/libs/output.ts
+++ b/packages/cli/plugin-ssg/src/libs/output.ts
@@ -9,7 +9,7 @@ export function writeHtmlFile(
 ) {
   htmlAry.forEach((html: any, index: number) => {
     const ssgRoute = ssgRoutes[index];
-    const filepath = path.join(baseDir, ssgRoute.output!);
+    const filepath = path.join(baseDir, ssgRoute.output);
     if (!fs.existsSync(path.dirname(filepath))) {
       fs.ensureDirSync(path.dirname(filepath));
     }

--- a/packages/cli/plugin-testing/src/cli/index.ts
+++ b/packages/cli/plugin-testing/src/cli/index.ts
@@ -1,8 +1,5 @@
 import path from 'path';
-import {
-  createRuntimeExportsUtils,
-  PLUGIN_SCHEMAS,
-} from '@modern-js/utils';
+import { createRuntimeExportsUtils, PLUGIN_SCHEMAS } from '@modern-js/utils';
 import { createPlugin, useAppContext } from '@modern-js/core';
 import test from './test';
 

--- a/packages/review/eslint-config-app/eslintrc.js
+++ b/packages/review/eslint-config-app/eslintrc.js
@@ -997,6 +997,7 @@ module.exports = {
         bracketSpacing: true,
         jsxBracketSameLine: true,
         arrowParens: 'avoid',
+        endOfLine: 'auto',
       },
     ],
 
@@ -1717,7 +1718,7 @@ module.exports = {
     // https://github.com/mysticatea/eslint-plugin-node/blob/HEAD/docs/rules/process-exit-as-throw.md
     'node/process-exit-as-throw': 'off',
     // https://github.com/mysticatea/eslint-plugin-node/blob/HEAD/docs/rules/shebang.md
-    'node/shebang': 'error',
+    'node/shebang': 'off',
     // https://github.com/mysticatea/eslint-plugin-node/blob/HEAD/docs/rules/no-deprecated-api.md
     'node/no-deprecated-api': 'off',
     // https://github.com/mysticatea/eslint-plugin-node/blob/HEAD/docs/rules/exports-style.md


### PR DESCRIPTION
As now default command "modern lint" in CI workflow will silently fix all errors, it did not provide the "check code format error" feature as expected, so this commit will fix the ci workflow file to make it work.

现在默认在 CI 工作流运行的"modern lint"会静默修复错误，没有如预期提示代码错误，所以这笔提交修复了这个错误，现在可正确显示错误并提示修改