### PR TITLE
fix: PluginAPI type should include common api

### DIFF
--- a/packages/cli/core/src/index.ts
+++ b/packages/cli/core/src/index.ts
@@ -25,11 +25,29 @@ import { manager, HooksRunner } from './manager';
 
 export type { Hooks };
 export * from './config';
-export * from './manager';
 export * from '@modern-js/plugin';
 export * from '@modern-js/plugin/node';
 
-export * from './pluginAPI';
+// TODO: remove export after refactor all plugins
+export {
+  manager,
+  mountHook,
+  usePlugins,
+  createPlugin,
+  registerHook,
+} from './manager';
+export type { CliHooks, CliPlugin, CliHookCallbacks } from './manager';
+
+// TODO: remove export after refactor all plugins
+export {
+  AppContext,
+  ConfigContext,
+  ResolvedConfigContext,
+  useAppContext,
+  useConfigContext,
+  useResolvedConfigContext,
+} from './pluginAPI';
+export type { PluginAPI } from './pluginAPI';
 
 program
   .name('modern')

--- a/packages/cli/core/src/manager.ts
+++ b/packages/cli/core/src/manager.ts
@@ -15,7 +15,7 @@ import { compatRequire } from '@modern-js/utils';
 import type { Hooks } from '@modern-js/types';
 import type { Command } from './utils/commander';
 import type { NormalizedConfig } from './config/mergeConfig';
-import { pluginAPI, PluginAPI } from './pluginAPI';
+import { pluginAPI } from './pluginAPI';
 
 export type HooksRunner = ToRunners<{
   config: ParallelWorkflow<void>;
@@ -73,17 +73,16 @@ export type CliHooks = typeof baseHooks & Hooks;
 /** all hook callbacks of cli plugin */
 export type CliHookCallbacks = ToThreads<CliHooks>;
 
-export const manager = createAsyncManager<CliHooks, PluginAPI>(
+export const manager = createAsyncManager<CliHooks, typeof pluginAPI>(
   baseHooks,
   pluginAPI,
 );
 
 export type CliPlugin = PluginOptions<
   CliHooks,
-  AsyncSetup<CliHooks, PluginAPI>
+  AsyncSetup<CliHooks, typeof pluginAPI>
 >;
 
-// TODO: remove export after refactor all plugins
 export const { createPlugin, registerHook, useRunner: mountHook } = manager;
 
 export const usePlugins = (plugins: string[]) =>

--- a/packages/cli/core/src/pluginAPI.ts
+++ b/packages/cli/core/src/pluginAPI.ts
@@ -1,3 +1,5 @@
+import type { CommonAPI } from '@modern-js/plugin';
+import type { CliHooks } from './manager';
 import {
   AppContext,
   ConfigContext,
@@ -15,7 +17,8 @@ export const pluginAPI = {
   useResolvedConfigContext,
 };
 
-export type PluginAPI = typeof pluginAPI;
+/** all apis for cli plugin */
+export type PluginAPI = typeof pluginAPI & CommonAPI<CliHooks>;
 
 // TODO: only export types after refactor all plugins
 export {

--- a/packages/server/core/src/plugin.ts
+++ b/packages/server/core/src/plugin.ts
@@ -1,6 +1,7 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import type { Component } from 'react';
 import {
+  CommonAPI,
   ToThreads,
   AsyncSetup,
   PluginOptions,
@@ -158,8 +159,6 @@ const pluginAPI = {
   useConfigContext,
 };
 
-type PluginAPI = typeof pluginAPI;
-
 const serverHooks = {
   // server hook
   gather,
@@ -196,6 +195,9 @@ export type ServerHooks = typeof serverHooks;
 
 /** all hook callbacks of server plugin */
 export type ServerHookCallbacks = ToThreads<ServerHooks>;
+
+/** all apis for server plugin */
+export type PluginAPI = typeof pluginAPI & CommonAPI<ServerHooks>;
 
 export const createServerManager = () =>
   createAsyncManager(serverHooks, pluginAPI);


### PR DESCRIPTION
# PR Details

- the `PluginAPI` type should include common api
- make exports of core more explicitly

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
