### PR TITLE
feat: add compatible logic of plugin options with "setup" param

### DIFF
--- a/.changeset/seven-kangaroos-tap.md
+++ b/.changeset/seven-kangaroos-tap.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin': patch
+---
+
+feat: add compatible logic of plugin options with "setup" param

--- a/packages/toolkit/plugin/src/manager/async.ts
+++ b/packages/toolkit/plugin/src/manager/async.ts
@@ -151,7 +151,7 @@ export const createAsyncManager = <
           const options = plugin();
           addPlugin(createPlugin(options.setup, options));
         }
-        // plain plugin options
+        // plain plugin options with `setup` param
         else if (plugin.setup) {
           addPlugin(createPlugin(plugin.setup, plugin));
         }

--- a/packages/toolkit/plugin/src/manager/sync.ts
+++ b/packages/toolkit/plugin/src/manager/sync.ts
@@ -173,7 +173,7 @@ export const createManager = <
           const options = plugin();
           addPlugin(createPlugin(options.setup, options));
         }
-        // plain plugin options
+        // plain plugin options with `setup` param
         else if (plugin.setup) {
           addPlugin(createPlugin(plugin.setup, plugin));
         }


### PR DESCRIPTION
# PR Details

feat: add compatible logic of plugin options with "setup" param

## Description

As #794 has provided `@modern-js/plugin` the ability to accept new plugin syntax with setup param, like the examples above:
```ts
// plugin example in modern.js
import type { CliPlugin } from '@modern-js/core';
export default (): CliPlugin => ({
  name: 'foo',
  setup: api => {},
  pre: ['@modern-js/plugin-unbundle']
});
```
Changed part snippet:
``` ts
// packages/toolkit/plugin/src/manager/async.ts
const usePlugin: AsyncManager<Hooks, API>['usePlugin'] = (...input) => {
    for (const plugin of input) {
       //... skip old logics
       // plain plugin options with `setup` param
       else if (plugin.setup) {
         addPlugin(createPlugin(plugin.setup, plugin));
       }
       // skip other logics
    }
    return manager;
};
```

But somehow the #794 PR forgot to bring this to changelog, and without changelog, we can't bump version for `@modern-js/plugin`.

This PR is gonna fix it.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
