### PR TITLE
feat(core): support new cli plugin config

### DIFF
--- a/.changeset/stupid-boats-shake.md
+++ b/.changeset/stupid-boats-shake.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/core': minor
+---
+
+feat: support new plugin config

--- a/packages/cli/core/src/context.ts
+++ b/packages/cli/core/src/context.ts
@@ -39,7 +39,7 @@ export const useResolvedConfigContext = () => ResolvedConfigContext.use().value;
 
 export const initAppContext = (
   appDirectory: string,
-  plugins: Array<LoadedPlugin>,
+  plugins: LoadedPlugin[],
   configFile: string | false,
   options?: {
     metaName?: string;

--- a/packages/cli/core/src/loadPlugins.ts
+++ b/packages/cli/core/src/loadPlugins.ts
@@ -5,27 +5,37 @@ import {
   INTERNAL_PLUGINS,
 } from '@modern-js/utils';
 import type { UserConfig } from './config';
-import { createPlugin } from './manager';
+import { CliPlugin, createPlugin } from './manager';
 
 const debug = createDebugger('load-plugins');
 
-type Plugin = string | [string, any];
+type PluginItem = string | [string, any];
 
 export type LoadedPlugin = {
-  cli?: any;
-  cliPkg?: string;
-  server?: any;
+  cli?: CliPlugin;
+  server?: string;
   serverPkg?: string;
 };
 
-export type PluginConfigItem =
+/**
+ * @deprecated
+ * Using NewPluginConfig insteand.
+ */
+type OldPluginConfig = Array<
+  | PluginItem
   | {
-      cli?: Plugin;
-      server?: Plugin;
+      cli?: PluginItem;
+      server?: PluginItem;
     }
-  | Plugin;
+>;
 
-export type PluginConfig = Array<PluginConfigItem>;
+type NewPluginConfig = {
+  cli?: CliPlugin[];
+  /** Custom server plugin is not supported yet. */
+  server?: never;
+};
+
+export type PluginConfig = OldPluginConfig | NewPluginConfig;
 
 /**
  * Try to resolve plugin entry file path.
@@ -49,7 +59,7 @@ const tryResolve = (name: string, appDirectory: string) => {
 
 export function getAppPlugins(
   appDirectory: string,
-  pluginConfig: PluginConfig,
+  oldPluginConfig: OldPluginConfig,
   internalPlugins?: typeof INTERNAL_PLUGINS,
 ) {
   const allPlugins = internalPlugins || INTERNAL_PLUGINS;
@@ -64,10 +74,23 @@ export function getAppPlugins(
         return isDepExists(appDirectory, name);
       })
       .map(name => allPlugins[name]),
-    ...pluginConfig,
+    ...oldPluginConfig,
   ];
   return appPlugins;
 }
+
+const resolveCliPlugin = (p: PluginItem, appDirectory: string): CliPlugin => {
+  const pkg = typeof p === 'string' ? p : p[0];
+  const path = tryResolve(pkg, appDirectory);
+  const module = compatRequire(path);
+
+  if (typeof module === 'function') {
+    const pluginOptions = Array.isArray(p) ? p[1] : undefined;
+    const result: CliPlugin = module(pluginOptions);
+    return createPlugin(result.setup, result);
+  }
+  return module;
+};
 
 /**
  * Load internal plugins which in @modern-js scope and user's custom plugins.
@@ -83,45 +106,24 @@ export const loadPlugins = (
     internalPlugins?: typeof INTERNAL_PLUGINS;
   } = {},
 ) => {
-  const { internalPlugins } = options;
-
-  const resolvePlugin = (p: Plugin) => {
-    const pkg = typeof p === 'string' ? p : p[0];
-    const path = tryResolve(pkg, appDirectory);
-    let module = compatRequire(path);
-    const pluginOptions = Array.isArray(p) ? p[1] : undefined;
-
-    if (typeof module === 'function') {
-      const plugin = module(pluginOptions);
-      module = createPlugin(plugin.setup, plugin);
-    }
-
-    return {
-      pkg,
-      path,
-      module,
-    };
-  };
-
+  const pluginConfig = userConfig.plugins;
   const plugins = getAppPlugins(
     appDirectory,
-    userConfig.plugins || [],
-    internalPlugins,
+    Array.isArray(pluginConfig) ? pluginConfig : [],
+    options.internalPlugins,
   );
 
-  return plugins.map(plugin => {
+  const loadedPlugins = plugins.map(plugin => {
     const _plugin =
       typeof plugin === 'string' || Array.isArray(plugin)
         ? { cli: plugin }
         : plugin;
 
     const { cli, server } = _plugin;
-    const loadedPlugin: LoadedPlugin = {} as LoadedPlugin;
-    if (cli) {
-      const { pkg, path, module } = resolvePlugin(cli);
+    const loadedPlugin: LoadedPlugin = {};
 
-      loadedPlugin.cli = { ...module, pluginPath: path };
-      loadedPlugin.cliPkg = pkg;
+    if (cli) {
+      loadedPlugin.cli = resolveCliPlugin(cli, appDirectory);
     }
 
     // server plugins don't support to accept params
@@ -137,4 +139,14 @@ export const loadPlugins = (
 
     return loadedPlugin;
   });
+
+  if (!Array.isArray(pluginConfig) && pluginConfig?.cli?.length) {
+    loadedPlugins.push(
+      ...pluginConfig.cli.map(item => ({
+        cli: createPlugin(item.setup, item),
+      })),
+    );
+  }
+
+  return loadedPlugins;
 };

--- a/packages/cli/core/tests/loadPlugin.test.ts
+++ b/packages/cli/core/tests/loadPlugin.test.ts
@@ -86,7 +86,21 @@ describe('load plugins', () => {
     }).toThrowError(/^Can not find plugin /);
   });
 
-  test(`should load new plugin correctly`, () => {
+  test(`should load new plugin array correctly`, () => {
+    const appDirectory = path.resolve(
+      __dirname,
+      './fixtures/load-plugin/user-plugins',
+    );
+    const plugin = (): CliPlugin => ({
+      name: 'foo',
+    });
+    const userConfig = { plugins: [plugin()] };
+    const loadedPlugins = loadPlugins(appDirectory, userConfig);
+
+    expect(loadedPlugins[0].cli?.name).toEqual('foo');
+  });
+
+  test(`should load new plugin object correctly`, () => {
     const appDirectory = path.resolve(
       __dirname,
       './fixtures/load-plugin/user-plugins',

--- a/packages/cli/core/tests/loadPlugin.test.ts
+++ b/packages/cli/core/tests/loadPlugin.test.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { CliPlugin } from '../src';
 import { loadPlugins, getAppPlugins } from '../src/loadPlugins';
 
 describe('load plugins', () => {
@@ -33,9 +34,7 @@ describe('load plugins', () => {
       {
         cli: {
           name: 'a',
-          pluginPath: path.join(fixture, './test-plugin-a.js'),
         },
-        cliPkg: path.join(fixture, './test-plugin-a.js'),
       },
       {
         server: './test-plugin-b',
@@ -54,8 +53,8 @@ describe('load plugins', () => {
       plugins: [{ cli: ['./test-plugin-c', 'c'] }, ['./test-plugin-c', 'c2']],
     });
 
-    expect(plugins[0].cli.name).toEqual('c');
-    expect(plugins[1].cli.name).toEqual('c2');
+    expect(plugins[0].cli!.name).toEqual('c');
+    expect(plugins[1].cli!.name).toEqual('c2');
   });
 
   test('should load user string plugin successfully', () => {
@@ -72,9 +71,7 @@ describe('load plugins', () => {
       {
         cli: {
           name: 'a',
-          pluginPath: path.join(fixture, './test-plugin-a.js'),
         },
-        cliPkg: path.join(fixture, './test-plugin-a.js'),
       },
     ]);
   });
@@ -87,5 +84,19 @@ describe('load plugins', () => {
         plugins: [{ cli: './test-plugin-a' }, { cli: './plugin-b' }],
       });
     }).toThrowError(/^Can not find plugin /);
+  });
+
+  test(`should load new plugin correctly`, () => {
+    const appDirectory = path.resolve(
+      __dirname,
+      './fixtures/load-plugin/user-plugins',
+    );
+    const plugin = (): CliPlugin => ({
+      name: 'foo',
+    });
+    const userConfig = { plugins: { cli: [plugin()] } };
+    const loadedPlugins = loadPlugins(appDirectory, userConfig);
+
+    expect(loadedPlugins[0].cli?.name).toEqual('foo');
   });
 });

--- a/packages/cli/plugin-unbundle/tests/fixtures/scan-imports-monorepo/packages/module-importer/package.json
+++ b/packages/cli/plugin-unbundle/tests/fixtures/scan-imports-monorepo/packages/module-importer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "module-a",
+  "name": "unbundle-module-importer",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/server/prod-server/tests/fixtures/pure/package.json
+++ b/packages/server/prod-server/tests/fixtures/pure/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "deploy",
+  "name": "prod-server-pure",
   "version": "0.1.0",
   "scripts": {
     "reset": "del-cli node_modules",

--- a/packages/toolkit/types/cli/index.d.ts
+++ b/packages/toolkit/types/cli/index.d.ts
@@ -57,7 +57,6 @@ export interface IAppContext {
   internalDirectory: string;
   plugins: {
     cli?: any;
-    cliPkg?: any;
     server?: any;
     serverPkg?: any;
   }[];


### PR DESCRIPTION
# PR Details

Support new plugin config: 

```ts
import MyPlugin from './plugins/my-plugin';
import { defineConfig } from '@modern-js/core';

export default defineConfig({
  plugins: [
    MyPlugin({ ... }),
  ]
});

// or
export default defineConfig({
  plugins: {
    cli: [
      MyPlugin({ ... }),
    ]
  }
});
```

- The old `plugin` config can still work as before.
- The `cliPkg` and `pluginPath` field of `LoadedPlugin` is removed, we can not get the `cliPkg` and `pluginPath` from the new plugin config, and no internal code is currently using this field.
- close https://github.com/modern-js-dev/modern.js/issues/686

## Motivation and Context

Provide better typescript support. 

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
