### PR TITLE
feat: terminate whistle proxy when exiting the process

### DIFF
--- a/.changeset/late-coins-judge.md
+++ b/.changeset/late-coins-judge.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/plugin-proxy": patch
+---
+
+fix: terminate whistle proxy when exiting the process

--- a/packages/cli/plugin-proxy/src/index.ts
+++ b/packages/cli/plugin-proxy/src/index.ts
@@ -7,6 +7,7 @@ import { PLUGIN_SCHEMAS } from '@modern-js/utils';
 import { createProxyRule } from './utils/createProxyRule';
 import WhistleProxy from './utils/whistleProxy';
 
+let proxyServer: WhistleProxy;
 export default createPlugin(
   () => ({
     validateSchema() {
@@ -23,14 +24,12 @@ export default createPlugin(
       }
 
       const rule = createProxyRule(internalDirectory, (dev as any).proxy);
-      const proxyServer = new WhistleProxy({ port: 8899, rule });
+      proxyServer = new WhistleProxy({ port: 8899, rule });
       await proxyServer.start();
-
-      // TODO
-      // should exit proxy server before process exit
-      // api.on('process-exit', () => {
-      //   proxyServer.close();
-      // });
+    },
+    beforeExit() {
+      // terminate whistle proxy
+      proxyServer?.close();
     },
   }),
   { name: '@modern-js/plugin-proxy' },

--- a/packages/cli/plugin-proxy/src/utils/whistleProxy.ts
+++ b/packages/cli/plugin-proxy/src/utils/whistleProxy.ts
@@ -62,6 +62,6 @@ export default class WhistleProxy {
   close() {
     execSync(`${this.bin} stop`);
     disableGlobalProxy();
-    logger.info(`Proxy Server has closed`);
+    logger.info(`Proxy Server has been closed`);
   }
 }

--- a/packages/cli/plugin-proxy/tests/.eslintrc.js
+++ b/packages/cli/plugin-proxy/tests/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['@modern-js'],
+  parserOptions: {
+    project: require.resolve('./tsconfig.json'),
+  },
+};

--- a/packages/cli/plugin-proxy/tests/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/plugin-proxy/tests/__snapshots__/cli.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`plugin proxy test config 1`] = `Array []`;
+
+exports[`plugin proxy test schema 1`] = `
+Array [
+  Array [
+    Object {
+      "schema": Object {
+        "typeof": Array [
+          "string",
+          "object",
+        ],
+      },
+      "target": "dev.proxy",
+    },
+  ],
+]
+`;

--- a/packages/cli/plugin-proxy/tests/cli.test.ts
+++ b/packages/cli/plugin-proxy/tests/cli.test.ts
@@ -1,0 +1,39 @@
+import path from 'path';
+import { manager } from '@modern-js/core';
+import plugin from '../src';
+
+const root = path.normalize(path.resolve(__dirname, '../../../../'));
+expect.addSnapshotSerializer({
+  test: val =>
+    typeof val === 'string' &&
+    (val.includes('modern.js') ||
+      val.includes('node_modules') ||
+      val.includes(root)),
+  print: val =>
+    // eslint-disable-next-line no-nested-ternary
+    typeof val === 'string'
+      ? // eslint-disable-next-line no-nested-ternary
+        val.includes('node_modules')
+        ? `"${val.replace(/.+node_modules/, '')}"`
+        : val.includes('modern.js')
+        ? `"${val.replace(/.+modern\.js/, '')}"`
+        : `"${val.replace(root, '')}"`
+      : (val as string),
+});
+
+describe('plugin proxy test', () => {
+  it('schema', async () => {
+    const main = manager.clone().usePlugin(plugin);
+    const runner = await main.init();
+    const result = await runner.validateSchema();
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('config', async () => {
+    const main = manager.clone().usePlugin(plugin);
+    const runner = await main.init();
+    const result = await runner.config();
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/cli/plugin-proxy/tests/index.test.ts
+++ b/packages/cli/plugin-proxy/tests/index.test.ts
@@ -1,7 +1,0 @@
-import plugin from '../src';
-
-describe('plugin-proxy', () => {
-  it('default', () => {
-    expect(plugin).toBeDefined();
-  });
-});

--- a/packages/cli/plugin-proxy/tests/tsconfig.json
+++ b/packages/cli/plugin-proxy/tests/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": true,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "paths": {},
+    "types": ["node", "jest"]
+  }
+}


### PR DESCRIPTION
# PR Details

Terminate "whistle" proxy when exiting the process

## Description

When developers use @modern-js/plugin-proxy for proxy uses, modern.js will not automatically close "whistle" proxy when terminating the process.

This PR will fix this problem.


## How Has This Been Tested

With unit test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.