### PR TITLE
fix: fix eslint error with "modern.config.ts"

### DIFF
--- a/.changeset/brown-bulldogs-tan.md
+++ b/.changeset/brown-bulldogs-tan.md
@@ -1,0 +1,6 @@
+---
+"@modern-js/module-generator": patch
+"@modern-js/mwa-generator": patch
+---
+
+fix: fix eslint error with "modern.config.ts"

--- a/packages/generator/generators/module-generator/templates/ts-template/tsconfig.json.handlebars
+++ b/packages/generator/generators/module-generator/templates/ts-template/tsconfig.json.handlebars
@@ -9,5 +9,5 @@
       "@style/*": ["./styles/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "modern.config.ts"]
 }

--- a/packages/generator/generators/mwa-generator/templates/ts-template/tsconfig.json
+++ b/packages/generator/generators/mwa-generator/templates/ts-template/tsconfig.json
@@ -9,5 +9,5 @@
       "@shared/*": ["./shared/*"]
     }
   },
-  "include": ["src", "shared", "config"]
+  "include": ["src", "shared", "config", "modern.config.ts"]
 }


### PR DESCRIPTION
# PR Details

fix eslint error with "modern.config.ts"

## Description

When using "modern.config.ts" at root directory of modern.js project, and run the command:

```bash
pnpm run lint
```

It will throw error like this
```
error: Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: modern.config.ts.
The file must be included in at least one of the projects provided at modern.config.ts
```

So, we will need to include "modern.config.ts" at `include` param in `tsconfig.json`.

This PR will fix it.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
