### PR TITLE
fix: set default value for required keys of NormalizedConfig

### DIFF
--- a/.changeset/afraid-bobcats-roll.md
+++ b/.changeset/afraid-bobcats-roll.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/core': patch
+---
+
+fix: set default value for type NormalizedConfig to ensure all config keys are required

--- a/packages/cli/core/src/config/defaults.ts
+++ b/packages/cli/core/src/config/defaults.ts
@@ -98,4 +98,7 @@ export const defaults = {
   dev: devDefaults,
   deploy: deployDefaults,
   tools: toolsDefaults,
+  plugins: [],
+  runtime: {},
+  runtimeByEntries: {},
 };

--- a/packages/cli/core/src/config/index.ts
+++ b/packages/cli/core/src/config/index.ts
@@ -299,7 +299,7 @@ export const resolveConfig = async (
       throw new Error(`Validate configuration error.`);
     }
   }
-  const resolved = mergeConfig([defaults as any, ...configs, userConfig]);
+  const resolved = mergeConfig([defaults, ...configs, userConfig]);
 
   resolved._raw = loaded.config;
 


### PR DESCRIPTION
# PR Details

Set default value for required keys of `NormalizedConfig` . Otherwise, the `plugins`, `runtime`, `runtimeByEntries` config could be undefined.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
