### PR TITLE
fix: hot module reload for react app throwing exception

### DIFF
--- a/.changeset/dry-goats-press.md
+++ b/.changeset/dry-goats-press.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/hmr-client": patch
+---
+
+revert 'react-error-overlay' to a stable version

--- a/packages/server/hmr-client/package.json
+++ b/packages/server/hmr-client/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@babel/runtime": "^7",
     "@modern-js/utils": "workspace:^1.1.6",
-    "react-error-overlay": "^6.0.9",
+    "react-error-overlay": "6.0.9",
     "strip-ansi": "^7.0.0",
     "url": "^0.11.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3301,7 +3301,7 @@ importers:
       '@types/node': ^14
       esbuild: ^0.13.13
       jest: ^27
-      react-error-overlay: ^6.0.9
+      react-error-overlay: 6.0.9
       strip-ansi: ^7.0.0
       typescript: ^4
       url: ^0.11.0
@@ -3310,7 +3310,7 @@ importers:
       '@babel/runtime': 7.16.7
       '@modern-js/utils': link:../../toolkit/utils
       esbuild: 0.13.15
-      react-error-overlay: 6.0.10
+      react-error-overlay: 6.0.9
       strip-ansi: 7.0.1
       url: 0.11.0
     devDependencies:
@@ -29689,6 +29689,12 @@ packages:
     resolution: {integrity: sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==}
     dependencies:
       esbuild: 0.13.15
+
+  /react-error-overlay/6.0.9:
+    resolution: {integrity: sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==}
+    dependencies:
+      esbuild: 0.13.15
+    dev: false
 
   /react-fast-compare/3.2.0:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}


### PR DESCRIPTION
refer to github issue: https://github.com/facebook/create-react-app/issues/11771

# PR Details

create-react-app v6.0.10 causes exception on dev server hot module replacement

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
