### PR TITLE
feat(plugin-analyze): add beforeGenerateRoutes hook

### DIFF
--- a/packages/cli/plugin-analyze/src/generateCode.ts
+++ b/packages/cli/plugin-analyze/src/generateCode.ts
@@ -45,7 +45,9 @@ const createImportSpecifier = (specifiers: ImportSpecifier[]): string => {
   }
 };
 
-const createImportStatements = (statements: ImportStatement[]): string => {
+export const createImportStatements = (
+  statements: ImportStatement[],
+): string => {
   // merge import statements with the same value.
   const deDuplicated: ImportStatement[] = [];
 
@@ -108,12 +110,17 @@ export const generateCode = async (
           routes: initialRoutes,
         });
 
+        const { code } = await mountHook().beforeGenerateRoutes({
+          entrypoint,
+          code: templates.fileSystemRoutes({ routes }),
+        });
+
         fs.outputFileSync(
           path.resolve(
             internalDirectory,
             `./${entryName}/${FILE_SYSTEM_ROUTES_FILE_NAME}`,
           ),
-          templates.fileSystemRoutes({ routes }),
+          code,
           'utf8',
         );
       }

--- a/packages/cli/plugin-analyze/src/index.ts
+++ b/packages/cli/plugin-analyze/src/index.ts
@@ -51,6 +51,11 @@ export const htmlPartials = createAsyncWaterfall<{
   partials: HtmlPartials;
 }>();
 
+export const beforeGenerateRoutes = createAsyncWaterfall<{
+  entrypoint: Entrypoint;
+  code: string;
+}>();
+
 registerHook({
   modifyEntryImports,
   modifyEntryExport,
@@ -60,6 +65,7 @@ registerHook({
   modifyServerRoutes,
   htmlPartials,
   addRuntimeExports,
+  beforeGenerateRoutes,
 });
 
 export default createPlugin(

--- a/packages/cli/plugin-analyze/tests/generateCode.test.ts
+++ b/packages/cli/plugin-analyze/tests/generateCode.test.ts
@@ -1,0 +1,64 @@
+import { createImportStatements } from '../src/generateCode';
+
+describe('generate code', () => {
+  test('should create import statements sucessfully', () => {
+    const statement = createImportStatements([
+      {
+        value: 'react',
+        specifiers: [
+          {
+            local: 'React',
+          },
+          {
+            imported: 'useState',
+          },
+          {
+            imported: 'useEffect',
+          },
+        ],
+      },
+    ]);
+    expect(statement).toEqual(
+      `import React, { useState, useEffect } from 'react';\n`,
+    );
+  });
+
+  test('should merge statements', () => {
+    const statement = createImportStatements([
+      {
+        value: 'a',
+        specifiers: [
+          {
+            local: 'b',
+            imported: 'c',
+          },
+        ],
+      },
+      {
+        value: 'a',
+        specifiers: [
+          {
+            imported: 'd',
+          },
+        ],
+      },
+    ]);
+    expect(statement).toEqual(`import { c as b, d } from 'a';\n\n`);
+  });
+
+  test(`should create import statement with initilize string`, () => {
+    expect(
+      createImportStatements([
+        {
+          value: 'a',
+          specifiers: [
+            {
+              local: 'a',
+            },
+          ],
+          initialize: 'console.log(a);',
+        },
+      ]),
+    ).toEqual(`import a from 'a';\nconsole.log(a);`);
+  });
+});

--- a/packages/toolkit/types/cli/index.d.ts
+++ b/packages/toolkit/types/cli/index.d.ts
@@ -121,4 +121,8 @@ export interface Hooks {
     partials: HtmlPartials;
   }>;
   addRuntimeExports: AsyncWaterfall<void>;
+  beforeGenerateRoutes: AsyncWaterfall<{
+    entrypoint: Entrypoint;
+    code: string;
+  }>;
 }


### PR DESCRIPTION
 添加修改生成 routes 文件的 hook:

```js
export const beforeGenerateRoutes = createAsyncWaterfall<{
  routes: ServerRoute[];
}>();
```