### PR TITLE
fix: fix typo at error message

### DIFF
--- a/.changeset/lemon-apples-hide.md
+++ b/.changeset/lemon-apples-hide.md
@@ -1,0 +1,8 @@
+---
+"@modern-js/plugin-lambda-fc": patch
+"@modern-js/plugin-lambda-scf": patch
+"@modern-js/bff-generator": patch
+"@modern-js/server-generator": patch
+---
+
+fix: fix typo at error message.

--- a/packages/cli/plugin-lambda-fc/src/index.ts
+++ b/packages/cli/plugin-lambda-fc/src/index.ts
@@ -58,7 +58,7 @@ export default createPlugin(() => ({
       fs.mkdir(publishDir);
     } else {
       logger.info(
-        `The tmp upload directory is already exist, empty: ${publishDir}`,
+        `The tmp upload directory already exists, empty: ${publishDir}`,
       );
       fs.emptyDirSync(publishDir);
     }

--- a/packages/cli/plugin-lambda-scf/src/index.ts
+++ b/packages/cli/plugin-lambda-scf/src/index.ts
@@ -33,7 +33,7 @@ export default createPlugin(() => ({
       fs.mkdir(publishDir);
     } else {
       logger.info(
-        `The tmp upload directory is already exist, empty: ${publishDir}`,
+        `The tmp upload directory already exists, empty: ${publishDir}`,
       );
       fs.emptyDirSync(publishDir);
     }

--- a/packages/generator/generators/bff-generator/src/index.ts
+++ b/packages/generator/generators/bff-generator/src/index.ts
@@ -47,8 +47,8 @@ export const handleTemplateFile = async (
   if (fs.existsSync(apiDir) && !isEmptyApiDir(apiDir)) {
     const files = fs.readdirSync(apiDir);
     if (files.length > 0) {
-      generator.logger.warn("'api' is already exist");
-      throw Error("'api' is already exist");
+      generator.logger.warn("'api' already exists");
+      throw Error("'api' already exists");
     }
   }
 

--- a/packages/generator/generators/bff-generator/tests/index.test.ts
+++ b/packages/generator/generators/bff-generator/tests/index.test.ts
@@ -102,7 +102,7 @@ describe('run bff generator', () => {
         appApi,
       );
     } catch (e: any) {
-      expect(e.message).toBe("'api' is already exist");
+      expect(e.message).toBe("'api' already exists");
     }
   });
 });

--- a/packages/generator/generators/server-generator/src/index.ts
+++ b/packages/generator/generators/server-generator/src/index.ts
@@ -45,7 +45,7 @@ const handleTemplateFile = async (
   if (fs.existsSync(serverDir) && !isEmptyServerDir(serverDir)) {
     const files = fs.readdirSync('server');
     if (files.length > 0) {
-      generator.logger.warn("'server' is already exist");
+      generator.logger.warn("'server' already exists");
       // eslint-disable-next-line no-process-exit
       process.exit(1);
     }


### PR DESCRIPTION
# PR Details

fix: fix typo at error message

## Description

Due to `is already exist` is not in correct grammar, we change it to `already exists`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
