### PR TITLE
fix: move some peerDependencies to dependecies

### DIFF
--- a/.changeset/friendly-apricots-accept.md
+++ b/.changeset/friendly-apricots-accept.md
@@ -1,0 +1,10 @@
+---
+'@modern-js/plugin-bff': patch
+'@modern-js/generator-common': patch
+'@modern-js/create-request': patch
+'@modern-js/plugin-express': patch
+'@modern-js/plugin-koa': patch
+'@modern-js/plugin-nest': patch
+---
+
+fix: move some peerDependencies to dependecies

--- a/packages/cli/plugin-bff/package.json
+++ b/packages/cli/plugin-bff/package.json
@@ -64,15 +64,15 @@
     "@modern-js/server-utils": "workspace:^1.2.1",
     "@modern-js/utils": "workspace:^1.3.3",
     "fs-extra": "^10.0.0",
-    "loader-utils": "^2.0.0"
+    "loader-utils": "^2.0.0",
+    "@modern-js/bff-utils": "workspace:^1.2.2",
+    "@modern-js/server-core": "workspace:^1.2.2",
+    "@modern-js/core": "workspace:^1.4.4"
   },
   "devDependencies": {
-    "@modern-js/bff-utils": "workspace:^1.2.2",
-    "@modern-js/core": "workspace:^1.4.4",
     "@scripts/build": "workspace:*",
     "@modern-js/plugin-analyze": "workspace:^1.3.3",
     "@modern-js/runtime": "workspace:^1.2.2",
-    "@modern-js/server-core": "workspace:^1.2.2",
     "@modern-js/types": "workspace:^1.3.4",
     "@types/babel__core": "^7.1.15",
     "@types/fs-extra": "^9.0.13",
@@ -86,11 +86,6 @@
     "webpack-chain": "^6.5.1",
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
-  },
-  "peerDependencies": {
-    "@modern-js/bff-utils": "workspace:^1.2.2",
-    "@modern-js/core": "workspace:^1.4.4",
-    "@modern-js/server-core": "workspace:^1.2.2"
   },
   "modernConfig": {
     "output": {

--- a/packages/server/create-request/package.json
+++ b/packages/server/create-request/package.json
@@ -72,11 +72,11 @@
     "@babel/runtime": "^7",
     "@modern-js/utils": "workspace:^1.2.2",
     "node-fetch": "^2.6.1",
-    "path-to-regexp": "^6.2.0"
+    "path-to-regexp": "^6.2.0",
+    "@modern-js/plugin-ssr": "workspace:^1.2.0"
   },
   "devDependencies": {
     "@scripts/build": "workspace:*",
-    "@modern-js/plugin-ssr": "workspace:^1.2.0",
     "@types/jest": "^27.0.3",
     "@types/node": "^14",
     "@types/node-fetch": "^2.5.12",
@@ -87,9 +87,6 @@
     "typescript": "^4",
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
-  },
-  "peerDependencies": {
-    "@modern-js/plugin-ssr": "workspace:^1.2.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/server/plugin-egg/package.json
+++ b/packages/server/plugin-egg/package.json
@@ -45,7 +45,11 @@
     "@modern-js/utils": "workspace:^1.3.2",
     "formidable": "^1.2.2",
     "type-is": "^1.6.18",
-    "egg-ts-helper": "^1.29.1"
+    "egg-ts-helper": "^1.29.1",
+    "@modern-js/bff-utils": "workspace:^1.2.2",
+    "@modern-js/core": "workspace:^1.4.3",
+    "@modern-js/server-core": "workspace:^1.2.2",
+    "@modern-js/bff-runtime": "workspace:^1.2.1"
   },
   "devDependencies": {
     "egg": "^2.29.4",
@@ -59,10 +63,6 @@
     "koa": "^2.13.1",
     "typescript": "^4",
     "supertest": "^6.1.6",
-    "@modern-js/bff-utils": "workspace:^1.2.2",
-    "@modern-js/bff-runtime": "workspace:^1.2.1",
-    "@modern-js/core": "workspace:^1.4.3",
-    "@modern-js/server-core": "workspace:^1.2.2",
     "@scripts/build": "workspace:*",
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
@@ -73,10 +73,6 @@
     }
   },
   "peerDependencies": {
-    "@modern-js/bff-utils": "workspace:^1.2.2",
-    "@modern-js/core": "workspace:^1.4.3",
-    "@modern-js/server-core": "workspace:^1.2.2",
-    "@modern-js/bff-runtime": "workspace:^1.2.1",
     "egg": "^2.29.4"
   },
   "publishConfig": {

--- a/packages/server/plugin-express/package.json
+++ b/packages/server/plugin-express/package.json
@@ -46,12 +46,15 @@
     "cookie-parser": "^1.4.5",
     "finalhandler": "^1.1.2",
     "formidable": "^1.2.2",
-    "type-is": "^1.6.18"
+    "type-is": "^1.6.18",
+    "@modern-js/core": "workspace:^1.4.0",
+    "@modern-js/bff-utils": "workspace:^1.2.2",
+    "@modern-js/server-core": "workspace:^1.2.2",
+    "@modern-js/bff-runtime": "workspace:^1.2.1"
   },
   "devDependencies": {
     "express": "^4.17.1",
     "@modern-js/server-utils": "workspace:^1.2.1",
-    "@modern-js/bff-runtime": "workspace:^1.2.1",
     "@types/cookie-parser": "^1.4.2",
     "@types/express": "^4.17.13",
     "@types/finalhandler": "^1.1.1",
@@ -62,9 +65,7 @@
     "@types/type-is": "^1.6.3",
     "supertest": "^6.1.6",
     "typescript": "^4",
-    "@modern-js/bff-utils": "workspace:^1.2.2",
     "@modern-js/core": "workspace:^1.4.0",
-    "@modern-js/server-core": "workspace:^1.2.2",
     "@scripts/build": "workspace:*",
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
@@ -75,10 +76,6 @@
     }
   },
   "peerDependencies": {
-    "@modern-js/bff-utils": "workspace:^1.2.2",
-    "@modern-js/core": "workspace:^1.4.0",
-    "@modern-js/server-core": "workspace:^1.2.2",
-    "@modern-js/bff-runtime": "workspace:^1.2.1",
     "express": "^4.17.1"
   },
   "publishConfig": {

--- a/packages/server/plugin-koa/package.json
+++ b/packages/server/plugin-koa/package.json
@@ -46,7 +46,11 @@
     "formidable": "^1.2.2",
     "koa-body": "^4.2.0",
     "koa-router": "^10.0.0",
-    "type-is": "^1.6.18"
+    "type-is": "^1.6.18",
+    "@modern-js/bff-utils": "workspace:^1.2.2",
+    "@modern-js/core": "workspace:^1.4.3",
+    "@modern-js/server-core": "workspace:^1.2.2",
+    "@modern-js/bff-runtime": "workspace:^1.2.1"
   },
   "devDependencies": {
     "koa": "^2.13.3",
@@ -59,10 +63,6 @@
     "@types/type-is": "^1.6.3",
     "supertest": "^6.1.6",
     "typescript": "^4",
-    "@modern-js/bff-runtime": "workspace:^1.2.1",
-    "@modern-js/bff-utils": "workspace:^1.2.2",
-    "@modern-js/core": "workspace:^1.4.3",
-    "@modern-js/server-core": "workspace:^1.2.2",
     "@scripts/build": "workspace:*",
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
@@ -73,10 +73,6 @@
     }
   },
   "peerDependencies": {
-    "@modern-js/bff-utils": "workspace:^1.2.2",
-    "@modern-js/core": "workspace:^1.4.3",
-    "@modern-js/server-core": "workspace:^1.2.2",
-    "@modern-js/bff-runtime": "workspace:^1.2.1",
     "koa": "^2.13.3"
   },
   "publishConfig": {

--- a/packages/server/plugin-nest/package.json
+++ b/packages/server/plugin-nest/package.json
@@ -53,12 +53,14 @@
     "formidable": "^1.2.2",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.3.0",
-    "type-is": "^1.6.18"
+    "type-is": "^1.6.18",
+    "@modern-js/bff-utils": "workspace:^1.2.2",
+    "@modern-js/core": "workspace:^1.4.0",
+    "@modern-js/server-core": "workspace:^1.2.2",
+    "@modern-js/bff-runtime": "workspace:^1.2.1"
   },
   "devDependencies": {
-    "@modern-js/bff-utils": "workspace:^1.2.2",
     "@modern-js/runtime": "workspace:^1.2.2",
-    "@modern-js/bff-runtime": "workspace:^1.2.1",
     "@modern-js/server-utils": "workspace:^1.2.1",
     "@types/babel__traverse": "^7.14.2",
     "@types/body-parser": "^1.19.1",
@@ -78,8 +80,6 @@
     "typescript": "^4",
     "@nestjs/common": "^8.0.6",
     "@nestjs/core": "^8.0.6",
-    "@modern-js/core": "workspace:^1.4.0",
-    "@modern-js/server-core": "workspace:^1.2.2",
     "@scripts/build": "workspace:*",
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
@@ -88,11 +88,7 @@
     "express": "^4.17.1",
     "fastify": "^3.20.1",
     "@nestjs/common": "^8.0.6",
-    "@nestjs/core": "^8.0.6",
-    "@modern-js/bff-utils": "workspace:^1.2.2",
-    "@modern-js/core": "workspace:^1.4.0",
-    "@modern-js/server-core": "workspace:^1.2.2",
-    "@modern-js/bff-runtime": "workspace:^1.2.1"
+    "@nestjs/core": "^8.0.6"
   },
   "peerDependenciesMeta": {
     "express": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,18 +458,18 @@ importers:
       '@babel/core': 7.16.7
       '@babel/runtime': 7.16.7
       '@modern-js/babel-compiler': link:../../toolkit/compiler/babel
+      '@modern-js/bff-utils': link:../../server/bff-utils
+      '@modern-js/core': link:../core
       '@modern-js/create-request': link:../../server/create-request
+      '@modern-js/server-core': link:../../server/core
       '@modern-js/server-utils': link:../../server/utils
       '@modern-js/utils': link:../../toolkit/utils
       esbuild: 0.13.15
       fs-extra: 10.0.0
       loader-utils: 2.0.2
     devDependencies:
-      '@modern-js/bff-utils': link:../../server/bff-utils
-      '@modern-js/core': link:../core
       '@modern-js/plugin-analyze': link:../plugin-analyze
       '@modern-js/runtime': link:../plugin-runtime
-      '@modern-js/server-core': link:../../server/core
       '@modern-js/types': link:../../toolkit/types
       '@scripts/build': link:../../../scripts/build
       '@scripts/jest-config': link:../../../scripts/jest-config
@@ -3328,11 +3328,11 @@ importers:
       typescript: ^4
     dependencies:
       '@babel/runtime': 7.16.7
+      '@modern-js/plugin-ssr': link:../../cli/plugin-ssr
       '@modern-js/utils': link:../../toolkit/utils
       node-fetch: 2.6.6
       path-to-regexp: 6.2.0
     devDependencies:
-      '@modern-js/plugin-ssr': link:../../cli/plugin-ssr
       '@scripts/build': link:../../../scripts/build
       '@scripts/jest-config': link:../../../scripts/jest-config
       '@types/jest': 27.4.0
@@ -3405,15 +3405,15 @@ importers:
     dependencies:
       '@babel/runtime': 7.16.7
       '@modern-js/adapter-helpers': link:../adapter-helpers
+      '@modern-js/bff-runtime': link:../bff-runtime
+      '@modern-js/bff-utils': link:../bff-utils
+      '@modern-js/core': link:../../cli/core
+      '@modern-js/server-core': link:../core
       '@modern-js/utils': link:../../toolkit/utils
       egg-ts-helper: 1.29.1
       formidable: 1.2.6
       type-is: 1.6.18
     devDependencies:
-      '@modern-js/bff-runtime': link:../bff-runtime
-      '@modern-js/bff-utils': link:../bff-utils
-      '@modern-js/core': link:../../cli/core
-      '@modern-js/server-core': link:../core
       '@scripts/build': link:../../../scripts/build
       '@scripts/jest-config': link:../../../scripts/jest-config
       '@types/formidable': 1.2.5
@@ -3460,16 +3460,16 @@ importers:
     dependencies:
       '@babel/runtime': 7.16.7
       '@modern-js/adapter-helpers': link:../adapter-helpers
+      '@modern-js/bff-runtime': link:../bff-runtime
+      '@modern-js/bff-utils': link:../bff-utils
+      '@modern-js/core': link:../../cli/core
+      '@modern-js/server-core': link:../core
       '@modern-js/utils': link:../../toolkit/utils
       cookie-parser: 1.4.6
       finalhandler: 1.1.2
       formidable: 1.2.6
       type-is: 1.6.18
     devDependencies:
-      '@modern-js/bff-runtime': link:../bff-runtime
-      '@modern-js/bff-utils': link:../bff-utils
-      '@modern-js/core': link:../../cli/core
-      '@modern-js/server-core': link:../core
       '@modern-js/server-utils': link:../utils
       '@scripts/build': link:../../../scripts/build
       '@scripts/jest-config': link:../../../scripts/jest-config
@@ -3515,16 +3515,16 @@ importers:
     dependencies:
       '@babel/runtime': 7.16.7
       '@modern-js/adapter-helpers': link:../adapter-helpers
+      '@modern-js/bff-runtime': link:../bff-runtime
+      '@modern-js/bff-utils': link:../bff-utils
+      '@modern-js/core': link:../../cli/core
+      '@modern-js/server-core': link:../core
       '@modern-js/utils': link:../../toolkit/utils
       formidable: 1.2.6
       koa-body: 4.2.0
       koa-router: 10.1.1
       type-is: 1.6.18
     devDependencies:
-      '@modern-js/bff-runtime': link:../bff-runtime
-      '@modern-js/bff-utils': link:../bff-utils
-      '@modern-js/core': link:../../cli/core
-      '@modern-js/server-core': link:../core
       '@scripts/build': link:../../../scripts/build
       '@scripts/jest-config': link:../../../scripts/jest-config
       '@types/formidable': 1.2.5
@@ -3580,6 +3580,10 @@ importers:
       typescript: ^4
     dependencies:
       '@modern-js/adapter-helpers': link:../adapter-helpers
+      '@modern-js/bff-runtime': link:../bff-runtime
+      '@modern-js/bff-utils': link:../bff-utils
+      '@modern-js/core': link:../../cli/core
+      '@modern-js/server-core': link:../core
       '@modern-js/utils': link:../../toolkit/utils
       '@nestjs/platform-express': 8.2.4_4074b1ae164556f5db19ac4b8b5667b7
       '@types/type-is': 1.6.3
@@ -3590,11 +3594,7 @@ importers:
       rxjs: 7.5.2
       type-is: 1.6.18
     devDependencies:
-      '@modern-js/bff-runtime': link:../bff-runtime
-      '@modern-js/bff-utils': link:../bff-utils
-      '@modern-js/core': link:../../cli/core
       '@modern-js/runtime': link:../../cli/plugin-runtime
-      '@modern-js/server-core': link:../core
       '@modern-js/server-utils': link:../utils
       '@nestjs/common': 8.2.4_88a789cb3f20cca25c3f70fe96f41643
       '@nestjs/core': 8.2.4_8b22effdebed417d7c9b4d391c70f023


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

之前因为 modernjs/utils 依赖的 typescript 版本问题，导致安装 modernjs/core 会有多个实例，把很多为 dependencies 的依赖改为了 peerDependencies。现在该问题已修复，将依赖修改回来，避免隐式依赖及 pnpm 安装之后的警告。

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
