### PR TITLE
fix: export all interface from @modern-js/core/config

### DIFF
--- a/.changeset/fluffy-apes-beam.md
+++ b/.changeset/fluffy-apes-beam.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/core": patch
+---
+
+export DeployConfig interface

--- a/packages/cli/core/src/config/index.ts
+++ b/packages/cli/core/src/config/index.ts
@@ -24,7 +24,7 @@ const debug = createDebugger('resolve-config');
 export { defaults as defaultsConfig };
 export { mergeConfig };
 
-export interface SourceConfig {
+interface SourceConfig {
   entries?: Record<
     string,
     | string
@@ -49,7 +49,7 @@ export interface SourceConfig {
   include?: Array<string | RegExp>;
 }
 
-export interface OutputConfig {
+interface OutputConfig {
   assetPrefix?: string;
   htmlPath?: string;
   jsPath?: string;
@@ -92,7 +92,7 @@ export interface OutputConfig {
   enableTsLoader?: boolean;
 }
 
-export interface ServerConfig {
+interface ServerConfig {
   routes?: Record<
     string,
     | string
@@ -111,12 +111,12 @@ export interface ServerConfig {
   enableMicroFrontendDebug?: boolean;
 }
 
-export interface DevConfig {
+interface DevConfig {
   assetPrefix?: string | boolean;
   https?: boolean;
 }
 
-export interface DeployConfig {
+interface DeployConfig {
   microFrontend?: boolean & Record<string, unknown>;
   domain?: string | Array<string>;
   domainByEntries?: Record<string, string | Array<string>>;
@@ -126,7 +126,7 @@ type ConfigFunction =
   | Record<string, unknown>
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   | ((config: Record<string, unknown>) => Record<string, unknown> | void);
-export interface ToolsConfig {
+interface ToolsConfig {
   webpack?: ConfigFunction;
   babel?: ConfigFunction;
   autoprefixer?: ConfigFunction;
@@ -139,13 +139,13 @@ export interface ToolsConfig {
   esbuild?: Record<string, unknown>;
 }
 
-export type RuntimeConfig = Record<string, any>;
+type RuntimeConfig = Record<string, any>;
 
-export interface RuntimeByEntriesConfig {
+interface RuntimeByEntriesConfig {
   [name: string]: RuntimeConfig;
 }
 
-export interface UserConfig {
+interface UserConfig {
   source?: SourceConfig;
   output?: OutputConfig;
   server?: ServerConfig;
@@ -157,12 +157,12 @@ export interface UserConfig {
   runtimeByEntries?: RuntimeByEntriesConfig;
 }
 
-export type ConfigParam =
+type ConfigParam =
   | UserConfig
   | Promise<UserConfig>
   | ((env: any) => UserConfig | Promise<UserConfig>);
 
-export interface LoadedConfig {
+interface LoadedConfig {
   config: UserConfig;
   filePath: string | false;
   dependencies: string[];
@@ -306,3 +306,17 @@ export const resolveConfig = async (
   return resolved;
 };
 /* eslint-enable max-statements, max-params */
+
+export type {
+  SourceConfig,
+  OutputConfig,
+  ServerConfig,
+  DevConfig,
+  DeployConfig,
+  ToolsConfig,
+  RuntimeConfig,
+  RuntimeByEntriesConfig,
+  UserConfig,
+  ConfigParam,
+  LoadedConfig,
+};

--- a/packages/cli/core/src/index.ts
+++ b/packages/cli/core/src/index.ts
@@ -20,13 +20,7 @@ import { enable } from '@modern-js/plugin/node';
 
 import type { Hooks } from '@modern-js/types';
 import { program, Command } from './utils/commander';
-import {
-  resolveConfig,
-  defineConfig,
-  loadUserConfig,
-  UserConfig,
-  ToolsConfig,
-} from './config';
+import { resolveConfig, loadUserConfig } from './config';
 import { loadPlugins } from './loadPlugins';
 import {
   AppContext,
@@ -43,8 +37,7 @@ import { NormalizedConfig } from './config/mergeConfig';
 import { loadEnv } from './loadEnv';
 
 export type { Hooks };
-export { defaultsConfig, mergeConfig } from './config';
-
+export * from './config';
 export * from '@modern-js/plugin';
 export * from '@modern-js/plugin/node';
 
@@ -117,7 +110,6 @@ export const usePlugins = (plugins: string[]) =>
   );
 
 export {
-  defineConfig,
   AppContext,
   ResolvedConfigContext,
   useAppContext,
@@ -126,7 +118,7 @@ export {
   ConfigContext,
 };
 
-export type { NormalizedConfig, IAppContext, UserConfig, ToolsConfig };
+export type { NormalizedConfig, IAppContext };
 
 const initAppDir = async (cwd?: string): Promise<string> => {
   if (!cwd) {
@@ -283,4 +275,4 @@ const createCli = () => {
 
 export const cli = createCli();
 
-export { loadUserConfig, initAppDir, initAppContext };
+export { initAppDir, initAppContext };

--- a/packages/cli/core/tests/fixtures/index-test/package.json
+++ b/packages/cli/core/tests/fixtures/index-test/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "index-test"
+}

--- a/packages/cli/core/tests/index.test.ts
+++ b/packages/cli/core/tests/index.test.ts
@@ -1,0 +1,74 @@
+import path from 'path';
+import { cli } from '../src';
+import { resolveConfig, loadUserConfig } from '../src/config';
+import { loadEnv } from '../src/loadEnv';
+
+jest.mock('../src/config', () => ({
+  __esModule: true,
+  ...jest.requireActual('../src/config'),
+  loadUserConfig: jest.fn(),
+  resolveConfig: jest.fn(),
+}));
+
+jest.mock('../src/loadEnv', () => ({
+  __esModule: true,
+  ...jest.requireActual('../src/loadEnv'),
+  loadEnv: jest.fn(),
+}));
+
+describe('@modern-js/core test', () => {
+  let mockResolveConfig: any = {};
+  let mockLoadedConfig: any = {};
+  const cwdSpy = jest.spyOn(process, 'cwd');
+  const cwd = path.join(__dirname, './fixtures/index-test');
+
+  const resetMock = () => {
+    jest.resetAllMocks();
+    cwdSpy.mockReturnValue(cwd);
+    (resolveConfig as jest.Mock).mockReturnValue(
+      Promise.resolve(mockResolveConfig),
+    );
+    (loadUserConfig as jest.Mock).mockImplementation(() =>
+      Promise.resolve(mockLoadedConfig),
+    );
+  };
+
+  const resetValues = () => {
+    mockLoadedConfig = {
+      config: {},
+      filePath: false,
+      dependencies: [],
+      pkgConfig: {},
+      jsConfig: {},
+    };
+    mockResolveConfig = {
+      server: {
+        port: 8080,
+      },
+      output: {
+        path: './my/test/path',
+      },
+    };
+  };
+
+  beforeEach(() => {
+    resetValues();
+    resetMock();
+  });
+
+  it('test cli create', () => {
+    expect(cli).toBeTruthy();
+  });
+
+  it('test cli init dev', async () => {
+    cwdSpy.mockReturnValue(path.join(cwd, 'nested-folder'));
+    const options = {
+      beforeUsePlugins: jest.fn(),
+    };
+    options.beforeUsePlugins.mockImplementation((plugins, _) => plugins);
+    await cli.init(['dev'], options);
+    expect(loadEnv).toHaveBeenCalledWith(cwd);
+    expect(options.beforeUsePlugins).toHaveBeenCalledWith([], {});
+    // TODO: add more test cases
+  });
+});


### PR DESCRIPTION
maintain 'export type {...}' to core/config/index.ts
this way core/index.ts can just export via: export * from './config'

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
