### PR TITLE
fix: fix plugin-unbundle parsing error with tsconfig

### DIFF
--- a/.changeset/fresh-knives-doubt.md
+++ b/.changeset/fresh-knives-doubt.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/plugin-unbundle": patch
+---
+
+fix: fix plugin-unbundle parsing error with tsconfig

--- a/packages/cli/plugin-unbundle/src/parse-dts.ts
+++ b/packages/cli/plugin-unbundle/src/parse-dts.ts
@@ -81,13 +81,14 @@ const visit = (node: ts.Node) => {
  */
 export const parseDTS = (files: string[]): Record<string, unknown> => {
   for (const filepath of files) {
-    const source = ts.createSourceFile(
-      filepath,
-      fs.readFileSync(filepath, 'utf8'),
-      ts.ScriptTarget.ES2015,
-    );
-
-    visit(source);
+    if (fs.existsSync(filepath)) {
+      const source = ts.createSourceFile(
+        filepath,
+        fs.readFileSync(filepath, 'utf8'),
+        ts.ScriptTarget.ES2015,
+      );
+      visit(source);
+    }
   }
 
   return enumsMap;

--- a/packages/cli/plugin-unbundle/tests/dts.test.ts
+++ b/packages/cli/plugin-unbundle/tests/dts.test.ts
@@ -1,0 +1,15 @@
+import { parseDTS } from '../src/parse-dts';
+
+const fs = require('fs');
+
+jest.mock('fs');
+
+describe('dts test', () => {
+  test('dts parse test ', () => {
+    fs.existsSync.mockReturnValue(false);
+    const enums = parseDTS(['modern.config.ts']);
+    expect(enums).toMatchObject({});
+  });
+});
+
+export {};


### PR DESCRIPTION
# PR Details

fix plugin-unbundle parsing error with tsconfig

## Issue


If modern.js project's `tsconfig.json` has included a nonexistent files in `include` array:

For this example, the nonexistent file is `modern.config.ts`:

```js title="tsconfig.json"
{
  "extends": "@modern-js/tsconfig/base",
  "include": ["src", "shared", "config", "modern.config.ts"]
}
```

Then when developers try to use modern.js `unbundle` feature, it will throw the error and stop running.

## Reason

When using `parseDTS` function in `plugin-unbundle`, it doesn't verify the existence of files.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
