### PR TITLE
feat: optimise "types" exports from plugin

### DIFF
--- a/.changeset/perfect-bobcats-wonder.md
+++ b/.changeset/perfect-bobcats-wonder.md
@@ -1,0 +1,26 @@
+---
+'@modern-js/plugin-cdn-cos': patch
+'@modern-js/plugin-cdn-oss': patch
+'@modern-js/plugin-garfish': patch
+'@modern-js/plugin-lambda-fc': patch
+'@modern-js/plugin-lambda-scf': patch
+'@modern-js/plugin-multiprocess': patch
+'@modern-js/plugin-sass': patch
+'@modern-js/plugin-testing': patch
+'@modern-js/plugin-static-hosting': patch
+'@modern-js/generator-common': patch
+'@modern-js/cloud-deploy-generator': patch
+'@modern-js/dependence-generator': patch
+'@modern-js/module-generator': patch
+'@modern-js/plugin-server': patch
+'@modern-js/app-tools': patch
+'@modern-js/module-tools': patch
+'@modern-js/node-bundle-require': patch
+'api-service-koa': patch
+'bff-express': patch
+'tmp': patch
+'testing-app': patch
+'testing-bff': patch
+---
+
+fix: optimise "types" exports from plugin

--- a/packages/cli/plugin-cdn-cos/src/modern-app-env.d.ts
+++ b/packages/cli/plugin-cdn-cos/src/modern-app-env.d.ts
@@ -1,2 +1,2 @@
-/// <reference types='@modern-js/module-tools/type' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/module-tools/types' />
+/// <reference types='@modern-js/plugin-testing/types' />

--- a/packages/cli/plugin-cdn-oss/src/modern-app-env.d.ts
+++ b/packages/cli/plugin-cdn-oss/src/modern-app-env.d.ts
@@ -1,5 +1,5 @@
-/// <reference types='@modern-js/module-tools/type' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/module-tools/types' />
+/// <reference types='@modern-js/plugin-testing/types' />
 
 declare module '@alicloud/fun/lib/commands/config' {
   async function config(): Promise<void>;

--- a/packages/cli/plugin-garfish/package.json
+++ b/packages/cli/plugin-garfish/package.json
@@ -24,6 +24,9 @@
       ],
       "runtime": [
         "./dist/types/runtime/index.d.ts"
+      ],
+      "types": [
+        "./type.d.ts"
       ]
     }
   },
@@ -31,6 +34,7 @@
   "module": "./dist/js/treeshaking/runtime/index.js",
   "jsnext:modern": "./dist/js/modern/index.js",
   "exports": {
+    "./types": "./type.d.ts",
     ".": {
       "node": {
         "jsnext:source": "./src/index.ts",

--- a/packages/cli/plugin-lambda-fc/src/modern-app-env.d.ts
+++ b/packages/cli/plugin-lambda-fc/src/modern-app-env.d.ts
@@ -1,5 +1,5 @@
-/// <reference types='@modern-js/module-tools/type' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/module-tools/types' />
+/// <reference types='@modern-js/plugin-testing/types' />
 
 declare module '@alicloud/fun/lib/commands/deploy' {
   async function deploy(options: {

--- a/packages/cli/plugin-lambda-scf/src/modern-app-env.d.ts
+++ b/packages/cli/plugin-lambda-scf/src/modern-app-env.d.ts
@@ -1,5 +1,5 @@
-/// <reference types='@modern-js/module-tools/type' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/module-tools/types' />
+/// <reference types='@modern-js/plugin-testing/types' />
 
 declare module '@serverless/components' {
   async function runComponents(): Promise<void>;

--- a/packages/cli/plugin-multiprocess/src/modern-app-env.d.ts
+++ b/packages/cli/plugin-multiprocess/src/modern-app-env.d.ts
@@ -1,2 +1,2 @@
-/// <reference types='@modern-js/module-tools/type' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/module-tools/types' />
+/// <reference types='@modern-js/plugin-testing/types' />

--- a/packages/cli/plugin-sass/package.json
+++ b/packages/cli/plugin-sass/package.json
@@ -29,6 +29,14 @@
     "./cli": {
       "jsnext:source": "./src/cli.ts",
       "default": "./dist/js/node/cli.js"
+    },
+    "./types": {
+      "node": {
+        "import": "./dist/js/modern/types.js",
+        "require": "./dist/js/node/types.js",
+        "types": "./dist/types/types.d.ts"
+      },
+      "default": "./dist/js/treeshaking/types.js"
     }
   },
   "typesVersions": {
@@ -38,6 +46,9 @@
       ],
       "cli": [
         "./dist/types/cli.d.ts"
+      ],
+      "types": [
+        "./dist/types/types.d.ts"
       ]
     }
   },

--- a/packages/cli/plugin-testing/package.json
+++ b/packages/cli/plugin-testing/package.json
@@ -18,6 +18,10 @@
   "module": "./dist/js/treeshaking/index.js",
   "jsnext:modern": "./dist/js/modern/index.js",
   "exports": {
+    "./types": {
+      "jsnext:source": "./type.d.ts",
+      "default": "./type.d.ts"
+    },
     "./type": {
       "jsnext:source": "./type.d.ts",
       "default": "./type.d.ts"
@@ -66,6 +70,9 @@
         "./dist/types/runtime-testing/index.d.ts"
       ],
       "type": [
+        "./type.d.ts"
+      ],
+      "types": [
         "./type.d.ts"
       ],
       "runtime-base": [

--- a/packages/cli/static-hosting/src/modern-app-env.d.ts
+++ b/packages/cli/static-hosting/src/modern-app-env.d.ts
@@ -1,2 +1,2 @@
-/// <reference types='@modern-js/module-tools/type' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/module-tools/types' />
+/// <reference types='@modern-js/plugin-testing/types' />

--- a/packages/generator/generator-common/src/newAction/module/index.ts
+++ b/packages/generator/generator-common/src/newAction/module/index.ts
@@ -80,6 +80,7 @@ export const ModuleActionFunctionsAppendTypeContent: Partial<
 > = {
   [ActionFunction.TailwindCSS]: `/// <reference types='@modern-js/plugin-tailwindcss/types' />`,
   [ActionFunction.Less]: `/// <reference types='@modern-js/plugin-less/types' />`,
+  [ActionFunction.Sass]: `/// <reference types='@modern-js/plugin-sass/types' />`,
 };
 
 export const ModuleNewActionGenerators: Partial<

--- a/packages/generator/generator-common/src/newAction/mwa/index.ts
+++ b/packages/generator/generator-common/src/newAction/mwa/index.ts
@@ -104,12 +104,13 @@ export const MWAActionFunctionsDependencies: Partial<
 export const MWAActionFunctionsAppendTypeContent: Partial<
   Record<ActionFunction, string>
 > = {
-  [ActionFunction.Test]: `/// <reference types='@modern-js/plugin-testing/type' />`,
-  [ActionFunction.MicroFrontend]: `/// <reference types='@modern-js/plugin-garfish/type' />`,
+  [ActionFunction.Test]: `/// <reference types='@modern-js/plugin-testing/types' />`,
+  [ActionFunction.MicroFrontend]: `/// <reference types='@modern-js/plugin-garfish/types' />`,
   [ActionFunction.TailwindCSS]: `/// <reference types='@modern-js/plugin-tailwindcss/types' />`,
   [ActionFunction.SSG]: `/// <reference types='@modern-js/plugin-ssg/types' />`,
   [ActionFunction.Proxy]: `/// <reference types='@modern-js/plugin-proxy/types' />`,
   [ActionFunction.Less]: `/// <reference types='@modern-js/plugin-less/types' />`,
+  [ActionFunction.Sass]: `/// <reference types='@modern-js/plugin-sass/types' />`,
   [ActionFunction.UnBundle]: `/// <reference types='@modern-js/plugin-unbundle/types' />`,
 };
 

--- a/packages/generator/generators/cloud-deploy-generator/src/modern-app-env.d.ts
+++ b/packages/generator/generators/cloud-deploy-generator/src/modern-app-env.d.ts
@@ -1,2 +1,2 @@
-/// <reference types='@modern-js/module-tools/type' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/module-tools/types' />
+/// <reference types='@modern-js/plugin-testing/types' />

--- a/packages/generator/generators/dependence-generator/tests/index.test.ts
+++ b/packages/generator/generators/dependence-generator/tests/index.test.ts
@@ -51,7 +51,7 @@ describe('run dependence-generator', () => {
       dependencies: { '@modern-js/runtime': '^1' },
       peerDependencies: { '@modern-js/core': '^1' },
       appendTypeContent:
-        "/// <reference types='@modern-js/plugin-testing/type' />",
+        "/// <reference types='@modern-js/plugin-testing/types' />",
     };
     await handleTemplateFile(mockGeneratorCore._context, mockGeneratorCore);
     expect(fs.existsSync(path.join(projectDir, 'package.json'))).toBe(true);
@@ -64,7 +64,7 @@ describe('run dependence-generator', () => {
       'utf-8',
     );
     expect(typeContent).toContain(
-      "/// <reference types='@modern-js/plugin-testing/type' />",
+      "/// <reference types='@modern-js/plugin-testing/types' />",
     );
   });
   it('config has project path', async () => {
@@ -79,7 +79,7 @@ describe('run dependence-generator', () => {
       dependencies: { '@modern-js/runtime': '^1' },
       peerDependencies: { '@modern-js/core': '^1' },
       appendTypeContent:
-        "/// <reference types='@modern-js/plugin-testing/type' />",
+        "/// <reference types='@modern-js/plugin-testing/types' />",
       projectPath: 'apps/mwa',
     };
     await handleTemplateFile(mockGeneratorCore._context, mockGeneratorCore);
@@ -98,7 +98,7 @@ describe('run dependence-generator', () => {
       'utf-8',
     );
     expect(typeContent).toContain(
-      "/// <reference types='@modern-js/plugin-testing/type' />",
+      "/// <reference types='@modern-js/plugin-testing/types' />",
     );
   });
 });

--- a/packages/generator/generators/module-generator/templates/ts-template/src/modern-app-env.d.ts.handlebars
+++ b/packages/generator/generators/module-generator/templates/ts-template/src/modern-app-env.d.ts.handlebars
@@ -1,2 +1,2 @@
-/// <reference types='@modern-js/module-tools/type' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/module-tools/types' />
+/// <reference types='@modern-js/plugin-testing/types' />

--- a/packages/server/plugin-server/src/modern-app-env.d.ts
+++ b/packages/server/plugin-server/src/modern-app-env.d.ts
@@ -1,2 +1,2 @@
-/// <reference types='@modern-js/module-tools/type' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/module-tools/types' />
+/// <reference types='@modern-js/plugin-testing/types' />

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -30,7 +30,7 @@
       "jsnext:source": "./src/index.ts",
       "default": "./dist/js/node/index.js"
     },
-    "./type": {
+    "./types": {
       "jsnext:source": "./lib/types.d.ts",
       "default": "./lib/types.d.ts"
     }

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -40,6 +40,9 @@
   },
   "typesVersions": {
     "*": {
+      "types": [
+        "./lib/types.d.ts"
+      ],
       "type": [
         "./lib/types.d.ts"
       ]

--- a/packages/toolkit/node-bundle-require/src/modern-app-env.d.ts
+++ b/packages/toolkit/node-bundle-require/src/modern-app-env.d.ts
@@ -1,2 +1,2 @@
-/// <reference types='@modern-js/module-tools/type' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/module-tools/types' />
+/// <reference types='@modern-js/plugin-testing/types' />

--- a/packages/toolkit/node-bundle-require/tests/modern-app-env.d.ts
+++ b/packages/toolkit/node-bundle-require/tests/modern-app-env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="@modern-js/module-tools/types" />
-/// <reference types="@modern-js/plugin-testing/type" />
+/// <reference types="@modern-js/plugin-testing/types" />

--- a/tests/integration/api-service-koa/api/modern-app-env.d.ts
+++ b/tests/integration/api-service-koa/api/modern-app-env.d.ts
@@ -1,5 +1,5 @@
 /// <reference types='@modern-js/app-tools/types' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-garfish/type' />
 /// <reference types='@modern-js/plugin-express/types' />
 /// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/bff-express/src/modern-app-env.d.ts
+++ b/tests/integration/bff-express/src/modern-app-env.d.ts
@@ -1,5 +1,5 @@
 /// <reference types='@modern-js/app-tools/types' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-micro-frontend/type' />
 /// <reference types='@modern-js/plugin-express/types' />
 /// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/new-mwa-app/src/modern-app-env.d.ts
+++ b/tests/integration/new-mwa-app/src/modern-app-env.d.ts
@@ -1,5 +1,5 @@
 /// <reference types='@modern-js/app-tools/types' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-garfish/type' />
 /// <reference types='@modern-js/plugin-express/types' />
 /// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/testing-app/src/modern-app-env.d.ts
+++ b/tests/integration/testing-app/src/modern-app-env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types='@modern-js/app-tools/types' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-garfish/type' />

--- a/tests/integration/testing-bff/src/modern-app-env.d.ts
+++ b/tests/integration/testing-bff/src/modern-app-env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types='@modern-js/app-tools/types' />
-/// <reference types='@modern-js/plugin-testing/type' />
+/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-garfish/type' />


### PR DESCRIPTION
# PR Details

feat: optimise "types" exports from plugin
## Description

This PR include these features listed above:

1. add types export for `@modern-js/plugin-sass` and `@modern-js/plugin-garfish`, including the plugin itself and generator's part.
2. change export path from `type` to `types` for `@modern-js/app-tools`, `@modern-js/plugin-testing` and `@modern-js/module-tools`.

Noted: As `@modern-js/plugin-testing` and `@modern-js/module-tools` has been using `type` for such a while, so for forward compatbility, the code still keep `type` as reference path.
```typescript
// regular uses for reference
/// <reference types='@modern-js/module-tools/types' />
/// <reference types='@modern-js/plugin-testing/types' />

// Old paths still work, but not recommended
/// <reference types='@modern-js/module-tools/type' />
/// <reference types='@modern-js/plugin-testing/type' />
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
