### PR TITLE
fix(plugin-unbundle): detect ugly react import statements

### DIFF
--- a/.changeset/clean-games-talk.md
+++ b/.changeset/clean-games-talk.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/plugin-unbundle": patch
+---
+
+fix 'React already imported' due to buggy regex test

--- a/packages/cli/plugin-unbundle/src/plugins/esbuild.ts
+++ b/packages/cli/plugin-unbundle/src/plugins/esbuild.ts
@@ -37,7 +37,7 @@ export const esbuildPlugin = (
       // match: import React from 'react'
       /import\s+React(,\s*{[^'"]*})?\s*from\s+['"]react['"]/,
       // match: import * from 'react'
-      /import\s+\*\s+as\s+React\s+from\s+['"]react['"]/,
+      /import\s*\*\s*as\s+React\s+from\s*['"]react['"]/,
       // React is already defined, avoid conflict: var React =
       /(const|var|let)\s+React\s*=/,
     ]


### PR DESCRIPTION

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

example:
import*as React from'react'
was originally not detected and would cause duplicate import statements

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
