### PR TITLE
feat(core): support api.setAppContext

### DIFF
--- a/.changeset/dirty-cherries-train.md
+++ b/.changeset/dirty-cherries-train.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/core': patch
+---
+
+feat: support api.setAppContext

--- a/packages/cli/core/src/context.ts
+++ b/packages/cli/core/src/context.ts
@@ -16,6 +16,8 @@ export const ResolvedConfigContext = createContext<NormalizedConfig>(
   {} as NormalizedConfig,
 );
 
+export const setAppContext = (value: IAppContext) => AppContext.set(value);
+
 export const useAppContext = () => AppContext.use().value;
 
 export const useConfigContext = () => ConfigContext.use().value;

--- a/packages/cli/core/src/pluginAPI.ts
+++ b/packages/cli/core/src/pluginAPI.ts
@@ -1,13 +1,15 @@
 import {
   AppContext,
   ConfigContext,
-  ResolvedConfigContext,
+  setAppContext,
   useAppContext,
   useConfigContext,
+  ResolvedConfigContext,
   useResolvedConfigContext,
 } from './context';
 
 export const pluginAPI = {
+  setAppContext,
   useAppContext,
   useConfigContext,
   useResolvedConfigContext,

--- a/packages/cli/core/tests/pluginAPI.test.ts
+++ b/packages/cli/core/tests/pluginAPI.test.ts
@@ -1,0 +1,19 @@
+import { CliPlugin, manager } from '../src';
+
+describe('pluginAPI', () => {
+  it('api.setAppContext', done => {
+    const plugin = (): CliPlugin => ({
+      setup(api) {
+        api.setAppContext({
+          ...api.useAppContext(),
+          packageName: 'foo',
+        });
+
+        expect(api.useAppContext().packageName).toEqual('foo');
+        done();
+      },
+    });
+
+    manager.clone().usePlugin(plugin).init();
+  });
+});


### PR DESCRIPTION
# PR Details

## Description

- support `api.setAppContext`

## Motivation and Context

plugin-analyze using `AppContext.set` api, adding `api.setAppContext` to replace it.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
