### PR TITLE
fix(plugin): should allow to use plugin without setup function

### DIFF
--- a/.changeset/late-boats-mix.md
+++ b/.changeset/late-boats-mix.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin': patch
+---
+
+fix: should allow to use plugin without setup function

--- a/packages/toolkit/plugin/src/manager/async.ts
+++ b/packages/toolkit/plugin/src/manager/async.ts
@@ -151,13 +151,13 @@ export const createAsyncManager = <
           const options = plugin();
           addPlugin(createPlugin(options.setup, options));
         }
-        // plain plugin options with `setup` param
-        else if (plugin.setup) {
+        // plain plugin object
+        else if (isObject(plugin)) {
           addPlugin(createPlugin(plugin.setup, plugin));
         }
         // unknown plugin
         else {
-          console.warn(`Unknown plugin: ${plugin.name || ''}`);
+          console.warn(`Unknown plugin: ${JSON.stringify(plugin)}`);
         }
       }
 

--- a/packages/toolkit/plugin/src/manager/sync.ts
+++ b/packages/toolkit/plugin/src/manager/sync.ts
@@ -173,13 +173,13 @@ export const createManager = <
           const options = plugin();
           addPlugin(createPlugin(options.setup, options));
         }
-        // plain plugin options with `setup` param
-        else if (plugin.setup) {
+        // plain plugin object
+        else if (isObject(plugin)) {
           addPlugin(createPlugin(plugin.setup, plugin));
         }
         // unknown plugin
         else {
-          console.warn(`Unknown plugin: ${plugin.name || ''}`);
+          console.warn(`Unknown plugin: ${JSON.stringify(plugin)}`);
         }
       }
 

--- a/packages/toolkit/plugin/tests/async.test.ts
+++ b/packages/toolkit/plugin/tests/async.test.ts
@@ -694,6 +694,29 @@ describe('async manager', () => {
       expect(list).toStrictEqual([0, 1, 2]);
     });
 
+    it('should allow to use plugin without setup function', async () => {
+      const manager = createAsyncManager<TestAsyncHooks>();
+
+      const list: number[] = [];
+      const plugin0: TestAsyncPlugin = {
+        name: 'plugin0',
+        setup: () => {
+          list.push(0);
+        },
+      };
+
+      const plugin1 = {
+        name: 'plugin1',
+        usePlugins: [plugin0],
+      };
+
+      manager.usePlugin(plugin1);
+
+      await manager.init();
+
+      expect(list).toStrictEqual([0]);
+    });
+
     it('should allow to use function plugin', async () => {
       const manager = createAsyncManager<TestAsyncHooks>();
 

--- a/packages/toolkit/plugin/tests/sync.test.ts
+++ b/packages/toolkit/plugin/tests/sync.test.ts
@@ -659,6 +659,28 @@ describe('sync manager', () => {
       expect(list).toStrictEqual([0, 1, 2]);
     });
 
+    it('should allow to use plugin without setup function', async () => {
+      const manager = createManager<TestHooks>();
+
+      const list: number[] = [];
+      const plugin0: TestPlugin = {
+        name: 'plugin0',
+        setup: () => {
+          list.push(0);
+        },
+      };
+
+      const plugin1: TestPlugin = {
+        name: 'plugin1',
+        usePlugins: [plugin0],
+      };
+
+      manager.usePlugin(plugin1);
+      manager.init();
+
+      expect(list).toStrictEqual([0]);
+    });
+
     it('should allow to use function plugin', async () => {
       const manager = createManager<TestHooks>();
 


### PR DESCRIPTION
# PR Details

## Description

Allow to use plugin without setup function (some plugins in jupiter are just wrappers).

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
