### PR TITLE
feat: add *.global.less/sass/scss support

### DIFF
--- a/.changeset/flat-goats-argue.md
+++ b/.changeset/flat-goats-argue.md
@@ -1,0 +1,7 @@
+---
+"@modern-js/plugin-less": patch
+"@modern-js/plugin-sass": patch
+"@modern-js/webpack": patch
+---
+
+feat: add \*.global.less/sass/scss support when "output.disableCssModuleExtension" is true

--- a/packages/cli/plugin-less/tests/.eslintrc.js
+++ b/packages/cli/plugin-less/tests/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['@modern-js'],
+  parserOptions: {
+    project: require.resolve('./tsconfig.json'),
+  },
+};

--- a/packages/cli/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/cli/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`plugin less test config 1`] = `
+Array [
+  Object {
+    "tools": Object {
+      "webpack": [Function],
+    },
+  },
+]
+`;
+
+exports[`plugin less test schema 1`] = `
+Array [
+  Array [
+    Object {
+      "schema": Object {
+        "typeof": Array [
+          "object",
+          "function",
+        ],
+      },
+      "target": "tools.less",
+    },
+  ],
+]
+`;

--- a/packages/cli/plugin-less/tests/index.test.ts
+++ b/packages/cli/plugin-less/tests/index.test.ts
@@ -1,9 +1,39 @@
-import plugin from '../src';
-import plugin2 from '../src/cli';
+import path from 'path';
+import { manager } from '@modern-js/core';
+import plugin from '../src/cli';
 
-describe('plugin-less', () => {
-  it('default', () => {
-    expect(plugin).toBeDefined();
-    expect(plugin).toBe(plugin2);
+const root = path.normalize(path.resolve(__dirname, '../../../../'));
+expect.addSnapshotSerializer({
+  test: val =>
+    typeof val === 'string' &&
+    (val.includes('modern.js') ||
+      val.includes('node_modules') ||
+      val.includes(root)),
+  print: val =>
+    // eslint-disable-next-line no-nested-ternary
+    typeof val === 'string'
+      ? // eslint-disable-next-line no-nested-ternary
+        val.includes('node_modules')
+        ? `"${val.replace(/.+node_modules/, '')}"`
+        : val.includes('modern.js')
+        ? `"${val.replace(/.+modern\.js/, '')}"`
+        : `"${val.replace(root, '')}"`
+      : (val as string),
+});
+
+describe('plugin less test', () => {
+  it('schema', async () => {
+    const main = manager.clone().usePlugin(plugin);
+    const runner = await main.init();
+    const result = await runner.validateSchema();
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('config', async () => {
+    const main = manager.clone().usePlugin(plugin);
+    const runner = await main.init();
+    const result = await runner.config();
+    expect(result).toMatchSnapshot();
   });
 });

--- a/packages/cli/plugin-less/tests/tsconfig.json
+++ b/packages/cli/plugin-less/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "isolatedModules": true,
+    "paths": {}
+  }
+}

--- a/packages/cli/plugin-sass/tests/.eslintrc.js
+++ b/packages/cli/plugin-sass/tests/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['@modern-js'],
+  parserOptions: {
+    project: require.resolve('./tsconfig.json'),
+  },
+};

--- a/packages/cli/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/cli/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`plugin sass test config 1`] = `
+Array [
+  Object {
+    "tools": Object {
+      "webpack": [Function],
+    },
+  },
+]
+`;
+
+exports[`plugin sass test schema 1`] = `
+Array [
+  Array [
+    Object {
+      "schema": Object {
+        "typeof": Array [
+          "object",
+          "function",
+        ],
+      },
+      "target": "tools.sass",
+    },
+  ],
+]
+`;

--- a/packages/cli/plugin-sass/tests/index.test.ts
+++ b/packages/cli/plugin-sass/tests/index.test.ts
@@ -1,9 +1,39 @@
-import plugin from '../src';
-import plugin2 from '../src/cli';
+import path from 'path';
+import { manager } from '@modern-js/core';
+import plugin from '../src/cli';
 
-describe('plugin-sass', () => {
-  it('default', () => {
-    expect(plugin).toBeDefined();
-    expect(plugin).toBe(plugin2);
+const root = path.normalize(path.resolve(__dirname, '../../../../'));
+expect.addSnapshotSerializer({
+  test: val =>
+    typeof val === 'string' &&
+    (val.includes('modern.js') ||
+      val.includes('node_modules') ||
+      val.includes(root)),
+  print: val =>
+    // eslint-disable-next-line no-nested-ternary
+    typeof val === 'string'
+      ? // eslint-disable-next-line no-nested-ternary
+        val.includes('node_modules')
+        ? `"${val.replace(/.+node_modules/, '')}"`
+        : val.includes('modern.js')
+        ? `"${val.replace(/.+modern\.js/, '')}"`
+        : `"${val.replace(root, '')}"`
+      : (val as string),
+});
+
+describe('plugin sass test', () => {
+  it('schema', async () => {
+    const main = manager.clone().usePlugin(plugin);
+    const runner = await main.init();
+    const result = await runner.validateSchema();
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('config', async () => {
+    const main = manager.clone().usePlugin(plugin);
+    const runner = await main.init();
+    const result = await runner.config();
+    expect(result).toMatchSnapshot();
   });
 });

--- a/packages/cli/plugin-sass/tests/tsconfig.json
+++ b/packages/cli/plugin-sass/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "isolatedModules": true,
+    "paths": {}
+  }
+}

--- a/packages/cli/webpack/src/utils/constants.ts
+++ b/packages/cli/webpack/src/utils/constants.ts
@@ -2,6 +2,8 @@ export const CSS_REGEX = /\.css$/;
 
 export const CSS_MODULE_REGEX = /\.module\.css$/;
 
+export const GLOBAL_CSS_REGEX = /\.global\.css$/;
+
 export const JS_REGEX = /\.(js|mjs|jsx)$/;
 
 export const TS_REGEX = /\.tsx?$/;


### PR DESCRIPTION
**Goal:** 
add *.global.less/sass/scss support when output.disableCssModuleExtension is set to true.
**Info:** 
When we follow the [tourrial](https://modernjs.dev/docs/guides/usages/css/css-modules#%E5%85%A8%E9%9D%A2%E5%90%AF%E7%94%A8-css-modules) and set `output.disableCssModuleExtension` to true, all css/less/sass files will be considered as css modules files if they were not named as `[name].global.css`.
```css
/* app.global.css */
.bg-blue {
  background-color: blue;
}
```
But css support is **not enough**, the developers might also want to use less/sass/scss for further uses.
So this PR provides the ability to fulfill their wishes:)