### PR TITLE
test: speed up unit test by adding --maxWorkers=2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "setup": "npm run reset && pnpm install --ignore-scripts",
     "reset": "pnpm dlx del-cli ./node_modules",
     "test": "npm run test:ut",
-    "test:ut": "node --conditions=jsnext:source -r btsm node_modules/jest/bin/jest.js -c jest.config.js",
+    "test:ut": "node --conditions=jsnext:source -r btsm node_modules/jest/bin/jest.js -c jest.config.js --maxWorkers=2",
     "test:e2e": "cd tests && npm run test",
     "fast-lint": "sh -x ./fast-lint.sh",
     "prepare": "pnpm run prepare --filter ./packages",


### PR DESCRIPTION
# PR Details

## Description

Some articles said that add `--maxWorkers=2` can speed up jest in GitHub actions.

**After verification, this param can indeed reduce the test time by 1~3 minutes.**

### Before:

![image](https://user-images.githubusercontent.com/7237365/159265413-e76655b8-8205-47d6-aed6-2505ebb05f77.png)

### After:

![image](https://user-images.githubusercontent.com/7237365/159265372-8dc63239-b0f4-4d53-8520-f8013c2fb9fd.png)

see: 

- https://dev.to/ddoice/fix-slow-tests-with-jest-in-github-actions-5h00
- https://bharathvaj.me/blog/speedup-jest-github-actions

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
