### PR TITLE
fix: add missing change-set for "@modern-js/plugin-analyze"

### DIFF
--- a/.changeset/strong-windows-divide.md
+++ b/.changeset/strong-windows-divide.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/plugin-analyze": patch
+---
+
+fix: fix "initialize" param wrongfully ignored problem


### PR DESCRIPTION
Add missing changeset for "@modern-js/plugin-analyze" in [#408](https://github.com/modern-js-dev/modern.js/commit/f78d9d3d266d9a0f86ccf1d00f542dbad03fcb96)