### PR TITLE
feat: add unbundle support for "arco design"

### DIFF
--- a/.changeset/lucky-tables-speak.md
+++ b/.changeset/lucky-tables-speak.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-unbundle': patch
+---
+
+feat: add unbundle support for "arco design"

--- a/packages/cli/plugin-unbundle/src/constants.ts
+++ b/packages/cli/plugin-unbundle/src/constants.ts
@@ -95,7 +95,11 @@ export const LAMBDA_API_FUNCTION_QUERY = '__lambda_api_function__';
 export const IGNORE_OPTIMIZE_DPES = ['domino'];
 
 // default lazy import ui components library
-export const DEFAULT_LAZY_IMPORT_UI_COMPONENTS = ['antd'];
+export const DEFAULT_LAZY_IMPORT_UI_COMPONENTS = [
+  'antd',
+  '@arco-design/web-react',
+  '@arco-design/web-react/icon',
+];
 
 export const ESBUILD_RESOLVE_PLUGIN_NAME = 'esm-resolve-plugin';
 

--- a/packages/cli/plugin-unbundle/src/plugins/lazy-import.ts
+++ b/packages/cli/plugin-unbundle/src/plugins/lazy-import.ts
@@ -6,7 +6,6 @@ import {
   DEFAULT_LAZY_IMPORT_UI_COMPONENTS,
 } from '../constants';
 import { isJsRequest } from '../utils';
-
 // FIXME: declare module 不生效的问题
 const traverse = require('@babel/traverse').default;
 const generate = require('@babel/generator').default;
@@ -31,6 +30,22 @@ const camelToKebab = (s: string) =>
     .replace(/([a-z])([A-Z])/g, '$1-$2')
     .replace(/\s+/g, '-')
     .toLowerCase();
+
+// assemble css import path
+// now only supports ant design and arco design
+// examples:
+// import 'antd/es/button/style/index.js'
+// import '@arco-design/web-react/es/Button/style/index.js'
+// import '@arco-design/web-react/icon/react-icon/IconArrowRight/index.js'
+export const assembleCSSImportPath = (source: string, importedName: string) => {
+  let libName = 'es';
+  let subFolder = 'style/';
+  if (source === '@arco-design/web-react/icon') {
+    libName = 'react-icon';
+    subFolder = '';
+  }
+  return `import '${source}/${libName}/${importedName}/${subFolder}index.js'`;
+};
 
 function changeImport(code: string) {
   const ast = parser.parse(code, {
@@ -78,10 +93,10 @@ function changeImport(code: string) {
 
       if (!isImportDefaultSpecifier && !isImportNamespaceSpecifier) {
         specifiers.forEach((specifier: any) => {
-          const importedName = ['antd'].includes(source)
+          const importedName = source.includes('antd')
             ? camelToKebab(specifier.imported.name)
             : specifier.imported.name;
-          const cssImporter = `import '${source}/es/${importedName}/style/index.js'`;
+          const cssImporter = assembleCSSImportPath(source, importedName);
           const cssImporterAst = parser.parse(cssImporter, {
             sourceType: 'module',
             plugins: ['jsx', 'typescript'],

--- a/packages/cli/plugin-unbundle/tests/style.test.ts
+++ b/packages/cli/plugin-unbundle/tests/style.test.ts
@@ -1,0 +1,28 @@
+import { DEFAULT_LAZY_IMPORT_UI_COMPONENTS } from '../src/constants';
+import { assembleCSSImportPath } from '../src/plugins/lazy-import';
+
+describe('style tests', () => {
+  test('support ui libraries', async () => {
+    expect(DEFAULT_LAZY_IMPORT_UI_COMPONENTS).toContain('antd');
+    expect(DEFAULT_LAZY_IMPORT_UI_COMPONENTS).toContain(
+      '@arco-design/web-react',
+    );
+    expect(DEFAULT_LAZY_IMPORT_UI_COMPONENTS).toContain(
+      '@arco-design/web-react/icon',
+    );
+  });
+
+  test('assemble ui import paths', async () => {
+    expect(assembleCSSImportPath('antd', 'button')).toBe(
+      `import 'antd/es/button/style/index.js'`,
+    );
+    expect(assembleCSSImportPath('@arco-design/web-react', 'Button')).toBe(
+      `import '@arco-design/web-react/es/Button/style/index.js'`,
+    );
+    expect(
+      assembleCSSImportPath('@arco-design/web-react/icon', 'IconArrowRight'),
+    ).toBe(
+      `import '@arco-design/web-react/icon/react-icon/IconArrowRight/index.js'`,
+    );
+  });
+});


### PR DESCRIPTION
# PR Details

add unbundle support for "arco design"

## Description

Now, `modern.js` supports importing [ant design](https://ant.design/) UI component without importing its css, like the examples above:
```jsx
import { List } from 'antd';
// As we don't need importing css for ant design, we add comment slash above.
// import "antd/dist/antd.css";
const App = () => <List/>
```

But somehow it's not availiable for [arco design](https://arco.design/en-US) yet. So this PR is gonna add its support.

After `arco design` is supported, developer can use command `modern dev --unbundled` to run project with `arco design` UI component, and without importing its css.

```jsx
import { List } from '@arco-design/web-react';
// As we don't need importing css for ant design, we add comment slash above.
// import "@arco-design/web-react/dist/css/arco.css";
const App = () => <List/>
```

Note: normal bundle support for `arco design` that uses command `modern dev` is still working in progress, which will be commited in another PR.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
