### PR TITLE
fix: fix esbuild error when project's tsconfig.json sets "target:es5"

### DIFF
--- a/.changeset/lucky-birds-laugh.md
+++ b/.changeset/lucky-birds-laugh.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/node-bundle-require": patch
+---
+
+fix esbuild error when project's tsconfig.json sets "target:es5"

--- a/packages/toolkit/node-bundle-require/src/index.ts
+++ b/packages/toolkit/node-bundle-require/src/index.ts
@@ -66,6 +66,10 @@ export async function bundleRequire(filepath: string, options?: Options) {
     format: 'cjs',
     platform: 'node',
     bundle: true,
+    // fix transforming error when the project's tsconfig.json
+    // sets `target: "es5"`
+    // reference: https://github.com/evanw/esbuild/releases/tag/v0.12.6
+    target: 'esnext',
     ...options?.esbuildOptions,
     plugins: [
       ...(options?.esbuildPlugins || []),

--- a/packages/toolkit/node-bundle-require/tests/fixture/a.ts
+++ b/packages/toolkit/node-bundle-require/tests/fixture/a.ts
@@ -1,1 +1,2 @@
 export const filename: string = __filename;
+export const showFileName = () => filename;

--- a/packages/toolkit/node-bundle-require/tests/index.test.ts
+++ b/packages/toolkit/node-bundle-require/tests/index.test.ts
@@ -6,6 +6,7 @@ test('require', async () => {
     path.join(__dirname, './fixture/input.ts'),
   );
   expect(result.default.a.filename.endsWith('a.ts')).toEqual(true);
+  expect(result.default.a.showFileName().endsWith('a.ts')).toEqual(true);
 });
 
 describe('external regexp', () => {

--- a/packages/toolkit/node-bundle-require/tests/index.test.ts
+++ b/packages/toolkit/node-bundle-require/tests/index.test.ts
@@ -5,6 +5,12 @@ test('require', async () => {
   const result = await bundleRequire(
     path.join(__dirname, './fixture/input.ts'),
   );
+  // when tsconfig.json sets `compilerOptions.target` to `es5`
+  // normally it will met error
+  // So we need to manually set esbuild's target to esnext to avoid that
+  // These two cases above use ES6+ ability, to test whether esbuild successfuly
+  // works on non-ES5 files
+  // reference: https://github.com/evanw/esbuild/releases/tag/v0.12.6
   expect(result.default.a.filename.endsWith('a.ts')).toEqual(true);
   expect(result.default.a.showFileName().endsWith('a.ts')).toEqual(true);
 });

--- a/packages/toolkit/node-bundle-require/tests/tsconfig.json
+++ b/packages/toolkit/node-bundle-require/tests/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
     "declaration": false,
+    "target": "es5",
     "jsx": "preserve",
     "baseUrl": "./",
     "paths": {}


### PR DESCRIPTION
# PR Details

fix esbuild error when project's tsconfig.json sets "target:es5"

## Description

Problem: When use modern.config.js for configuration in modern.js project, which has some typings that ES5 doesn't support, like `const`
```typescript
// modern.config.ts
const a=1;
```
and tsconfig.json has been set as “target:es5"
```typescript
{
  "compilerOptions": {
    "target": "es5",
  }
}
```

The Compiler will throw error like this:
```shell
Transforming const to the configured target environment ("es5") is not supported yet
```

Reason:
According to ESbuild 0.12.6 [change note](https://github.com/evanw/esbuild/releases/tag/v0.12.6), `target` would be read from 'tsconfig.json' when esbuild's own target is not defined

Fix:
Manually set esbuild's target to `esnext` in @modern-js/node-bundle-require

Some snippets for the feature:
Only respect target in tsconfig.json when esbuild's target is not configured (#1332)
In version 0.12.4, esbuild began respecting the target setting in tsconfig.json. However, sometimes tsconfig.json contains target values that should not be used. With this release, esbuild will now only use the target value in tsconfig.json as the language level when esbuild's target setting is not configured. If esbuild's target setting is configured then the target value in tsconfig.json is now ignored.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
