### PR TITLE
feat(module-tool): copy dts files from src to dist folder

### DIFF
--- a/.changeset/fast-seahorses-teach.md
+++ b/.changeset/fast-seahorses-teach.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/module-tools': minor
+---
+
+feature: copy dts files from src to dist folder.

--- a/packages/solutions/module-tools/src/tasks/generator-dts/index.ts
+++ b/packages/solutions/module-tools/src/tasks/generator-dts/index.ts
@@ -57,14 +57,9 @@ const resolveLog = (
 // copy .d.ts files from src dir to dist dir
 const copyDts = async (srcDir: string, distDir: string) => {
   const files = glob.sync(`${srcDir}/**/*.d.ts`);
-
-  if (files.length) {
-    return Promise.all(
-      files.map(filePath =>
-        fs.copy(filePath, filePath.replace(srcDir, distDir)),
-      ),
-    );
-  }
+  Promise.all(
+    files.map(filePath => fs.copy(filePath, filePath.replace(srcDir, distDir))),
+  );
 };
 
 const generatorDts = async (_: NormalizedConfig, config: IGeneratorConfig) => {


### PR DESCRIPTION
# PR Details

## Description

目前 `module-tools` 在 build 时，不会将 src 目录下的 `.d.ts` 文件拷贝到 `dist/types` 目录下，而 `tsc` 默认也是不处理 `.d.ts` 文件的，这导致 build 后可能出现类型缺失的问题。

因此在 `generatorDts` 阶段，我们主动对 src 下的 `.d.ts` 文件进行拷贝，以避免此问题。

## Related Issue

issue #663 由于 `plugin-less/src/types.d.ts` 缺失，导致类型不可用。

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
