### PR TITLE
feat:  plugins support to accept options

### DIFF
--- a/.changeset/poor-goats-occur.md
+++ b/.changeset/poor-goats-occur.md
@@ -1,0 +1,7 @@
+---
+"@modern-js/core": patch
+"@modern-js/plugin-multiprocess": patch
+"@modern-js/types": patch
+---
+
+feat: support to pass options to plugins

--- a/packages/cli/core/src/context.ts
+++ b/packages/cli/core/src/context.ts
@@ -4,6 +4,7 @@ import address from 'address';
 import type { IAppContext } from '@modern-js/types';
 import { UserConfig } from './config';
 import { NormalizedConfig } from './config/mergeConfig';
+import type { LoadedPlugin } from './loadPlugins';
 
 export type { IAppContext };
 
@@ -23,10 +24,7 @@ export const useResolvedConfigContext = () => ResolvedConfigContext.use().value;
 
 export const initAppContext = (
   appDirectory: string,
-  plugins: Array<{
-    cli: any;
-    server: any;
-  }>,
+  plugins: Array<LoadedPlugin>,
   configFile: string | false,
   options?: {
     metaName?: string;

--- a/packages/cli/core/src/loadPlugins.ts
+++ b/packages/cli/core/src/loadPlugins.ts
@@ -4,49 +4,50 @@ import {
   compatRequire,
   INTERNAL_PLUGINS,
 } from '@modern-js/utils';
+import type { UserConfig } from './config';
 
 const debug = createDebugger('load-plugins');
 
+type Plugin = string | [string, any];
+
+export type LoadedPlugin = {
+  cli?: Required<{ pluginPath: string }>;
+  cliPkg?: string;
+  server?: Required<{ pluginPath: string }>;
+  serverPkg?: string;
+};
+
 export interface PluginConfigItem {
-  cli?: string;
-  server?: string;
+  cli?: Plugin;
+  server?: Plugin;
 }
 
 export type PluginConfig = Array<PluginConfigItem>;
 
+export type TransformPlugin = (
+  plugin: PluginConfig,
+  resolvedConfig: UserConfig,
+  pluginOptions?: any,
+) => PluginConfig;
+
 /**
  * Try to resolve plugin entry file path.
+ * @param name - Plugin name.
  * @param appDirectory - Application root directory.
- * @param plugin - Plugin name or plugin name with options.
  * @returns Resolved file path.
  */
-const resolvePlugin = (appDirectory: string, plugin: PluginConfigItem) => {
-  const tryResolve = (name: string) => {
-    let filePath = '';
-    try {
-      filePath = require.resolve(name, { paths: [appDirectory] });
-      delete require.cache[filePath];
-    } catch (err) {
-      if ((err as any).code === 'MODULE_NOT_FOUND') {
-        throw new Error(`Can not find plugin ${name}.`);
-      }
-      throw err;
+const tryResolve = (name: string, appDirectory: string) => {
+  let filePath = '';
+  try {
+    filePath = require.resolve(name, { paths: [appDirectory] });
+    delete require.cache[filePath];
+  } catch (err) {
+    if ((err as any).code === 'MODULE_NOT_FOUND') {
+      throw new Error(`Can not find plugin ${name}.`);
     }
-    return filePath;
-  };
-
-  const resolved: PluginConfigItem = {};
-
-  if (typeof plugin === 'string' || plugin.cli) {
-    resolved.cli =
-      typeof plugin === 'string' ? tryResolve(plugin) : tryResolve(plugin.cli!);
+    throw err;
   }
-
-  if (plugin.server) {
-    resolved.server = tryResolve(plugin.server);
-  }
-
-  return resolved;
+  return filePath;
 };
 
 export function getAppPlugins(
@@ -74,36 +75,67 @@ export function getAppPlugins(
 /**
  * Load internal plugins which in @modern-js scope and user's custom plugins.
  * @param appDirectory - Application root directory.
- * @param pluginsConfig - Plugins declared in the user configuration.
+ * @param userConfig - Resolved user config.
+ * @param options.internalPlugins - Internal plugins.
+ * @param options.transformPlugin - transform plugin before using it.
  * @returns Plugin Objects has been required.
  */
 export const loadPlugins = (
   appDirectory: string,
-  pluginConfig: PluginConfig,
-  internalPlugins?: typeof INTERNAL_PLUGINS,
+  userConfig: UserConfig,
+  options: {
+    internalPlugins?: typeof INTERNAL_PLUGINS;
+    transformPlugin?: TransformPlugin;
+  } = {},
 ) => {
-  const plugins = getAppPlugins(appDirectory, pluginConfig, internalPlugins);
+  const { internalPlugins, transformPlugin } = options;
 
-  return plugins.map(plugin => {
-    const { cli, server } = resolvePlugin(appDirectory, plugin);
-
-    debug(`resolve plugin %s: %s`, plugin, {
-      cli,
-      server,
-    });
-
-    const cliPlugin = cli && { ...compatRequire(cli), pluginPath: cli };
-    // server plugin should be required by server
-    const serverPlugin = server && {
-      // ...compatRequire(server),
-      pluginPath: server,
-    };
+  const resolvePlugin = (p: Plugin) => {
+    const pkg = typeof p === 'string' ? p : p[0];
+    const path = tryResolve(pkg, appDirectory);
+    let module = compatRequire(path);
+    const pluginOptions = Array.isArray(p) ? p[1] : undefined;
+    if (transformPlugin) {
+      module = transformPlugin(module, userConfig, pluginOptions);
+    } else {
+      module = typeof module === 'function' ? module(pluginOptions) : module;
+    }
 
     return {
-      cli: cliPlugin,
-      cliPath: typeof plugin === 'string' ? plugin : plugin.cli,
-      server: serverPlugin,
-      serverPath: typeof plugin === 'string' ? undefined : plugin.server,
+      pkg,
+      path,
+      module,
     };
+  };
+
+  const plugins = getAppPlugins(
+    appDirectory,
+    userConfig.plugins || [],
+    internalPlugins,
+  );
+
+  return plugins.map(plugin => {
+    const { cli, server } = plugin;
+    const loadedPlugin: LoadedPlugin = {} as LoadedPlugin;
+    if (cli) {
+      const { pkg, path, module } = resolvePlugin(cli);
+
+      loadedPlugin.cli = { ...module, pluginPath: path };
+      loadedPlugin.cliPkg = pkg;
+    }
+
+    if (server) {
+      const { pkg, path, module } = resolvePlugin(server);
+
+      loadedPlugin.server = { ...module, pluginPath: path };
+      loadedPlugin.serverPkg = pkg;
+    }
+
+    debug(`resolve plugin %s: %s`, plugin, {
+      cli: loadedPlugin.cli,
+      server: loadedPlugin.server,
+    });
+
+    return loadedPlugin;
   });
 };

--- a/packages/cli/core/tests/fixtures/load-plugin/user-plugins/test-plugin-c.js
+++ b/packages/cli/core/tests/fixtures/load-plugin/user-plugins/test-plugin-c.js
@@ -1,0 +1,3 @@
+Object.defineProperty(exports, '__esModule', { value: true });
+
+exports.default = name => ({ name });

--- a/packages/cli/core/tests/index.test.ts
+++ b/packages/cli/core/tests/index.test.ts
@@ -62,13 +62,8 @@ describe('@modern-js/core test', () => {
 
   it('test cli init dev', async () => {
     cwdSpy.mockReturnValue(path.join(cwd, 'nested-folder'));
-    const options = {
-      beforeUsePlugins: jest.fn(),
-    };
-    options.beforeUsePlugins.mockImplementation((plugins, _) => plugins);
-    await cli.init(['dev'], options);
+    await cli.init(['dev']);
     expect(loadEnv).toHaveBeenCalledWith(cwd, undefined);
-    expect(options.beforeUsePlugins).toHaveBeenCalledWith([], {});
     // TODO: add more test cases
   });
 });

--- a/packages/cli/core/tests/loadPlugin.test.ts
+++ b/packages/cli/core/tests/loadPlugin.test.ts
@@ -39,7 +39,6 @@ describe('load plugins', () => {
       },
       {
         server: {
-          name: 'b',
           pluginPath: path.join(fixture, './test-plugin-b.js'),
         },
         serverPkg: './test-plugin-b',
@@ -64,6 +63,27 @@ describe('load plugins', () => {
           pluginPath: path.join(fixture, './test-plugin-c.js'),
         },
         cliPkg: './test-plugin-c',
+      },
+    ]);
+  });
+
+  test('should load user string plugin successfully', () => {
+    const fixture = path.resolve(
+      __dirname,
+      './fixtures/load-plugin/user-plugins',
+    );
+
+    const plugins = loadPlugins(fixture, {
+      plugins: [path.join(fixture, './test-plugin-a.js') as any],
+    });
+
+    expect(plugins).toEqual([
+      {
+        cli: {
+          name: 'a',
+          pluginPath: path.join(fixture, './test-plugin-a.js'),
+        },
+        cliPkg: path.join(fixture, './test-plugin-a.js'),
       },
     ]);
   });

--- a/packages/cli/core/tests/loadPlugin.test.ts
+++ b/packages/cli/core/tests/loadPlugin.test.ts
@@ -22,10 +22,12 @@ describe('load plugins', () => {
       './fixtures/load-plugin/user-plugins',
     );
 
-    const plugins = loadPlugins(fixture, [
-      { cli: path.join(fixture, './test-plugin-a.js') },
-      { server: './test-plugin-b' },
-    ]);
+    const plugins = loadPlugins(fixture, {
+      plugins: [
+        { cli: path.join(fixture, './test-plugin-a.js') },
+        { server: './test-plugin-b' },
+      ],
+    });
 
     expect(plugins).toEqual([
       {
@@ -33,43 +35,66 @@ describe('load plugins', () => {
           name: 'a',
           pluginPath: path.join(fixture, './test-plugin-a.js'),
         },
-        cliPath: path.join(fixture, './test-plugin-a.js'),
+        cliPkg: path.join(fixture, './test-plugin-a.js'),
       },
       {
         server: {
+          name: 'b',
           pluginPath: path.join(fixture, './test-plugin-b.js'),
         },
-        serverPath: './test-plugin-b',
+        serverPkg: './test-plugin-b',
       },
     ]);
   });
 
-  test('should load user string plugin successfully', () => {
+  test('should pass options to Plugin', () => {
     const fixture = path.resolve(
       __dirname,
       './fixtures/load-plugin/user-plugins',
     );
 
-    const plugins = loadPlugins(fixture, [
-      path.join(fixture, './test-plugin-a.js') as any,
-    ]);
+    const plugins = loadPlugins(fixture, {
+      plugins: [{ cli: ['./test-plugin-c', 'c'] }],
+    });
 
     expect(plugins).toEqual([
       {
         cli: {
-          name: 'a',
-          pluginPath: path.join(fixture, './test-plugin-a.js'),
+          name: 'c',
+          pluginPath: path.join(fixture, './test-plugin-c.js'),
         },
-        cliPath: path.join(fixture, './test-plugin-a.js'),
+        cliPkg: './test-plugin-c',
       },
     ]);
+  });
+
+  test('should call transformPlugin', () => {
+    const fixture = path.resolve(
+      __dirname,
+      './fixtures/load-plugin/user-plugins',
+    );
+
+    const options = {
+      transformPlugin: jest.fn(),
+    };
+    options.transformPlugin.mockImplementation((plugins, _) => plugins);
+
+    loadPlugins(
+      fixture,
+      { plugins: [{ cli: path.join(fixture, './test-plugin-a.js') }] },
+      options,
+    );
+
+    expect(options.transformPlugin).toHaveBeenCalled();
   });
 
   test(`should throw error when plugin not found `, () => {
     const fixture = path.resolve(__dirname, './fixtures/load-plugin/not-found');
 
     expect(() => {
-      loadPlugins(fixture, [{ cli: './test-plugin-a' }, { cli: './plugin-b' }]);
+      loadPlugins(fixture, {
+        plugins: [{ cli: './test-plugin-a' }, { cli: './plugin-b' }],
+      });
     }).toThrowError(/^Can not find plugin /);
   });
 });

--- a/packages/cli/plugin-multiprocess/src/index.ts
+++ b/packages/cli/plugin-multiprocess/src/index.ts
@@ -35,7 +35,7 @@ export default createPlugin(
     afterBuild() {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const { distDirectory, plugins } = useAppContext();
-      const serverPluginPkgs = plugins.map(p => p.serverPath).filter(Boolean);
+      const serverPluginPkgs = plugins.map(p => p.serverPkg).filter(Boolean);
 
       const routeJSON = path.join(distDirectory, ROUTE_SPEC_FILE);
       const { routes } = fs.readJSONSync(routeJSON);

--- a/packages/toolkit/types/cli/index.d.ts
+++ b/packages/toolkit/types/cli/index.d.ts
@@ -57,9 +57,9 @@ export interface IAppContext {
   internalDirectory: string;
   plugins: {
     cli?: any;
-    cliPath?: any;
+    cliPkg?: any;
     server?: any;
-    serverPath?: any;
+    serverPkg?: any;
   }[];
   entrypoints: Entrypoint[];
   checkedEntries: string[];


### PR DESCRIPTION
# PR Details

Plugins support to accept options. 

## Description

Usage:
```
// modern.config.ts

import { defineConfig } from '@modern-js/app-tools'

export default defineConfig({
  plugins:  [{cli: ['plugin-a', {option: 'xx'} ]
});
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
