### PR TITLE
feat(plugin): allow manger.clone to override plugin api

### DIFF
--- a/.changeset/slow-books-greet.md
+++ b/.changeset/slow-books-greet.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin': patch
+---
+
+feat: allow manger.clone to override pluginAPI

--- a/packages/toolkit/plugin/tests/async.test.ts
+++ b/packages/toolkit/plugin/tests/async.test.ts
@@ -398,6 +398,22 @@ describe('async manager', () => {
     expect(count).toBe(2);
   });
 
+  it('should support manager clone and override pluginAPI', done => {
+    const myAPI = { hello: () => 1 };
+    const manager = createAsyncManager({}, myAPI);
+    const plugin = {
+      setup(api: typeof myAPI) {
+        expect(api.hello()).toEqual(2);
+        done();
+      },
+    };
+    const clonedManager = manager.clone({
+      hello: () => 2,
+    });
+
+    clonedManager.usePlugin(() => plugin).init();
+  });
+
   it('isPlugin if exclusive plugins of manager', () => {
     const manager0 = createManager();
     const manager1 = createAsyncManager();

--- a/packages/toolkit/plugin/tests/sync.test.ts
+++ b/packages/toolkit/plugin/tests/sync.test.ts
@@ -392,6 +392,22 @@ describe('sync manager', () => {
     expect(count).toBe(1);
   });
 
+  it('should support manager clone and override pluginAPI', done => {
+    const myAPI = { hello: () => 1 };
+    const manager = createManager({}, myAPI);
+    const plugin = {
+      setup(api: typeof myAPI) {
+        expect(api.hello()).toEqual(2);
+        done();
+      },
+    };
+    const clonedManager = manager.clone({
+      hello: () => 2,
+    });
+
+    clonedManager.usePlugin(() => plugin).init();
+  });
+
   it('isPlugin: exclusive plugins of manager', () => {
     const manager0 = createAsyncManager();
     const manager1 = createManager();


### PR DESCRIPTION
# PR Details

Support using manager.clone to override plugin api, which makes it easier to write test cases.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
