### PR TITLE
fix: output copy type && img resource support inline and url module

### DIFF
--- a/.changeset/chilled-countries-beam.md
+++ b/.changeset/chilled-countries-beam.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/module-tools': patch
+---
+
+feat: add img resource's inline and url type declaration

--- a/.changeset/fluffy-chefs-bow.md
+++ b/.changeset/fluffy-chefs-bow.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/core': patch
+'@modern-js/webpack': patch
+---
+
+fix: output.copy type

--- a/packages/cli/core/src/config/index.ts
+++ b/packages/cli/core/src/config/index.ts
@@ -66,7 +66,7 @@ interface OutputConfig {
   mountId?: string;
   favicon?: string;
   faviconByEntries?: Record<string, string | undefined>;
-  copy?: Record<string, unknown>;
+  copy?: Array<Record<string, unknown> & { from: string }>;
   scriptExt?: Record<string, unknown>;
   disableTsChecker?: boolean;
   disableHtmlFolder?: boolean;

--- a/packages/cli/webpack/src/config/client.ts
+++ b/packages/cli/webpack/src/config/client.ts
@@ -278,7 +278,7 @@ export class ClientWebpackConfig extends BaseWebpackConfig {
     this.chain.plugin('copy').use(CopyPlugin, [
       {
         patterns: [
-          ...((this.options.output.copy as any) || []),
+          ...(this.options.output.copy || []),
           {
             from: '**/*',
             to: 'public',

--- a/packages/generator/generator-utils/tests/stripAnsi.test.ts
+++ b/packages/generator/generator-utils/tests/stripAnsi.test.ts
@@ -1,0 +1,10 @@
+import { stripAnsi } from '../src';
+
+describe('test stripAnsi utils', () => {
+  test('stripAnsi right', () => {
+    expect(stripAnsi('v1.2.3')).toBe('v1.2.3');
+  });
+  test('stripAnsi error', () => {
+    expect(() => stripAnsi(1 as any)).toThrow(TypeError);
+  });
+});

--- a/packages/generator/generators/bff-generator/tests/index.test.ts
+++ b/packages/generator/generators/bff-generator/tests/index.test.ts
@@ -10,7 +10,14 @@ import {
 import { AppAPI } from '@modern-js/codesmith-api-app';
 import generator, { handleTemplateFile } from '../src';
 
-jest.setTimeout(60000);
+jest.mock('@modern-js/generator-utils', () => {
+  const originalModule = jest.requireActual('@modern-js/generator-utils');
+  return {
+    __esModule: true,
+    ...originalModule,
+    getPackageVersion: jest.fn(() => '^1.0.0'),
+  };
+});
 
 describe('bff-generator', () => {
   it('default', () => {

--- a/packages/generator/generators/bff-generator/tests/index.test.ts
+++ b/packages/generator/generators/bff-generator/tests/index.test.ts
@@ -10,7 +10,7 @@ import {
 import { AppAPI } from '@modern-js/codesmith-api-app';
 import generator, { handleTemplateFile } from '../src';
 
-jest.setTimeout(40000);
+jest.setTimeout(60000);
 
 describe('bff-generator', () => {
   it('default', () => {

--- a/packages/solutions/app-tools/lib/types.d.ts
+++ b/packages/solutions/app-tools/lib/types.d.ts
@@ -56,6 +56,98 @@ declare module '*.svg' {
   export default src;
 }
 
+declare module '*.bmp?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.gif?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpg?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpeg?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.png?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.ico?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.webp?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.svg?inline' {
+  import * as React from 'react';
+
+  export const ReactComponent: React.FunctionComponent<
+    React.SVGProps<SVGSVGElement>
+  >;
+
+  const src: string;
+  export default src;
+}
+
+declare module '*.bmp?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.gif?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpg?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpeg?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.png?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.ico?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.webp?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.svg?url' {
+  import * as React from 'react';
+
+  export const ReactComponent: React.FunctionComponent<
+    React.SVGProps<SVGSVGElement>
+  >;
+
+  const src: string;
+  export default src;
+}
+
 declare module '*.css' {
   const classes: { readonly [key: string]: string };
   export default classes;

--- a/packages/solutions/module-tools/lib/types.d.ts
+++ b/packages/solutions/module-tools/lib/types.d.ts
@@ -55,6 +55,98 @@ declare module '*.svg' {
   export default src;
 }
 
+declare module '*.bmp?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.gif?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpg?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpeg?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.png?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.ico?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.webp?inline' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.svg?inline' {
+  import * as React from 'react';
+
+  export const ReactComponent: React.FunctionComponent<
+    React.SVGProps<SVGSVGElement>
+  >;
+
+  const src: string;
+  export default src;
+}
+
+declare module '*.bmp?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.gif?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpg?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpeg?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.png?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.ico?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.webp?url' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.svg?url' {
+  import * as React from 'react';
+
+  export const ReactComponent: React.FunctionComponent<
+    React.SVGProps<SVGSVGElement>
+  >;
+
+  const src: string;
+  export default src;
+}
+
 declare module '*.css' {
   const classes: { readonly [key: string]: string };
   export default classes;

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -104,6 +104,8 @@
     "typescript": "^4",
     "@scripts/build": "workspace:*",
     "jest": "^27",
+    "@types/react": "^17",
+    "@types/react-dom": "^17",
     "@scripts/jest-config": "workspace:*"
   },
   "sideEffects": false,

--- a/packages/toolkit/utils/tests/index.test.ts
+++ b/packages/toolkit/utils/tests/index.test.ts
@@ -1,5 +1,7 @@
 import { canUseNpm, canUsePnpm, canUseYarn } from '../src';
 
+jest.setTimeout(40000);
+
 describe('test generator utils', () => {
   test('test canUseNpm', async () => {
     const npmAbility = await canUseNpm();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3961,6 +3961,8 @@ importers:
       '@types/lodash.merge': ^4.6.6
       '@types/node': ^14
       '@types/normalize-path': ^3.0.0
+      '@types/react': ^17
+      '@types/react-dom': ^17
       chalk: ^4.1.2
       commander: ^8.1.0
       dotenv: ^10.0.0
@@ -4023,6 +4025,8 @@ importers:
       '@types/lodash.merge': 4.6.6
       '@types/node': 14.18.4
       '@types/normalize-path': 3.0.0
+      '@types/react': 17.0.38
+      '@types/react-dom': 17.0.11
       commander: 8.3.0
       jest: 27.4.5
       typescript: 4.5.4


### PR DESCRIPTION
# PR Details

修复 output.copy 类型定义
修复图片资源使用 inline 和 url 后缀时类型问题
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
