### PR TITLE
fix: create route.json failure

### DIFF
--- a/.changeset/perfect-lobsters-press.md
+++ b/.changeset/perfect-lobsters-press.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/app-tools": patch
+---
+
+fix: create route.json failure

--- a/packages/solutions/app-tools/src/utils/routes.ts
+++ b/packages/solutions/app-tools/src/utils/routes.ts
@@ -5,7 +5,7 @@ import { fs, ROUTE_SPEC_FILE } from '@modern-js/utils';
 const generateRoutes = async (appContext: IAppContext) => {
   const { serverRoutes, distDirectory } = appContext;
   const output = JSON.stringify({ routes: serverRoutes }, null, 2);
-  await fs.writeFile(path.join(distDirectory, ROUTE_SPEC_FILE), output);
+  await fs.outputFile(path.join(distDirectory, ROUTE_SPEC_FILE), output);
 };
 
 export { generateRoutes };

--- a/packages/solutions/app-tools/tests/routes.test.ts
+++ b/packages/solutions/app-tools/tests/routes.test.ts
@@ -7,7 +7,7 @@ jest.mock('@modern-js/utils', () => {
     __esModule: true,
     ...originalModule,
     fs: {
-      writeFile: jest.fn((filename: string, output: string) => ({
+      outputFile: jest.fn((filename: string, output: string) => ({
         filename,
         output,
       })),
@@ -22,6 +22,6 @@ describe('routes', () => {
       distDirectory: './dist',
     };
     await generateRoutes(mockAppContext as any);
-    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    expect(fs.outputFile).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
# PR Details

## Description

生产环境构建时 app-tools 不会生成 dist 目录，生成 routes.json 时，需要保证有 dist 目录。

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
