### PR TITLE
fix: allow other bff plugin in unbundle mode

### DIFF
--- a/.changeset/clean-hornets-raise.md
+++ b/.changeset/clean-hornets-raise.md
@@ -1,0 +1,6 @@
+---
+"@modern-js/plugin-testing": patch
+"@modern-js/plugin-unbundle": patch
+---
+
+fix: allow other bff plugin in unbundle mode

--- a/.changeset/ten-paws-remain.md
+++ b/.changeset/ten-paws-remain.md
@@ -1,0 +1,6 @@
+---
+"@modern-js/plugin-egg": patch
+"@modern-js/plugin-koa": patch
+---
+
+fix: allow user to set statusCode 404

--- a/packages/cli/plugin-testing/package.json
+++ b/packages/cli/plugin-testing/package.json
@@ -67,6 +67,9 @@
       ],
       "type": [
         "./type.d.ts"
+      ],
+      "runtime-base": [
+        "./dist/types/runtime-testing/base.d.ts"
       ]
     }
   },

--- a/packages/cli/plugin-unbundle/src/utils.ts
+++ b/packages/cli/plugin-unbundle/src/utils.ts
@@ -40,9 +40,24 @@ export const cleanUrl = (s: string) => s.replace(/(\?.*$|#.*$)/, '');
 export const isFunction = (o: unknown) =>
   Object.prototype.toString.call(o) === '[object Function]';
 
-export const shouldUseBff = (appDirectory: string): boolean =>
-  fs.existsSync(path.resolve(appDirectory, BFF_API_DIR)) &&
-  hasDependency(appDirectory, '@modern-js/plugin-bff');
+export const hasBffPlugin = (appDirectory: string): boolean => {
+  const packageJson = require(path.join(appDirectory, 'package.json'));
+  const { dependencies, devDependencies } = packageJson;
+  const hasPlugin = [
+    ...Object.keys(dependencies),
+    ...Object.keys(devDependencies),
+  ].some(name => name.includes('plugin-bff'));
+
+  return hasPlugin;
+};
+
+export const shouldUseBff = (appDirectory: string): boolean => {
+  const existBffPlugin = hasBffPlugin(appDirectory);
+
+  return (
+    fs.existsSync(path.resolve(appDirectory, BFF_API_DIR)) && existBffPlugin
+  );
+};
 
 export const getBFFMiddleware = async (
   config: NormalizedConfig,

--- a/packages/cli/plugin-unbundle/tests/fixtures/scan-imports/package.json
+++ b/packages/cli/plugin-unbundle/tests/fixtures/scan-imports/package.json
@@ -6,5 +6,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {
+    "@xxx/plugin-bff": "^1.0.0"
+  }
 }

--- a/packages/cli/plugin-unbundle/tests/utils.test.ts
+++ b/packages/cli/plugin-unbundle/tests/utils.test.ts
@@ -1,0 +1,13 @@
+import * as path from 'path';
+import { shouldUseBff, hasBffPlugin } from '../src/utils';
+
+describe('utils', () => {
+  test('should use bff correctly', () => {
+    const appDirectory1 = path.join(__dirname, './fixtures/tailwind-example');
+    expect(hasBffPlugin(appDirectory1)).toBe(false);
+
+    const appDirectory2 = path.join(__dirname, './fixtures/scan-imports');
+    expect(hasBffPlugin(appDirectory2)).toBe(true);
+    expect(shouldUseBff(appDirectory2)).toBe(false);
+  });
+});

--- a/packages/server/plugin-egg/src/plugin.ts
+++ b/packages/server/plugin-egg/src/plugin.ts
@@ -209,7 +209,10 @@ export default createPlugin(
         await next();
         if (!ctx.body) {
           // restore statusCode
-          if (ctx.res.statusCode === 404) {
+          if (
+            ctx.res.statusCode === 404 &&
+            !(ctx.response as any)._explicitStatus
+          ) {
             ctx.res.statusCode = 200;
           }
           ctx.respond = false;

--- a/packages/server/plugin-koa/src/plugin.ts
+++ b/packages/server/plugin-koa/src/plugin.ts
@@ -95,7 +95,10 @@ export default createPlugin(
         await next();
         if (!ctx.body) {
           // restore statusCode
-          if (ctx.res.statusCode === 404) {
+          if (
+            ctx.res.statusCode === 404 &&
+            !(ctx.response as any)._explicitStatus
+          ) {
             ctx.res.statusCode = 200;
           }
           ctx.respond = false;


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description
放开 unbundle 判断是 bff 项目的限制。（允许非 @modern-js/plugin-bff 插件）
修复自定义 server 用户设置 404 状态码，不生效的问题。

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
