### PR TITLE
fix: lint scope

### DIFF
--- a/packages/cli/core/.eslintrc.js
+++ b/packages/cli/core/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  root: true,
+  extends: ['@modern-js'],
+  parserOptions: {
+    // the base path used to search for `tsconfig.json`
+    tsconfigRootDir: __dirname,
+    // the relative path to sub-package's `tsconfig.json`
+    project: ['./tsconfig.json'],
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["packages", "tests"]
+  "include": ["packages", "tests"],
+  "exclude": ["**/node_modules/", "**/dist/"]
 }


### PR DESCRIPTION
# PR Details

Narrow the lint scope in monorepo root  `tsconfig.json`. 
It's better  that each sub-package has it's own eslint config. 
An example in `@modern-js/core`:
```
// .eslintrc.js
module.exports = {
  root: true,
  extends: ['@modern-js'],
  parserOptions: {
    // the base path used to search for `tsconfig.json`
    tsconfigRootDir: __dirname,
    // the relative path to sub-package's `tsconfig.json` 
    project: ['./tsconfig.json'],
  },
};
```


## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
