### PR TITLE
fix(plugin-unbundle): include client injected files in build

### DIFF
--- a/.changeset/selfish-tables-visit.md
+++ b/.changeset/selfish-tables-visit.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/plugin-unbundle": patch
+---
+
+fix plugin-unbundle missing file error

--- a/packages/cli/plugin-unbundle/modern.config.js
+++ b/packages/cli/plugin-unbundle/modern.config.js
@@ -1,0 +1,10 @@
+/** @type {import('@modern-js/module-tools').UserConfig} */
+module.exports = {
+  source: {
+    entries: {
+      main: './src/index.ts',
+      injectErrorOverlay: './src/client/error-overlay.ts',
+      injectClientIndex: './src/client/index.ts',
+    },
+  },
+};

--- a/packages/cli/plugin-unbundle/src/client/error-overlay.ts
+++ b/packages/cli/plugin-unbundle/src/client/error-overlay.ts
@@ -924,6 +924,16 @@ const OPEN_EDITOR_PATH = `/__open-stack-frame-in-editor`;
 customElements.define(
   'modern-js-error-overlay',
   class HmrErrorOverlay extends HTMLElement {
+    message: any = undefined;
+
+    fileLoc: any = undefined;
+
+    stack: any = undefined;
+
+    frame: any = undefined;
+
+    sr: any = undefined;
+
     constructor({ title, message, frame, loc, stack }) {
       super();
       this.title = title;
@@ -985,11 +995,7 @@ customElements.define(
       this.sr.querySelector('[data-nextjs-codeframe]').addEventListener(
         'click',
         event => {
-          if (
-            event &&
-            event.target &&
-            event.target.className === 'error-file-link'
-          ) {
+          if (event?.target?.className === 'error-file-link') {
             fetch(
               `${OPEN_EDITOR_PATH}?filename=${encodeURIComponent(
                 event.target.innerText,

--- a/packages/cli/plugin-unbundle/src/client/index.ts
+++ b/packages/cli/plugin-unbundle/src/client/index.ts
@@ -43,12 +43,18 @@ function createErrorOverlay(data) {
   }
 }
 
+type LoggerFunction = (...args: any[]) => void;
+type LoggerType = {
+  info: LoggerFunction;
+  error: LoggerFunction;
+  warn: LoggerFunction;
+};
 const logger = [`info`, 'error', 'warn'].reduce((m, c) => {
   m[c] = (...params) =>
     // eslint-disable-next-line no-console
     console[c === 'info' ? 'log' : c](`[HMR]:`, ...params);
   return m;
-}, {});
+}, {} as LoggerType);
 
 let isFisrtUpdate = true;
 
@@ -158,7 +164,7 @@ let updateQueue = [];
 let updating = false;
 
 const doAccept = async (id, acceptedPath, timestamp) => {
-  if (updateQueue.indexOf(id) < 0) {
+  if (!updateQueue.includes(id)) {
     updateQueue.push({ id, acceptedPath });
   }
 
@@ -243,6 +249,7 @@ export const createHotContext = url => {
     // private
     _id: id,
     _declinedDeps: {},
+    _acceptedDeps: {},
     _selfAccepted: false,
     _selfDeclined: false,
     _disposeCallbacks: [],

--- a/packages/cli/plugin-unbundle/src/constants.ts
+++ b/packages/cli/plugin-unbundle/src/constants.ts
@@ -64,8 +64,8 @@ export const DEFAULT_EXTENSIONS = [
 export const CSS_REGEX = /\.(css|sass|scss|less|styl)($|\?)/;
 export const CSS_MODULE_REGEX = /\.module.(css|sass|scss|less|styl)($|\?)/;
 
-// hmr sockjs client
-export const DEV_CLIENT_PATH = path.resolve(__dirname, './client');
+// hmr sockjs client, should inject modern build into client
+export const DEV_CLIENT_PATH = path.resolve(__dirname, '../modern/client');
 
 export const DEV_CLIENT_PATH_ALIAS = `@_modern_js_dev_client`;
 

--- a/packages/cli/plugin-unbundle/tests/client.test.ts
+++ b/packages/cli/plugin-unbundle/tests/client.test.ts
@@ -1,0 +1,337 @@
+import { HMR_SOCK_PATH } from '@modern-js/utils';
+
+// use require to prevent tsconfig linting client code
+const { __addQuery__, updateStyle, removeStyle } = require('../src/client');
+
+// const MockedWebSocket = jest.mocked(WebSocket);
+
+// eslint-disable-next-line max-statements
+describe('plugin-unbundled client test', () => {
+  let OriginalWebSocket: any;
+  let originalLocation: any;
+  let mockOverlayRegistered = false;
+
+  class MockElement extends HTMLElement {
+    constructor() {
+      super();
+      this.className = 'my-custom-mock-element';
+    }
+  }
+
+  const prepareErrorOverlay = () => {
+    jest.spyOn(customElements, 'get').mockImplementation(() => MockElement);
+    if (!mockOverlayRegistered) {
+      jest
+        .mocked(customElements.get)
+        .mockImplementationOnce((elementName: string) => {
+          customElements.define(elementName, MockElement);
+          mockOverlayRegistered = true;
+          return MockElement;
+        });
+    }
+  };
+
+  beforeAll(() => {
+    OriginalWebSocket = global.WebSocket;
+    originalLocation = window.location;
+    global.WebSocket = jest.fn(() => ({})) as any;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: jest.fn() },
+    });
+    jest.spyOn(console, 'info').mockImplementation();
+    jest.spyOn(console, 'warn').mockImplementation();
+    jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterAll(() => {
+    global.WebSocket = OriginalWebSocket;
+    window.location = originalLocation;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    // clean up JSDOM after each test
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  });
+
+  it('add query test', () => {
+    const url = 'https://example.com/api';
+    const firstQuery = __addQuery__(url, 'a=1');
+    expect(firstQuery).toEqual(`${url}?a=1`);
+    const secondQuery = __addQuery__(firstQuery, 'b=2');
+    expect(secondQuery).toEqual(`${firstQuery}&b=2`);
+  });
+
+  it('test update/remove style', () => {
+    const testStyleCode = 'test style';
+    const appendChildSpy = jest.spyOn(document.head, 'appendChild');
+    const removeChildSpy = jest.spyOn(document.head, 'removeChild');
+    const styleId = 225;
+    updateStyle(styleId, testStyleCode);
+
+    // should insert style into document
+    expect(document.head.appendChild).toHaveBeenCalledTimes(1);
+    const [appendedElement] = appendChildSpy.mock.calls[0] as [
+      HTMLStyleElement,
+    ];
+    expect(appendedElement.nodeName).toEqual('STYLE');
+    expect(appendedElement.textContent).toEqual(testStyleCode);
+
+    jest.clearAllMocks();
+    // remove style non existing style
+    removeStyle(styleId - 1);
+    expect(removeChildSpy).not.toHaveBeenCalled();
+
+    removeStyle(styleId);
+    expect(removeChildSpy).toHaveBeenCalledTimes(1);
+    const [removedChild] = removeChildSpy.mock.calls[0];
+    expect(removedChild).toBe(appendedElement);
+  });
+
+  it('test websocket initialization', () => {
+    // must use isolate modules to re-import client code for test
+    // this is due to client initialization on module load
+    jest.isolateModules(() => {
+      require('../src/client');
+      require('../src/constants');
+      expect(jest.mocked(WebSocket).mock.instances).toHaveLength(1);
+
+      // check correct websocket address
+      expect(jest.mocked(WebSocket).mock.calls[0][0]).toEqual(
+        `${location.origin.replace(/http/, 'ws')}${HMR_SOCK_PATH}`,
+      );
+
+      // get websocket instance
+      const createdWebSocket = jest.mocked(WebSocket).mock.results[0]
+        .value as WebSocket;
+
+      expect(createdWebSocket).toBeTruthy();
+
+      // check websocket initialized correctly
+      expect(createdWebSocket.onmessage).toBeTruthy();
+      expect(createdWebSocket.onerror).toBeTruthy();
+      expect(createdWebSocket.onclose).toBeTruthy();
+    });
+  });
+
+  it('test websocket reconnect', () => {
+    jest.useFakeTimers();
+    jest.isolateModules(() => {
+      require('../src/client');
+
+      // get websocket instance
+      const createdWebSocket = jest.mocked(WebSocket).mock.results[0]
+        .value as WebSocket;
+
+      jest.mocked(WebSocket).mockClear();
+      const someLongTimeDuration = 6000000; // 100 minutes
+      jest.advanceTimersByTime(someLongTimeDuration);
+      expect(jest.mocked(WebSocket)).not.toHaveBeenCalled();
+
+      // initialization is already tested by previous test
+      createdWebSocket.onclose!(new CloseEvent('test close'));
+      // do not immediatly reconnect, wait a while
+      expect(jest.mocked(WebSocket)).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(someLongTimeDuration);
+      expect(jest.mocked(WebSocket)).toHaveBeenCalled();
+    });
+  });
+
+  it('test websocket connection error', () => {
+    jest.isolateModules(() => {
+      require('../src/client');
+
+      // get websocket instance
+      const createdWebSocket = jest.mocked(WebSocket).mock.results[0]
+        .value as WebSocket;
+
+      // initialization is already tested by previous test
+      createdWebSocket.onerror!(new Event('test error'));
+    });
+  });
+
+  // // // TODO: refactor websocket command type to enum
+  it('test websocket "connected" message', () => {
+    jest.isolateModules(() => {
+      require('../src/client');
+
+      // get websocket instance
+      const createdWebSocket = jest.mocked(WebSocket).mock.results[0]
+        .value as WebSocket;
+
+      // initialization is already tested by previous test
+      const messageObj = { type: 'connected' };
+      createdWebSocket.onmessage!(
+        new MessageEvent('test', { data: JSON.stringify(messageObj) }),
+      );
+    });
+  });
+
+  it('test websocket "reload" message', () => {
+    jest.isolateModules(() => {
+      require('../src/client');
+
+      expect(window.location.reload).not.toHaveBeenCalled();
+
+      // get websocket instance
+      const createdWebSocket = jest.mocked(WebSocket).mock.results[0]
+        .value as WebSocket;
+
+      // initialization is already tested by previous test
+      const messageObj = { type: 'reload' };
+      createdWebSocket.onmessage!(
+        new MessageEvent('test', { data: JSON.stringify(messageObj) }),
+      );
+      expect(window.location.reload).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('test websocket "error" message', () => {
+    jest.isolateModules(() => {
+      prepareErrorOverlay();
+      require('../src/client');
+
+      // get websocket instance
+      const createdWebSocket = jest.mocked(WebSocket).mock.results[0]
+        .value as WebSocket;
+
+      let insertedElements = document.querySelectorAll(
+        '.my-custom-mock-element',
+      );
+      expect(insertedElements).toHaveLength(0);
+
+      // initialization is already tested by previous test
+      const messageObj = { type: 'error', message: 'this is a test error' };
+      createdWebSocket.onmessage!(
+        new MessageEvent('test', { data: JSON.stringify(messageObj) }),
+      );
+
+      insertedElements = document.querySelectorAll('.my-custom-mock-element');
+      expect(insertedElements).toHaveLength(1);
+
+      createdWebSocket.onmessage!(
+        new MessageEvent('test', { data: JSON.stringify(messageObj) }),
+      );
+
+      insertedElements = document.querySelectorAll('.my-custom-mock-element');
+      expect(insertedElements).toHaveLength(1);
+    });
+  });
+
+  it('test websocket first "update" on error message', () => {
+    jest.isolateModules(() => {
+      prepareErrorOverlay();
+      require('../src/client');
+
+      // get websocket instance
+      const createdWebSocket = jest.mocked(WebSocket).mock.results[0]
+        .value as WebSocket;
+
+      // initialization is already tested by previous test
+      const messageObj: any = {
+        type: 'error',
+        message: 'this is a test error',
+      };
+      createdWebSocket.onmessage!(
+        new MessageEvent('test', { data: JSON.stringify(messageObj) }),
+      );
+
+      // if there is already a error in first update
+      // which meanings some resource load failed
+      // so should reload page to ensure app run correctly
+      expect(window.location.reload).not.toHaveBeenCalled();
+      messageObj.type = 'update';
+      createdWebSocket.onmessage!(
+        new MessageEvent('test', { data: JSON.stringify(messageObj) }),
+      );
+      expect(window.location.reload).toHaveBeenCalled();
+
+      // set up update message
+      messageObj.hmrTimestamp = 123456;
+      messageObj.changes = [{ id: 1, accepted: true }];
+    });
+  });
+
+  it('test "createHotContext"', () => {
+    // eslint-disable-next-line max-statements
+    jest.isolateModules(() => {
+      const { createHotContext } = require('../src/client');
+      const hotmodule = createHotContext('myModule');
+
+      expect(typeof hotmodule.accept).toBe('function');
+      expect(typeof hotmodule.decline).toBe('function');
+      expect(typeof hotmodule.dispose).toBe('function');
+      expect(typeof hotmodule.prune).toBe('function');
+      expect(typeof hotmodule.invalidate).toBe('function');
+
+      const pruneFn = jest.fn();
+      const disposeFn = jest.fn();
+      const acceptFn = jest.fn();
+      hotmodule.dispose(disposeFn);
+      hotmodule.prune(pruneFn);
+      hotmodule.accept(acceptFn);
+
+      const hotmodule2 = createHotContext('myModule2');
+      expect(hotmodule2).not.toBe(hotmodule);
+      expect(disposeFn).not.toHaveBeenCalled();
+
+      const hotmoduleCopy = createHotContext('myModule');
+      expect(hotmoduleCopy).toBe(hotmodule);
+      expect(disposeFn).toHaveBeenCalledTimes(1);
+      disposeFn.mockClear();
+      createHotContext('myModule');
+      expect(disposeFn).not.toHaveBeenCalled();
+    });
+  });
+
+  it('test websocket "prune" message', () => {
+    jest.isolateModules(() => {
+      prepareErrorOverlay();
+      const { createHotContext } = require('../src/client');
+      const hotmodule = createHotContext('myModule');
+      const pruneFn = jest.fn();
+      hotmodule.prune(pruneFn);
+
+      // get websocket instance
+      const createdWebSocket = jest.mocked(WebSocket).mock.results[0]
+        .value as WebSocket;
+
+      // initialization is already tested by previous test
+      const messageObj: any = {
+        type: 'prune',
+        changes: ['myModule'],
+      };
+      createdWebSocket.onmessage!(
+        new MessageEvent('test', { data: JSON.stringify(messageObj) }),
+      );
+
+      expect(pruneFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('test websocket "update" hot module', () => {
+    // TODO: solve ESM support issue to test dynamic import
+  });
+
+  it('test websocket "close" message', () => {
+    jest.isolateModules(() => {
+      require('../src/client');
+
+      // get websocket instance
+      const createdWebSocket = jest.mocked(WebSocket).mock.results[0]
+        .value as WebSocket;
+
+      // initialization is already tested by previous test
+      const messageObj = { type: 'close' };
+      createdWebSocket.onmessage!(
+        new MessageEvent('test', { data: JSON.stringify(messageObj) }),
+      );
+    });
+  });
+});

--- a/packages/cli/plugin-unbundle/tests/error-overlay.test.ts
+++ b/packages/cli/plugin-unbundle/tests/error-overlay.test.ts
@@ -1,0 +1,23 @@
+describe('unbundle error-overlay test', () => {
+  it('test error overlay initialize', () => {
+    jest.isolateModules(() => {
+      jest.spyOn(customElements, 'define');
+      require('../src/client/error-overlay');
+      expect(customElements.define).toHaveBeenCalled();
+      const [, OverlayConstructor] = jest.mocked(customElements.define).mock
+        .calls[0];
+      const overlay = new OverlayConstructor({
+        title: 'test-error',
+        message: 'this is a test',
+        frame: undefined,
+        loc: undefined,
+        stack: undefined,
+      }) as any;
+      expect(overlay).toBeTruthy();
+      overlay.connectedCallback();
+      overlay.disconnectedCallback();
+    });
+  });
+});
+
+export {};


### PR DESCRIPTION
# PR Details
modify client/index.js and client/error-overlay.js to Typescript files,
and change injection of these files to the modern build version
the previous `modern build` changes caused plugin-unbundle build to not
include these two files anymore, causing an error. This PR fixes the issue
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
