### PR TITLE
feat: support devServer middleware hook

### DIFF
--- a/.changeset/brave-icons-yell.md
+++ b/.changeset/brave-icons-yell.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/core': patch
+'@modern-js/server-core': patch
+'@modern-js/server': patch
+---
+
+support setup dev middleware first step

--- a/packages/cli/core/src/config/index.ts
+++ b/packages/cli/core/src/config/index.ts
@@ -134,6 +134,13 @@ interface DeployConfig {
 type ConfigFunction =
   | Record<string, unknown>
   | ((config: Record<string, unknown>) => Record<string, unknown> | void);
+
+type DevServerConfig = {
+  headers: Record<string, string>;
+  onBeforeSetupMiddleware: any;
+  onAfterSetupMiddleware: any;
+  [propsName: string]: any;
+};
 interface ToolsConfig {
   webpack?: ConfigFunction;
   babel?: ConfigFunction;
@@ -141,7 +148,7 @@ interface ToolsConfig {
   postcss?: ConfigFunction;
   styledComponents?: ConfigFunction;
   lodash?: ConfigFunction;
-  devServer?: Record<string, unknown>;
+  devServer?: DevServerConfig;
   tsLoader?: ConfigFunction;
   terser?: ConfigFunction;
   minifyCss?: ConfigFunction;

--- a/packages/server/core/src/plugin.ts
+++ b/packages/server/core/src/plugin.ts
@@ -63,12 +63,12 @@ export type APIServerStartInput = {
 };
 const prepareApiServer = createAsyncPipeline<APIServerStartInput, Adapter>();
 
-const preDevServerInit = createParallelWorkflow<NormalizedConfig, any>();
+const beforeDevServer = createParallelWorkflow<NormalizedConfig, any>();
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 const setupCompiler = createParallelWorkflow<{}, any[]>();
 
-const postDevServerInit = createParallelWorkflow<NormalizedConfig, any>();
+const afterDevServer = createParallelWorkflow<NormalizedConfig, any>();
 
 // TODO FIXME
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -171,9 +171,9 @@ const serverHooks = {
   create,
   prepareWebServer,
   prepareApiServer,
-  preDevServerInit,
+  beforeDevServer,
   setupCompiler,
-  postDevServerInit,
+  afterDevServer,
   beforeRouteSet,
   afterRouteSet,
   preServerInit,

--- a/website/docs/apis/config/tools/dev-server.md
+++ b/website/docs/apis/config/tools/dev-server.md
@@ -25,7 +25,53 @@ export default defineConfig({
   }
 });
 ```
+
 :::tip 提示
-为了方便接入，Modern.js 大部分配置与 Webpack DevServer 保持一致。
+为了方便接入，Modern.js 大部分配置与 Webpack DevServer 保持一致，部分配置仍有差异。
 :::
 
+## 配置差异
+
+### onBeforeSetupMiddleware
+
+:::info 实验性的
+这是一个实验性功能。
+:::
+
+* 类型： `Array`
+* 默认值： `null`
+
+在所有开发环境中间件前执行：
+
+```javascript
+devServer: {
+  onBeforeSetupMiddleware: [
+    async (ctx, next) => {
+      console.log('before dev middleware');
+      next();
+    },
+  ],
+},
+```
+
+### onAfterSetupMiddleware
+
+:::info 实验性的
+这是一个实验性功能。
+:::
+
+* 类型： `Array`
+* 默认值： `null`
+
+在所有开发环境中间件后执行：
+
+```javascript
+devServer: {
+  onAfterSetupMiddleware: [
+    async (ctx, next) => {
+      console.log('after dev middleware');
+      next();
+    },
+  ],
+},
+```


### PR DESCRIPTION
# PR Details

support beforeDevServer、afterDevServer server hook.

onBeforeSetupMiddleware, onAfterSetupMiddleware can be used as syntactic sugar.

## Description

can config in jupiter.config.js like this:

```
{
  tools: {
    devServer: {
      onBeforeSetupMiddleware: [
        async (ctx, next) => {
          console.log('before');
          next();
        },
      ],
      onAfterSetupMiddleware: [
        async (ctx, next) => {
          console.log('after');
          next();
        },
      ],
    },
  },
}
```

next step is to implement more configurations, such as specifying the middleware writing of the route

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
