### PR TITLE
chore: clean legacy files after build website

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           branch: gh-pages
           folder: website/dist
-          clean: false
+          clean: true


### PR DESCRIPTION
# PR Details

There are too many files in https://github.com/modern-js-dev/modern.js/tree/gh-pages/assets/js.

Enable `clean` option to delete legacy files after build website.

![image](https://user-images.githubusercontent.com/7237365/161055564-ea8a8d3c-e1d8-47c8-b662-1b93e2f502f7.png)

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
