### PR TITLE
feat(plugin): manager.usePlugin support accept new plugin function

### DIFF
--- a/packages/cli/core/src/manager.ts
+++ b/packages/cli/core/src/manager.ts
@@ -84,11 +84,5 @@ export const { createPlugin, registerHook, useRunner: mountHook } = manager;
 export const usePlugins = (plugins: string[]) =>
   plugins.forEach(pluginPath => {
     const module = compatRequire(require.resolve(pluginPath));
-
-    if (typeof module === 'function') {
-      const plugin = module();
-      manager.usePlugin(createPlugin(plugin.setup, plugin));
-    } else {
-      manager.usePlugin(module);
-    }
+    manager.usePlugin(module);
   });

--- a/packages/toolkit/plugin/package.json
+++ b/packages/toolkit/plugin/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7",
+    "@modern-js/utils": "workspace:^1.3.4",
     "farrow-pipeline": "^1.10.6"
   },
   "devDependencies": {

--- a/packages/toolkit/plugin/tests/async.test.ts
+++ b/packages/toolkit/plugin/tests/async.test.ts
@@ -603,7 +603,7 @@ describe('async manager', () => {
           done();
         },
       };
-      manager.usePlugin(manager.createPlugin(plugin.setup, plugin));
+      manager.usePlugin(() => plugin);
       manager.init();
     });
 
@@ -627,7 +627,7 @@ describe('async manager', () => {
         },
       };
 
-      manager.usePlugin(manager.createPlugin(plugin.setup, plugin));
+      manager.usePlugin(() => plugin);
       manager.init();
     });
   });
@@ -652,7 +652,7 @@ describe('async manager', () => {
         },
       };
 
-      manager.usePlugin(manager.createPlugin(plugin1.setup, plugin1));
+      manager.usePlugin(() => plugin1);
 
       await manager.init();
 
@@ -670,7 +670,7 @@ describe('async manager', () => {
         },
       };
 
-      const plugin1: TestAsyncPlugin = {
+      const plugin1 = {
         name: 'plugin1',
         usePlugins: [plugin0],
         setup: () => {
@@ -678,7 +678,7 @@ describe('async manager', () => {
         },
       };
 
-      const plugin2: TestAsyncPlugin = {
+      const plugin2 = {
         name: 'plugin2',
         usePlugins: [plugin1],
         setup: () => {
@@ -686,7 +686,7 @@ describe('async manager', () => {
         },
       };
 
-      manager.usePlugin(manager.createPlugin(plugin2.setup, plugin2));
+      manager.usePlugin(() => plugin2);
 
       await manager.init();
 

--- a/packages/toolkit/plugin/tests/sync.test.ts
+++ b/packages/toolkit/plugin/tests/sync.test.ts
@@ -573,7 +573,7 @@ describe('sync manager', () => {
           done();
         },
       };
-      manager.usePlugin(manager.createPlugin(plugin.setup, plugin));
+      manager.usePlugin(() => plugin);
       manager.init();
     });
 
@@ -594,7 +594,7 @@ describe('sync manager', () => {
         },
       };
 
-      manager.usePlugin(manager.createPlugin(plugin.setup, plugin));
+      manager.usePlugin(() => plugin);
       manager.init();
     });
   });
@@ -619,8 +619,7 @@ describe('sync manager', () => {
         },
       };
 
-      manager.usePlugin(manager.createPlugin(plugin1.setup, plugin1));
-
+      manager.usePlugin(() => plugin1);
       manager.init();
 
       expect(list).toStrictEqual([0, 1]);
@@ -653,8 +652,7 @@ describe('sync manager', () => {
         },
       };
 
-      manager.usePlugin(manager.createPlugin(plugin2.setup, plugin2));
-
+      manager.usePlugin(() => plugin2);
       manager.init();
 
       expect(list).toStrictEqual([0, 1, 2]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4525,6 +4525,7 @@ importers:
   packages/toolkit/plugin:
     specifiers:
       '@babel/runtime': ^7
+      '@modern-js/utils': workspace:^1.3.4
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@types/jest': ^26
@@ -4534,6 +4535,7 @@ importers:
       typescript: ^4
     dependencies:
       '@babel/runtime': 7.16.7
+      '@modern-js/utils': link:../utils
       farrow-pipeline: 1.11.3
     devDependencies:
       '@scripts/build': link:../../../scripts/build


### PR DESCRIPTION
# PR Details

manager.usePlugin support accept new plugin function, this makes it easier to write unit tests for new plugins.

```js
const plugin = () => ({
  name: 'foo',
  setup: () => {}
});

// before
manager.usePlugin(manager.createPlugin(plugin.setup, plugin));

// after
manager.usePlugin(plugin);
```

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
