### PR TITLE
feat(plugin-unbundle): add config option for ignoring package

### DIFF
--- a/.changeset/twelve-papayas-move.md
+++ b/.changeset/twelve-papayas-move.md
@@ -1,0 +1,6 @@
+---
+"@modern-js/plugin-unbundle": patch
+"@modern-js/utils": patch
+---
+
+new user config for plugin-unbundle

--- a/monorepo.code-workspace
+++ b/monorepo.code-workspace
@@ -435,6 +435,10 @@
     {
       "name": "Integration Tests",
       "path": "tests"
+    },
+    {
+      "name": "Local Test Projects",
+      "path": "local-test-project"
     }
   ],
   "settings": {

--- a/packages/cli/plugin-unbundle/src/dev.ts
+++ b/packages/cli/plugin-unbundle/src/dev.ts
@@ -22,5 +22,6 @@ export const dev = async (
   // create html template for each js entry
   createHtml(config, appContext);
 
-  await startDevServer(config, appContext);
+  const closeServer = await startDevServer(config, appContext);
+  return closeServer;
 };

--- a/packages/cli/plugin-unbundle/src/index.ts
+++ b/packages/cli/plugin-unbundle/src/index.ts
@@ -10,46 +10,60 @@ import * as unbundleHooks from './hooks';
 
 export * from './hooks';
 
-registerHook({ ...unbundleHooks });
-
 export default createPlugin(
-  () => ({
-    validateSchema() {
-      return PLUGIN_SCHEMAS['@modern-js/plugin-unbundle'];
-    },
-    commands({ program }) {
-      const appContext = useAppContext();
-
-      const config = useResolvedConfigContext();
-
-      const devCommand = program.commandsMap.get('dev');
-
-      devCommand?.option('--unbundled', 'dev with unbundled mode');
-
-      if (
-        process.argv.slice(2)[0] === 'dev' &&
-        process.argv.includes('--unbundled')
-      ) {
-        devCommand?.action(async () => {
-          await dev(config, appContext);
-        });
-      }
-    },
-    async htmlPartials({ entrypoint, partials }) {
-      if (process.argv[2] === 'dev' && process.argv.includes('--unbundled')) {
+  () => {
+    registerHook({ ...unbundleHooks });
+    let closeDevServer: (() => Promise<void>) | undefined;
+    return {
+      validateSchema() {
+        return PLUGIN_SCHEMAS['@modern-js/plugin-unbundle'];
+      },
+      commands({ program }) {
         const appContext = useAppContext();
+
         const config = useResolvedConfigContext();
 
-        const { createHtmlPartials } = await import('./create-entry');
+        const devCommand = program.commandsMap.get('dev');
 
-        partials.head.push(createHtmlPartials(entrypoint, appContext, config));
-      }
+        devCommand?.option('--unbundled', 'dev with unbundled mode');
 
-      return {
-        entrypoint,
-        partials,
-      };
-    },
-  }),
+        if (
+          process.argv.slice(2)[0] === 'dev' &&
+          process.argv.includes('--unbundled')
+        ) {
+          devCommand?.action(async () => {
+            if (closeDevServer) {
+              await closeDevServer();
+              closeDevServer = undefined;
+            }
+            closeDevServer = await dev(config, appContext);
+          });
+        }
+      },
+      async beforeRestart() {
+        if (closeDevServer) {
+          await closeDevServer();
+        }
+        closeDevServer = undefined;
+      },
+      async htmlPartials({ entrypoint, partials }) {
+        if (process.argv[2] === 'dev' && process.argv.includes('--unbundled')) {
+          const appContext = useAppContext();
+          const config = useResolvedConfigContext();
+
+          const { createHtmlPartials } = await import('./create-entry');
+
+          partials.head.push(
+            createHtmlPartials(entrypoint, appContext, config),
+          );
+        }
+
+        return {
+          entrypoint,
+          partials,
+        };
+      },
+    };
+  },
   { name: '@modern-js/plugin-unbundle' },
 );

--- a/packages/cli/plugin-unbundle/src/plugins/container.ts
+++ b/packages/cli/plugin-unbundle/src/plugins/container.ts
@@ -91,6 +91,7 @@ export interface PluginContainer {
   options: InputOptions;
   buildStart: (options: InputOptions) => Promise<void>;
   watchChange: (id: string) => void;
+  closeWatcher: () => void;
   // resolveImportMeta(property: string): string | null
   resolveId: (
     id: string,
@@ -295,6 +296,15 @@ export const createPluginContainer = async (
             event: event as ChangeEvent,
           });
         }
+      }
+    },
+
+    closeWatcher() {
+      for (plugin of plugins) {
+        if (!plugin.closeWatcher) {
+          continue;
+        }
+        plugin.closeWatcher.call(ctx as any);
       }
     },
 

--- a/packages/cli/plugin-unbundle/src/typings/index.d.ts
+++ b/packages/cli/plugin-unbundle/src/typings/index.d.ts
@@ -8,6 +8,19 @@ declare module '@modern-js/core' {
   interface OutputConfig {
     disableAutoImportStyle?: boolean;
   }
+
+  interface DevConfig {
+    unbundle?: {
+      /**
+       * Some package A may require another package B that is intended for Node.js
+       * use only. In such a case, if package B cannot be converted to ESM, it will
+       * cause package A to fail during unbundle development, even though package B
+       * is not really required. Package B can thus be safely ignored via this option
+       * to ensure transpilation of package A to ESM
+       */
+      ignore?: string | string[];
+    };
+  }
 }
 
 declare module 'acorn-class-fields';

--- a/packages/cli/plugin-unbundle/src/utils.ts
+++ b/packages/cli/plugin-unbundle/src/utils.ts
@@ -209,3 +209,24 @@ export const logWithHistory = () => {
     }
   };
 };
+
+export const setIgnoreDependencies = (
+  userConfig: NormalizedConfig,
+  virtualDeps: Record<string, string>,
+) => {
+  const ignore = userConfig?.dev?.unbundle?.ignore;
+  if (!ignore) {
+    return;
+  }
+
+  const normalizeIgnore = Array.isArray(ignore) ? ignore : [ignore];
+  normalizeIgnore.forEach(dependencyToIgnore => {
+    virtualDeps[dependencyToIgnore] = `
+      /**
+       * Dependency ${dependencyToIgnore} ignored via user config
+       * /
+      export {};
+      export default {};
+    `;
+  });
+};

--- a/packages/cli/plugin-unbundle/tests/__snapshots__/index.test.ts.snap
+++ b/packages/cli/plugin-unbundle/tests/__snapshots__/index.test.ts.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`plugin-unbundle schema 1`] = `
+Array [
+  Array [
+    Object {
+      "schema": Object {
+        "type": "boolean",
+      },
+      "target": "source.disableAutoImportStyle",
+    },
+    Object {
+      "schema": Object {
+        "type": "boolean",
+      },
+      "target": "server.https",
+    },
+    Object {
+      "schema": Object {
+        "properties": Object {
+          "ignore": Object {
+            "items": Object {
+              "type": "string",
+            },
+            "type": Array [
+              "string",
+              "array",
+            ],
+          },
+        },
+        "type": "object",
+      },
+      "target": "dev.unbundle",
+    },
+  ],
+]
+`;

--- a/packages/cli/plugin-unbundle/tests/index.test.ts
+++ b/packages/cli/plugin-unbundle/tests/index.test.ts
@@ -1,9 +1,28 @@
 import * as path from 'path';
+import { manager } from '@modern-js/core';
 import plugin from '../src';
 
 import { hasTailwind } from '../src/plugins/css';
+import { dev } from '../src/dev';
+
+jest.mock('../src/dev');
+jest.mock('@modern-js/core', () => ({
+  __esModule: true,
+  ...jest.requireActual('@modern-js/core'),
+  registerHook: jest.fn(),
+}));
 
 describe('plugin-unbundle', () => {
+  let originalArgv: string[];
+  beforeAll(() => {
+    originalArgv = process.argv;
+    process.argv = ['xxx/xxx/xxx/node', 'xxx/xxx/modern', 'dev', '--unbundled'];
+  });
+
+  afterAll(() => {
+    process.argv = originalArgv;
+  });
+
   it('default', () => {
     expect(plugin).toBeDefined();
   });
@@ -12,5 +31,50 @@ describe('plugin-unbundle', () => {
     expect(
       hasTailwind(path.join(__dirname, './fixtures/tailwind-example')),
     ).toBe(true);
+  });
+
+  it('schema', async () => {
+    const main = manager.clone().usePlugin(plugin);
+    const runner = await main.init();
+    const result = await runner.validateSchema();
+    expect(result).toMatchSnapshot();
+  });
+
+  // eslint-disable-next-line max-statements
+  it('commands', async () => {
+    const main = manager.clone().usePlugin(plugin);
+    const runner = await main.init();
+    const closeDevServerMock = jest.fn().mockReturnValue(Promise.resolve());
+    jest.mocked(dev).mockResolvedValue(closeDevServerMock);
+    const devCommand = {
+      option: jest.fn(),
+      action: jest.fn(),
+    };
+    const program = {
+      commandsMap: {
+        get: jest.fn().mockReturnValue(devCommand),
+      },
+    };
+    await runner.commands({ program } as any);
+    expect(program.commandsMap.get).toHaveBeenCalledWith('dev');
+    expect(devCommand.option).toHaveBeenCalledWith(
+      '--unbundled',
+      expect.anything(),
+    );
+    expect(devCommand.action).toHaveBeenCalledTimes(1);
+    const devCommandAction = devCommand.action.mock.calls[0][0];
+    expect(devCommandAction).toBeTruthy();
+    expect(typeof devCommandAction).toBe('function');
+    await devCommandAction();
+    expect(dev).toHaveBeenCalledTimes(1);
+    expect(closeDevServerMock).not.toHaveBeenCalled();
+
+    await runner.beforeRestart();
+    await devCommandAction();
+    expect(closeDevServerMock).toHaveBeenCalledTimes(1);
+
+    closeDevServerMock.mockClear();
+    await devCommandAction();
+    expect(closeDevServerMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/plugin-unbundle/tests/utils.test.ts
+++ b/packages/cli/plugin-unbundle/tests/utils.test.ts
@@ -1,7 +1,14 @@
 import * as path from 'path';
-import { shouldUseBff, hasBffPlugin } from '../src/utils';
+import { NormalizedConfig } from '@modern-js/core';
+import {
+  shouldUseBff,
+  hasBffPlugin,
+  setIgnoreDependencies,
+  replaceAsync,
+} from '../src/utils';
+import type {} from '../src/typings';
 
-describe('utils', () => {
+describe('plugin-unbundle utils', () => {
   test('should use bff correctly', () => {
     const appDirectory1 = path.join(__dirname, './fixtures/tailwind-example');
     expect(hasBffPlugin(appDirectory1)).toBe(false);
@@ -9,5 +16,63 @@ describe('utils', () => {
     const appDirectory2 = path.join(__dirname, './fixtures/scan-imports');
     expect(hasBffPlugin(appDirectory2)).toBe(true);
     expect(shouldUseBff(appDirectory2)).toBe(false);
+  });
+
+  test('setIgnoreDependencies', () => {
+    const virtualDeps: any = {
+      test: 'test',
+    };
+    const userConfig = {} as NormalizedConfig;
+    setIgnoreDependencies(userConfig, virtualDeps);
+    expect(virtualDeps).toMatchObject({ test: 'test' });
+
+    userConfig.dev = {
+      unbundle: {
+        ignore: 'test0',
+      },
+    };
+
+    const testExport = /export\s+{.*}\s*;/m;
+    const testExportDefault = /export\s+default\s+{.*}\s*;/;
+
+    setIgnoreDependencies(userConfig, virtualDeps);
+    expect(virtualDeps.test0).toBeTruthy();
+    expect(testExport.test(virtualDeps.test0)).toBeTruthy();
+    expect(testExportDefault.test(virtualDeps.test0)).toBeTruthy();
+
+    userConfig.dev.unbundle!.ignore = ['test1', 'test2', 'test-3'];
+    setIgnoreDependencies(userConfig, virtualDeps);
+    for (const testDep of userConfig.dev.unbundle!.ignore!) {
+      expect(virtualDeps[testDep]).toBeTruthy();
+      expect(testExport.test(virtualDeps[testDep])).toBeTruthy();
+      expect(testExportDefault.test(virtualDeps[testDep])).toBeTruthy();
+    }
+  });
+
+  test('replaceAsync', async () => {
+    const simpleReplaceStr = 'test1, test2, test3, test4';
+    const simpleResult = await replaceAsync(
+      simpleReplaceStr,
+      /test/,
+      'noTest' as any,
+    );
+    expect(simpleResult.includes('test')).toBeTruthy();
+    expect(simpleResult.includes('noTest')).toBeTruthy();
+
+    let count = 0;
+    const sleep = (ms: number) =>
+      new Promise(resolve => setTimeout(resolve, ms));
+    const replacer = async (match: string) => {
+      count++;
+      await sleep(50);
+      return `${match}-${count}`;
+    };
+    const complicatedReplaceStr = 'test, test, test, test, test';
+    const complicatedResult = await replaceAsync(
+      complicatedReplaceStr,
+      /test/g,
+      replacer,
+    );
+    expect(complicatedResult.includes('test-5')).toBeTruthy();
   });
 });

--- a/packages/toolkit/utils/src/constants.ts
+++ b/packages/toolkit/utils/src/constants.ts
@@ -194,6 +194,18 @@ export const PLUGIN_SCHEMAS = {
       target: 'server.https',
       schema: { type: 'boolean' },
     },
+    {
+      target: 'dev.unbundle',
+      schema: {
+        type: 'object',
+        properties: {
+          ignore: {
+            type: ['string', 'array'],
+            items: { type: 'string' },
+          },
+        },
+      },
+    },
   ],
   '@modern-js/plugin-ssg': [
     {


### PR DESCRIPTION

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
A package that cannot be converted to ESM may be optionally required by some dependency intended only for Node.js use. However, this will cause that dependency to throw error on unbundle development. Add user config to ignore such dependencies

Fix unbunde dev server crash on restart. Should expose closeServer method to allow plugin to clean up resources on restart.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
