### PR TITLE
fix: fix "initialize" param wrongfully ignored problem

### DIFF
--- a/packages/cli/plugin-analyze/src/generateCode.ts
+++ b/packages/cli/plugin-analyze/src/generateCode.ts
@@ -61,6 +61,12 @@ const createImportStatements = (statements: ImportStatement[]): string => {
       seen.set(value, specifiers);
     } else {
       seen.get(value).push(...specifiers);
+      // make "initialize" param can be connected when multiple plugins were imported from same package
+      const modifyIndex = deDuplicated.findIndex(v => v.value === value);
+      const originInitialize = deDuplicated[modifyIndex]?.initialize ?? '';
+      deDuplicated[modifyIndex].initialize = originInitialize.concat(
+        `\n${initialize || ''}`,
+      );
     }
   }
 


### PR DESCRIPTION
Now, when we use `modifyEntryImports` hook in `createPlugin` function, we can import a plugin to a specified package, like the code shown below:
```typescript
modifyEntryImports({ entrypoint, imports }: any) {
      imports.push({
            value: '@modern-js/runtime/plugins',
            specifiers: [{ imported: 'foo' }],
      });
}
```
And, if we need to add some extra logic while importing plugins, we could use `initialize` param:
```typescript
modifyEntryImports({ entrypoint, imports }: any) {
      imports.push({
            value: '@modern-js/runtime/plugins',
            specifiers: [{ imported: 'foo' }],
            // put extra logic here in `initialize` 
           initialize: `console.log('This is foo plugin extra logic')`
      });
}
```
That would result in modern.js generated project node_modules/.modern-js/main/index.js like:
(Of course you need to import 'foo' plugin at first)
```
import {router,foo} from '@modern-js/runtime/plugins'
console.log('This is foo plugin extra logic')
```
But, when we use `initialize` in different plugin that are imported from same package(such as `@modern-js/runtime/plugins`), the framework could only accept the first plugin's `initialize` param.
This PR would fix the problem.

