### PR TITLE
feat(webpack): enable css extract in dev mode by default

### DIFF
--- a/.changeset/clever-seals-learn.md
+++ b/.changeset/clever-seals-learn.md
@@ -2,4 +2,4 @@
 '@modern-js/webpack': patch
 ---
 
-feat: enable css extract in dev mode by default
+feat: enable css extract in dev mode by default.

--- a/.changeset/clever-seals-learn.md
+++ b/.changeset/clever-seals-learn.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+feat: enable css extract in dev mode by default

--- a/packages/cli/webpack/src/utils/createCSSRule.ts
+++ b/packages/cli/webpack/src/utils/createCSSRule.ts
@@ -1,10 +1,9 @@
 import Chain from 'webpack-chain';
 import { getPostcssConfig } from '@modern-js/css-config';
 import type { NormalizedConfig } from '@modern-js/core';
-import { isProd } from '@modern-js/utils';
 
 export const enableCssExtract = (config: NormalizedConfig) => {
-  return isProd() && config.output.disableCssExtract !== true;
+  return config.output.disableCssExtract !== true;
 };
 
 interface CSSLoaderOptions {

--- a/website/docs/apis/config/output/disable-css-extract.md
+++ b/website/docs/apis/config/output/disable-css-extract.md
@@ -14,7 +14,7 @@ sidebar_position: 18
 
 Modern.js 默认会把 CSS 提取为独立文件，并输出到 `dist` 目录。
 
-设置该选项为 `true` 后，CSS 文件会经过 `style-loader` 处理并内联到 JS 文件中，在运行时动态插入 style 标签，从而加载项目的样式。
+设置该选项为 `true` 后，CSS 文件会经过 `style-loader` 处理，内联到 JS 文件中，并在运行时动态插入 style 标签，从而完成样式加载。
 
 具体配置如下:
 

--- a/website/docs/apis/config/output/disable-css-extract.md
+++ b/website/docs/apis/config/output/disable-css-extract.md
@@ -12,9 +12,9 @@ sidebar_position: 18
 * 类型： `boolean`
 * 默认值： `false`
 
-生产环境下，默认会把 css 提取为独立文件输出到 dist 目录。
+Modern.js 默认会把 CSS 提取为独立文件，并输出到 `dist` 目录。
 
-设置该选项为 true 后，生产环境不会提取 css 文件，会在运行时动态插入 style 标签加载项目的样式。
+设置该选项为 `true` 后，CSS 文件会经过 `style-loader` 处理并内联到 JS 文件中，在运行时动态插入 style 标签，从而加载项目的样式。
 
 具体配置如下:
 

--- a/website/docs/guides/features/framework-plugin/extend.md
+++ b/website/docs/guides/features/framework-plugin/extend.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # 扩展插件 Hook
 
-本章节介绍如何通过【[动态注册 Hook 模型](/docs/apis/runtime/plugin/manager#动态注册-hook-模型)】的方式来扩展插件 Hook。
+本章节介绍如何通过动态注册 [Hook 模型](/docs/apis/runtime/plugin/hook#hook-模型) 的方式来扩展插件 Hook。
 
 ## 示例
 


### PR DESCRIPTION
# PR Details

Enable css extract in dev mode by default, so we can keep the dist files same in dev and prod mode.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
