### PR TITLE
fix(eslint): remove no-invalid-void-type rule

### DIFF
--- a/.changeset/brown-pigs-brake.md
+++ b/.changeset/brown-pigs-brake.md
@@ -1,0 +1,5 @@
+---
+'@modern-js-app/eslint-config': patch
+---
+
+fix: remove no-invalid-void-type rule

--- a/packages/cli/plugin-garfish/src/cli/index.ts
+++ b/packages/cli/plugin-garfish/src/cli/index.ts
@@ -17,7 +17,6 @@ import {
 export const externals = { 'react-dom': 'react-dom', react: 'react' };
 
 type Initializer = Parameters<typeof createPlugin>[0];
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 type NonVoidPromiseAble<T> = T extends void | Promise<any> ? never : T;
 export type LifeCycle = NonVoidPromiseAble<ReturnType<Initializer>>;
 

--- a/packages/cli/plugin-less/src/types.ts
+++ b/packages/cli/plugin-less/src/types.ts
@@ -14,7 +14,6 @@ type Options = {
 
 declare module '@modern-js/core' {
   interface ToolsConfig {
-    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
     less?: Options | ((options: Options) => Options | void);
   }
 }

--- a/packages/cli/plugin-sass/src/types.ts
+++ b/packages/cli/plugin-sass/src/types.ts
@@ -5,7 +5,6 @@ type SassOptions = Options<'sync'> | Options<'async'>;
 
 declare module '@modern-js/core' {
   interface ToolsConfig {
-    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
     sass?: SassOptions | ((options: SassOptions) => SassOptions | void);
   }
 }

--- a/packages/cli/plugin-tailwind/src/types.ts
+++ b/packages/cli/plugin-tailwind/src/types.ts
@@ -4,7 +4,6 @@ declare module '@modern-js/core' {
   interface ToolsConfig {
     tailwindcss?:
       | Record<string, any>
-      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
       | ((options: Record<string, any>) => Record<string, any> | void);
   }
   interface SourceConfig {

--- a/packages/review/eslint-config-app/eslintrc.js
+++ b/packages/review/eslint-config-app/eslintrc.js
@@ -2013,8 +2013,6 @@ module.exports = {
         '@typescript-eslint/no-for-in-array': 'error',
         // https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules
         '@typescript-eslint/no-implicit-any-catch': 'off',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-invalid-void-type.md
-        '@typescript-eslint/no-invalid-void-type': 'error',
         // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-inferrable-types.md
         '@typescript-eslint/no-inferrable-types': [
           'error',

--- a/packages/runtime/src/plugin.ts
+++ b/packages/runtime/src/plugin.ts
@@ -57,7 +57,6 @@ const client = createAsyncPipeline<
     readonly context?: RuntimeContext;
     rootElement: HTMLElement;
   },
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   void
 >();
 

--- a/packages/solutions/monorepo-tools/src/hooks/index.ts
+++ b/packages/solutions/monorepo-tools/src/hooks/index.ts
@@ -7,7 +7,6 @@ const afterMonorepoDeploy = createAsyncWorkflow<
     operator: DagOperator;
     deployProjectNames: string[];
   },
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   void
 >();
 

--- a/packages/toolkit/compiler/babel/src/type.ts
+++ b/packages/toolkit/compiler/babel/src/type.ts
@@ -1,4 +1,4 @@
-import { TransformOptions } from '@babel/core';
+import type { TransformOptions } from '@babel/core';
 import type { IOptions } from 'glob';
 
 export type BabelOptions = TransformOptions;

--- a/packages/toolkit/esmpack/src/utils/parseExports.ts
+++ b/packages/toolkit/esmpack/src/utils/parseExports.ts
@@ -76,8 +76,7 @@ async function doParse(ctx: ParseContext, fileLoc: string) {
     throw new Error('parseExportVariableNames failed');
   }
   traverse(
-    // TODO: error TS2345: Argument of type 'File | Program' is not assignable to parameter of type 'Node | Node[] | null | undefined'
-    ast as any,
+    ast,
     visitorCreator({
       testUMD: true,
     }),

--- a/packages/toolkit/plugin/src/manager/async.ts
+++ b/packages/toolkit/plugin/src/manager/async.ts
@@ -12,7 +12,6 @@ import {
 } from './sync';
 import { useRunner } from './runner';
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type AsyncInitializer<O> = () => void | O | Promise<O | void>;
 
 const ASYNC_PLUGIN_SYMBOL = 'ASYNC_PLUGIN_SYMBOL';
@@ -41,7 +40,6 @@ export type PluginFromAsyncManager<M extends AsyncManager<any, any>> =
 
 export type AsyncManager<
   EP extends Record<string, any>,
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   PR extends ProgressRecord | void = void,
 > = {
   createPlugin: (
@@ -73,7 +71,6 @@ export type AsyncManager<
 export const createAsyncManager = <
   // eslint-disable-next-line @typescript-eslint/ban-types
   EP extends Record<string, any> = {},
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   PR extends ProgressRecord | void = void,
 >(
   processes?: PR,

--- a/packages/toolkit/plugin/src/manager/sync.ts
+++ b/packages/toolkit/plugin/src/manager/sync.ts
@@ -36,7 +36,6 @@ import {
 } from '../workflow';
 import { RunnerContext, useRunner } from './runner';
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type Initializer<O> = () => O | void;
 
 const SYNC_PLUGIN_SYMBOL = 'SYNC_PLUGIN_SYMBOL';
@@ -91,14 +90,11 @@ export type Progress2Thread<P extends Progress> = P extends Workflow<
 
 export type ProgressRecord = Record<string, Progress>;
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type Progresses2Threads<PS extends ProgressRecord | void> = {
   [K in keyof PS]: PS[K] extends Progress
     ? Progress2Thread<PS[K]>
-    : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    PS[K] extends void
-    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      void
+    : PS[K] extends void
+    ? void
     : never;
 };
 
@@ -120,14 +116,11 @@ export type RunnerFromProgress<P extends Progress> = P extends Waterfall<
   ? AsyncPipeline<I, O>['run']
   : never;
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type Progresses2Runners<PS extends ProgressRecord | void> = {
   [K in keyof PS]: PS[K] extends Progress
     ? RunnerFromProgress<PS[K]>
-    : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    PS[K] extends void
-    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      void
+    : PS[K] extends void
+    ? void
     : never;
 };
 
@@ -146,7 +139,6 @@ export type InitOptions = {
 };
 export type Manager<
   EP extends Record<string, any>,
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   PR extends ProgressRecord | void = void,
 > = {
   createPlugin: (
@@ -184,7 +176,6 @@ export const DEFAULT_OPTIONS: Required<PluginOptions> = {
 export const createManager = <
   // eslint-disable-next-line @typescript-eslint/ban-types
   EP extends Record<string, any> = {},
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   PR extends ProgressRecord | void = void,
 >(
   processes?: PR,
@@ -296,10 +287,8 @@ export const createManager = <
 export const generateRunner = <
   // eslint-disable-next-line @typescript-eslint/ban-types
   EP extends Record<string, any> = {},
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   PR extends ProgressRecord | void = void,
 >(
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   hooksList: (void | Partial<
     Progresses2Threads<PR & ClearDraftProgress<EP>>
   >)[],
@@ -364,7 +353,6 @@ export const cloneProgress = (progress: Progress): Progress => {
   throw new Error(`Unknown progress: ${progress}`);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export const cloneProgressRecord = <PR extends ProgressRecord | void>(
   record: PR,
 ): PR => {

--- a/packages/toolkit/plugin/src/waterfall/async.ts
+++ b/packages/toolkit/plugin/src/waterfall/async.ts
@@ -42,32 +42,25 @@ export type AsyncWaterfall2AsyncBrook<P extends AsyncWaterfall<any>> =
 
 export type AsyncWaterfallRecord = Record<string, AsyncWaterfall<any>>;
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type AsyncWaterfalls2Brooks<PS extends AsyncWaterfallRecord | void> = {
   [K in keyof PS]: PS[K] extends AsyncWaterfall<any>
     ? AsyncWaterfall2AsyncBrook<PS[K]>
-    : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    PS[K] extends void
-    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      void
+    : PS[K] extends void
+    ? void
     : never;
 };
 
 export type RunnerFromAsyncWaterfall<M extends AsyncWaterfall<any>> =
   M extends AsyncWaterfall<infer VS> ? AsyncWaterfall<VS>['run'] : never;
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type AsyncWaterfalls2Runners<PS extends AsyncWaterfallRecord | void> = {
   [K in keyof PS]: PS[K] extends AsyncWaterfall<any>
     ? RunnerFromAsyncWaterfall<PS[K]>
-    : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    PS[K] extends void
-    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      void
+    : PS[K] extends void
+    ? void
     : never;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export const createAsyncWaterfall = <I = void>(): AsyncWaterfall<I> => {
   const pipeline = createAsyncPipeline<I, I>();
 

--- a/packages/toolkit/plugin/src/waterfall/sync.ts
+++ b/packages/toolkit/plugin/src/waterfall/sync.ts
@@ -27,7 +27,6 @@ export type RunWaterfallOptions<I = unknown> = {
   onLast?: Brook<I>;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type Waterfall<I = void> = {
   run: (input: I, options?: RunWaterfallOptions<I>) => I;
   use: (...I: BrookInputs<I>) => Waterfall<I>;
@@ -43,14 +42,11 @@ export type Waterfall2Brook<P extends Waterfall<any>> = P extends Waterfall<
 
 export type WaterfallRecord = Record<string, Waterfall<any>>;
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type Waterfalls2Brooks<PS extends WaterfallRecord | void> = {
   [K in keyof PS]: PS[K] extends Waterfall<any>
     ? Waterfall2Brook<PS[K]>
-    : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    PS[K] extends void
-    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      void
+    : PS[K] extends void
+    ? void
     : never;
 };
 
@@ -60,18 +56,14 @@ export type RunnerFromWaterfall<M extends Waterfall<any>> = M extends Waterfall<
   ? Waterfall<VS>['run']
   : never;
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type Waterfalls2Runners<PS extends WaterfallRecord | void> = {
   [K in keyof PS]: PS[K] extends Waterfall<any>
     ? RunnerFromWaterfall<PS[K]>
-    : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    PS[K] extends void
-    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      void
+    : PS[K] extends void
+    ? void
     : never;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export const createWaterfall = <I = void>(): Waterfall<I> => {
   const pipeline = createPipeline<I, I>();
 

--- a/packages/toolkit/plugin/src/workflow/async.ts
+++ b/packages/toolkit/plugin/src/workflow/async.ts
@@ -17,15 +17,12 @@ export type AsyncWorkflow2AsyncWorker<W extends AsyncWorkflow<any, any>> =
 
 export type AsyncWorkflowRecord = Record<string, AsyncWorkflow<any, any>>;
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type AsyncWorkflows2AsyncWorkers<PS extends AsyncWorkflowRecord | void> =
   {
     [K in keyof PS]: PS[K] extends AsyncWorkflow<any, any>
       ? AsyncWorkflow2AsyncWorker<PS[K]>
-      : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      PS[K] extends void
-      ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        void
+      : PS[K] extends void
+      ? void
       : never;
   };
 
@@ -34,21 +31,17 @@ export type RunnerFromAsyncWorkflow<W extends AsyncWorkflow<any, any>> =
     ? AsyncWorkflow<I, O>['run']
     : never;
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type AsyncWorkflows2Runners<PS extends AsyncWorkflowRecord | void> = {
   [K in keyof PS]: PS[K] extends AsyncWorkflow<any, any>
     ? RunnerFromAsyncWorkflow<PS[K]>
-    : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    PS[K] extends void
-    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      void
+    : PS[K] extends void
+    ? void
     : never;
 };
 
 export const isAsyncWorkflow = (input: any): input is AsyncWorkflow<any, any> =>
   Boolean(input?.[ASYNC_WORKFLOW_SYMBOL]);
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export const createAsyncWorkflow = <I = void, O = unknown>(): AsyncWorkflow<
   I,
   O

--- a/packages/toolkit/plugin/src/workflow/parallel.ts
+++ b/packages/toolkit/plugin/src/workflow/parallel.ts
@@ -16,28 +16,22 @@ export type ParallelWorkflow2Worker<W extends ParallelWorkflow<any>> =
 export type ParallelWorkflowRecord = Record<string, ParallelWorkflow<any>>;
 
 export type ParallelWorkflows2Workers<
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   PS extends ParallelWorkflowRecord | void,
 > = {
   [K in keyof PS]: PS[K] extends ParallelWorkflow<any>
     ? ParallelWorkflow2Worker<PS[K]>
-    : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    PS[K] extends void
-    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      void
+    : PS[K] extends void
+    ? void
     : never;
 };
 
 export type ParallelWorkflows2AsyncWorkers<
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   PS extends ParallelWorkflowRecord | void,
 > = {
   [K in keyof PS]: PS[K] extends ParallelWorkflow<any>
     ? ParallelWorkflow2Worker<PS[K]>
-    : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    PS[K] extends void
-    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      void
+    : PS[K] extends void
+    ? void
     : never;
 };
 
@@ -47,15 +41,12 @@ export type RunnerFromParallelWorkflow<W extends ParallelWorkflow<any>> =
     : never;
 
 export type ParallelWorkflows2Runners<
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   PS extends ParallelWorkflowRecord | void,
 > = {
   [K in keyof PS]: PS[K] extends ParallelWorkflow<any>
     ? RunnerFromParallelWorkflow<PS[K]>
-    : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    PS[K] extends void
-    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      void
+    : PS[K] extends void
+    ? void
     : never;
 };
 
@@ -64,7 +55,6 @@ export const isParallelWorkflow = (
 ): input is ParallelWorkflow<any> => Boolean(input?.[PARALLEL_WORKFLOW_SYMBOL]);
 
 export const createParallelWorkflow = <
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   I = void,
   O = unknown,
 >(): ParallelWorkflow<I, O> => {

--- a/packages/toolkit/plugin/src/workflow/sync.ts
+++ b/packages/toolkit/plugin/src/workflow/sync.ts
@@ -24,32 +24,25 @@ export type Workflow2Worker<W extends Workflow<any, any>> = W extends Workflow<
 
 export type WorkflowRecord = Record<string, Workflow<any, any>>;
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type Workflows2Workers<PS extends WorkflowRecord | void> = {
   [K in keyof PS]: PS[K] extends Workflow<any, any>
     ? Workflow2Worker<PS[K]>
-    : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    PS[K] extends void
-    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      void
+    : PS[K] extends void
+    ? void
     : never;
 };
 
 export type RunnerFromWorkflow<W extends Workflow<any, any>> =
   W extends Workflow<infer I, infer O> ? Workflow<I, O>['run'] : never;
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export type Workflows2Runners<PS extends WorkflowRecord | void> = {
   [K in keyof PS]: PS[K] extends Workflow<any, any>
     ? RunnerFromWorkflow<PS[K]>
-    : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    PS[K] extends void
-    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      void
+    : PS[K] extends void
+    ? void
     : never;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export const createWorkflow = <I = void, O = unknown>(): Workflow<I, O> => {
   const pipeline = createPipeline<I, O[]>();
 

--- a/packages/toolkit/utils/src/applyOptionsChain.ts
+++ b/packages/toolkit/utils/src/applyOptionsChain.ts
@@ -3,12 +3,10 @@ import { isFunction, logger, isPlainObject } from './index';
 
 export const applyOptionsChain = <T, U>(
   defaults: T,
-  /* eslint-disable @typescript-eslint/no-invalid-void-type */
   options?:
     | T
     | ((config: T, utils?: U) => T | void)
     | Array<T | ((config: T, utils?: U) => T | void)>,
-  /* eslint-enable @typescript-eslint/no-invalid-void-type */
   utils?: U,
   mergeFn = Object.assign,
 ): T => {


### PR DESCRIPTION
# PR Details

Remove `no-invalid-void-type` rule, it is not a recommend rule of typescript-eslint, an void is a commonly used type in out codebase.

- https://typescript-eslint.io/rules/no-invalid-void-type/

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
