### PR TITLE
feat: enhance custom env vars

### DIFF
--- a/.changeset/early-deers-lick.md
+++ b/.changeset/early-deers-lick.md
@@ -1,0 +1,6 @@
+---
+"@modern-js/core": patch
+"@modern-js/webpack": patch
+---
+
+feat: enhance custom env

--- a/packages/cli/core/src/index.ts
+++ b/packages/cli/core/src/index.ts
@@ -172,7 +172,8 @@ const createCli = () => {
 
     const appDirectory = await initAppDir();
 
-    loadEnv(appDirectory);
+    const metaName = options?.options?.metaName ?? 'MODERN';
+    loadEnv(appDirectory, process.env[`${metaName.toUpperCase()}_ENV`]);
 
     const loaded = await loadUserConfig(
       appDirectory,

--- a/packages/cli/core/tests/index.test.ts
+++ b/packages/cli/core/tests/index.test.ts
@@ -67,7 +67,7 @@ describe('@modern-js/core test', () => {
     };
     options.beforeUsePlugins.mockImplementation((plugins, _) => plugins);
     await cli.init(['dev'], options);
-    expect(loadEnv).toHaveBeenCalledWith(cwd);
+    expect(loadEnv).toHaveBeenCalledWith(cwd, undefined);
     expect(options.beforeUsePlugins).toHaveBeenCalledWith([], {});
     // TODO: add more test cases
   });

--- a/packages/cli/core/tests/loadEnv.test.ts
+++ b/packages/cli/core/tests/loadEnv.test.ts
@@ -124,6 +124,34 @@ describe('load environment variables', () => {
     delete process.env.NODE_ENV;
   });
 
+  test(`get custom .env file by MODERN_ENV`, () => {
+    createFixtures('custom_environment', [
+      {
+        name: '.env',
+        content: `DB_HOST=localhost
+        DB_USER=root
+        DB_PASS=root
+        `,
+      },
+      {
+        name: '.env.staging',
+        content: `DB_HOST=localhost
+        DB_USER=root-local-dev
+        `,
+      },
+    ]);
+
+    loadEnv(path.join(fixture, 'custom_environment'), 'staging');
+
+    expect(process.env.DB_HOST).toBe('localhost');
+
+    expect(process.env.DB_USER).toBe('root-local-dev');
+
+    expect(process.env.DB_PASS).toBe('root');
+
+    delete process.env.MODERN_ENV;
+  });
+
   test(`support dotenv-expand`, () => {
     createFixtures('expand', [
       {

--- a/packages/cli/webpack/src/config/client.ts
+++ b/packages/cli/webpack/src/config/client.ts
@@ -89,13 +89,24 @@ export class ClientWebpackConfig extends BaseWebpackConfig {
     );
   }
 
+  private getCustomPublicEnv() {
+    const { metaName } = this.appContext;
+    const prefix = `${metaName.split(/[-_]/)[0]}_`.toUpperCase();
+    const envReg = new RegExp(`^${prefix}`);
+    return Object.keys(process.env).filter(key => envReg.test(key));
+  }
+
   private useDefinePlugin() {
     const { envVars, globalVars } = this.options.source || {};
+    const publicEnvVars = this.getCustomPublicEnv();
     this.chain.plugin('define').use(DefinePlugin, [
       {
-        ...['NODE_ENV', 'BUILD_MODE', ...(envVars || [])].reduce<
-          Record<string, string>
-        >((memo, name) => {
+        ...[
+          'NODE_ENV',
+          'BUILD_MODE',
+          ...publicEnvVars,
+          ...(envVars || []),
+        ].reduce<Record<string, string>>((memo, name) => {
           memo[`process.env.${name}`] = JSON.stringify(process.env[name]);
           return memo;
         }, {}),

--- a/packages/cli/webpack/tests/base.test.ts
+++ b/packages/cli/webpack/tests/base.test.ts
@@ -14,7 +14,7 @@ describe('base webpack config', () => {
     entrypoints: [
       {
         entryName: 'page-a',
-        entryPath: path.resolve(fixtures, './demo/src/page-a/index.jsx'),
+        entry: path.resolve(fixtures, './demo/src/page-a/index.jsx'),
       },
     ],
     internalDirAlias: '@_modern_js_internal',

--- a/packages/cli/webpack/tests/client.test.ts
+++ b/packages/cli/webpack/tests/client.test.ts
@@ -4,6 +4,7 @@ import { ClientWebpackConfig } from '../src/config/client';
 describe('@modern-js/webpack#config/client', () => {
   it('ClientWebpackConfig', () => {
     const appContext: IAppContext = {
+      metaName: 'modern-js',
       appDirectory: __dirname,
       distDirectory: `${__dirname}/dist`,
       srcDirectory: `${__dirname}/src`,
@@ -75,5 +76,9 @@ describe('@modern-js/webpack#config/client', () => {
       'vm',
       'zlib',
     ]);
+
+    const getCustomPublicEnv = jest.spyOn(client, 'getCustomPublicEnv');
+    client.useDefinePlugin();
+    expect(getCustomPublicEnv).toBeCalled();
   });
 });


### PR DESCRIPTION
# PR Details

1. When a custom env var starts with prefix `MODERN_`, it will be handled as a public env var(no need to define in `source.envVars`).
2. Support more .env files,  loading different .env file by the `MODERN_ENV` env var .

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
