### PR TITLE
feat: remove unnecessary peerDependencies

### DIFF
--- a/.changeset/spicy-rings-talk.md
+++ b/.changeset/spicy-rings-talk.md
@@ -1,0 +1,23 @@
+---
+'@modern-js/plugin-analyze': patch
+'@modern-js/plugin-cdn-cos': patch
+'@modern-js/plugin-cdn-oss': patch
+'@modern-js/plugin-changeset': patch
+'@modern-js/plugin-docsite': patch
+'@modern-js/plugin-esbuild': patch
+'@modern-js/plugin-fast-refresh': patch
+'@modern-js/plugin-jarvis': patch
+'@modern-js/plugin-less': patch
+'@modern-js/plugin-nocode': patch
+'@modern-js/plugin-proxy': patch
+'@modern-js/plugin-router': patch
+'@modern-js/runtime': patch
+'@modern-js/plugin-sass': patch
+'@modern-js/plugin-server-build': patch
+'@modern-js/plugin-ssr': patch
+'@modern-js/plugin-state': patch
+'@modern-js/plugin-storybook': patch
+'@modern-js/plugin-unbundle': patch
+---
+
+feat: remove unnecessary peerDependencies

--- a/packages/cli/plugin-analyze/package.json
+++ b/packages/cli/plugin-analyze/package.json
@@ -65,9 +65,6 @@
     "jest": "^27",
     "typescript": "^4"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.4.3"
-  },
   "sideEffects": false,
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/cli/plugin-cdn-cos/package.json
+++ b/packages/cli/plugin-cdn-cos/package.json
@@ -45,9 +45,6 @@
     "cos-nodejs-sdk-v5": "^2.10.10",
     "mime-types": "^2.1.34"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.4.4"
-  },
   "devDependencies": {
     "@babel/runtime": "^7",
     "@scripts/build": "workspace:*",

--- a/packages/cli/plugin-cdn-oss/package.json
+++ b/packages/cli/plugin-cdn-oss/package.json
@@ -45,9 +45,6 @@
     "js-yaml": "^4.1.0",
     "walk": "^2.3.15"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.4.4"
-  },
   "devDependencies": {
     "@babel/runtime": "^7",
     "@scripts/build": "workspace:*",

--- a/packages/cli/plugin-changeset/package.json
+++ b/packages/cli/plugin-changeset/package.json
@@ -57,9 +57,6 @@
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.4.3"
-  },
   "sideEffects": false,
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/cli/plugin-docsite/package.json
+++ b/packages/cli/plugin-docsite/package.json
@@ -85,9 +85,6 @@
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.4.4"
-  },
   "sideEffects": false,
   "modernConfig": {
     "output": {

--- a/packages/cli/plugin-esbuild/package.json
+++ b/packages/cli/plugin-esbuild/package.json
@@ -40,7 +40,6 @@
     "test": "jest --passWithNoTests"
   },
   "peerDependencies": {
-    "@modern-js/core": "workspace:^1.3.2",
     "webpack": "^5.54.0"
   },
   "dependencies": {

--- a/packages/cli/plugin-fast-refresh/package.json
+++ b/packages/cli/plugin-fast-refresh/package.json
@@ -67,9 +67,6 @@
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.3.2"
-  },
   "sideEffects": false,
   "modernConfig": {
     "output": {

--- a/packages/cli/plugin-jarvis/package.json
+++ b/packages/cli/plugin-jarvis/package.json
@@ -80,9 +80,6 @@
     "jest": "^27",
     "typescript": "^4"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.5.0"
-  },
   "modernConfig": {},
   "sideEffects": false,
   "publishConfig": {

--- a/packages/cli/plugin-less/package.json
+++ b/packages/cli/plugin-less/package.json
@@ -81,9 +81,6 @@
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.5.0"
-  },
   "sideEffects": false,
   "modernConfig": {
     "output": {

--- a/packages/cli/plugin-nocode/package.json
+++ b/packages/cli/plugin-nocode/package.json
@@ -63,9 +63,6 @@
     "webpack": "^5.65.0",
     "webpack-sources": "^3.2.2"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.4.4"
-  },
   "devDependencies": {
     "@scripts/build": "workspace:*",
     "@modern-js/core": "workspace:^1.4.4",

--- a/packages/cli/plugin-proxy/package.json
+++ b/packages/cli/plugin-proxy/package.json
@@ -71,9 +71,6 @@
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.5.0"
-  },
   "sideEffects": false,
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/cli/plugin-router/package.json
+++ b/packages/cli/plugin-router/package.json
@@ -61,9 +61,7 @@
   },
   "peerDependencies": {
     "react": ">=16.8",
-    "react-dom": ">=16.8",
-    "@modern-js/core": "workspace:^1.4.6",
-    "@modern-js/runtime-core": "workspace:^1.2.2"
+    "react-dom": ">=16.8"
   },
   "dependencies": {
     "@babel/runtime": "^7",

--- a/packages/cli/plugin-router/src/runtime/plugin.tsx
+++ b/packages/cli/plugin-router/src/runtime/plugin.tsx
@@ -62,7 +62,7 @@ export type RouterConfig = Partial<HistoryConfig> & {
 // todo: check
 const isBrowser = () => typeof window !== 'undefined';
 
-export const routerPlugin: any = ({
+export const routerPlugin = ({
   serverBase = [],
   history: customHistory,
   supportHtml5History = true,
@@ -74,7 +74,7 @@ export const routerPlugin: any = ({
   const select = (pathname: string) =>
     serverBase.find(baseUrl => pathname.search(baseUrl) === 0) || '/';
   return {
-    name: 'foo',
+    name: '@modern-js/plugin-router',
     setup: () => {
       return {
         hoc: ({ App }, next) => {

--- a/packages/cli/plugin-runtime/package.json
+++ b/packages/cli/plugin-runtime/package.json
@@ -135,9 +135,6 @@
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.4.2"
-  },
   "sideEffects": false,
   "modernConfig": {},
   "publishConfig": {

--- a/packages/cli/plugin-sass/package.json
+++ b/packages/cli/plugin-sass/package.json
@@ -68,9 +68,6 @@
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.4.3"
-  },
   "sideEffects": false,
   "modernConfig": {
     "output": {

--- a/packages/cli/plugin-server-build/package.json
+++ b/packages/cli/plugin-server-build/package.json
@@ -53,9 +53,6 @@
     "jest": "^27",
     "@scripts/jest-config": "workspace:*"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.4.4"
-  },
   "sideEffects": false,
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/cli/plugin-ssr/package.json
+++ b/packages/cli/plugin-ssr/package.json
@@ -93,8 +93,6 @@
     "@scripts/jest-config": "workspace:*"
   },
   "peerDependencies": {
-    "@modern-js/core": "workspace:^1.4.3",
-    "@modern-js/runtime-core": "workspace:^1.2.3",
     "@loadable/component": "^5.15.0",
     "@types/loadable__component": "^5.13.4"
   },

--- a/packages/cli/plugin-state/package.json
+++ b/packages/cli/plugin-state/package.json
@@ -92,8 +92,6 @@
   },
   "sideEffects": false,
   "peerDependencies": {
-    "@modern-js/core": "workspace:^1.3.2",
-    "@modern-js/runtime-core": "workspace:^1.2.1",
     "react": "^17.0.2"
   },
   "modernConfig": {},

--- a/packages/cli/plugin-storybook/package.json
+++ b/packages/cli/plugin-storybook/package.json
@@ -88,9 +88,7 @@
     "webpack-chain": "^6.5.1"
   },
   "peerDependencies": {
-    "@modern-js/core": "workspace:^1.4.4",
     "@modern-js/runtime": "workspace:^1.2.3",
-    "@modern-js/runtime-core": "workspace:^1.2.4",
     "react": "^17"
   },
   "sideEffects": false,

--- a/packages/cli/plugin-unbundle/package.json
+++ b/packages/cli/plugin-unbundle/package.json
@@ -146,7 +146,6 @@
   },
   "peerDependencies": {
     "@modern-js/bff-utils": "workspace:^1.2.1",
-    "@modern-js/core": "workspace:^1.4.6",
     "typescript": "^4"
   },
   "publishConfig": {


### PR DESCRIPTION
# PR Details

feat: remove unnecessary peerDependencies

## Description

In the former plugin design, we need to use peerDependencies including `@modern-js/core` or `@modern-js/runtime-core` to ensure there is only one instance for core. 
But later we migrated to the new plugin design, these peerDependencies are no longer needed. So this PR is gonna remove them.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
