### PR TITLE
fix: disable load webpack when apiOnly mode

### DIFF
--- a/.changeset/giant-phones-tell.md
+++ b/.changeset/giant-phones-tell.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server': patch
+'@modern-js/app-tools': patch
+---
+
+fix: disable load webpack when apiOnly mode

--- a/packages/cli/plugin-bff/package.json
+++ b/packages/cli/plugin-bff/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.3.6",
+  "version": "1.3.7",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -33,6 +33,10 @@
     "./server": {
       "jsnext:source": "./src/server.ts",
       "default": "./dist/js/node/server.js"
+    },
+    "./loader": {
+      "jsnext:source": "./src/loader.ts",
+      "default": "./dist/js/node/loader.js"
     }
   },
   "typesVersions": {

--- a/packages/server/server/src/dev-tools/babel/register.ts
+++ b/packages/server/server/src/dev-tools/babel/register.ts
@@ -33,6 +33,7 @@ export const enableRegister = (
     ],
     extensions: ['.js', '.ts'],
     babelrc: false,
+    configFile: false,
     root: projectRoot,
   });
 };

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -1,8 +1,4 @@
-import {
-  Configuration,
-  getWebpackConfig,
-  WebpackConfigTarget,
-} from '@modern-js/webpack';
+import type { Configuration } from '@modern-js/webpack';
 import {
   fs,
   logger,
@@ -51,6 +47,9 @@ export const dev = async (options: DevOptions) => {
 
   let compiler = null;
   if (existSrc) {
+    const { getWebpackConfig, WebpackConfigTarget } = await import(
+      '@modern-js/webpack'
+    );
     const webpackConfigs = [
       isSSR(userConfig) && getWebpackConfig(WebpackConfigTarget.NODE),
       getWebpackConfig(WebpackConfigTarget.CLIENT),
@@ -69,7 +68,7 @@ export const dev = async (options: DevOptions) => {
     dev: {
       ...{
         client: {
-          port: port!.toString(),
+          port: port.toString(),
           overlay: false,
           logging: 'none',
           path: HMR_SOCK_PATH,


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

disable load webpack when apiOnly mode

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
