### PR TITLE
chore: remove never reported eslint-disable comment

### DIFF
--- a/packages/cli/babel-preset-app/jest.config.js
+++ b/packages/cli/babel-preset-app/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/babel-preset-base/jest.config.js
+++ b/packages/cli/babel-preset-base/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/babel-preset-lib/jest.config.js
+++ b/packages/cli/babel-preset-lib/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/babel-preset-module/jest.config.js
+++ b/packages/cli/babel-preset-module/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/core/jest.config.js
+++ b/packages/cli/core/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/css-config/jest.config.js
+++ b/packages/cli/css-config/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/i18n-cli-language-detector/jest.config.js
+++ b/packages/cli/i18n-cli-language-detector/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-analyze/jest.config.js
+++ b/packages/cli/plugin-analyze/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-analyze/tests/fixtures/default-export/no-default-export.js
+++ b/packages/cli/plugin-analyze/tests/fixtures/default-export/no-default-export.js
@@ -1,4 +1,2 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 export const a = '1';
 export const b = '2';
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/packages/cli/plugin-analyze/tests/fixtures/entries/index-entry/src/index.jsx
+++ b/packages/cli/plugin-analyze/tests/fixtures/entries/index-entry/src/index.jsx
@@ -1,8 +1,8 @@
-/* eslint-disable node/no-unsupported-features/es-syntax, no-undef */
+/* eslint-disable no-undef */
 import React from 'react';
 import { Render } from 'react-dom';
 
 const App = () => <div>app</div>;
 
 Render(<App />, document.getElementById('root'));
-/* eslint-enable node/no-unsupported-features/es-syntax, no-undef */
+/* eslint-enable no-undef */

--- a/packages/cli/plugin-bff/jest.config.js
+++ b/packages/cli/plugin-bff/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-cdn-cos/jest.config.js
+++ b/packages/cli/plugin-cdn-cos/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-cdn-oss/jest.config.js
+++ b/packages/cli/plugin-cdn-oss/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-changeset/jest.config.js
+++ b/packages/cli/plugin-changeset/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-docsite/jest.config.js
+++ b/packages/cli/plugin-docsite/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-esbuild/jest.config.js
+++ b/packages/cli/plugin-esbuild/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-fast-refresh/jest.config.js
+++ b/packages/cli/plugin-fast-refresh/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-fetch/jest.config.js
+++ b/packages/cli/plugin-fetch/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-garfish/jest.config.js
+++ b/packages/cli/plugin-garfish/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-i18n/jest.config.js
+++ b/packages/cli/plugin-i18n/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-jarvis/jest.config.js
+++ b/packages/cli/plugin-jarvis/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-lambda-fc/jest.config.js
+++ b/packages/cli/plugin-lambda-fc/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-lambda-scf/jest.config.js
+++ b/packages/cli/plugin-lambda-scf/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-less/jest.config.js
+++ b/packages/cli/plugin-less/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-multiprocess/jest.config.js
+++ b/packages/cli/plugin-multiprocess/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-nocode/jest.config.js
+++ b/packages/cli/plugin-nocode/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-proxy/jest.config.js
+++ b/packages/cli/plugin-proxy/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-router/jest.config.js
+++ b/packages/cli/plugin-router/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-runtime/jest.config.js
+++ b/packages/cli/plugin-runtime/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-sass/jest.config.js
+++ b/packages/cli/plugin-sass/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-ssg/jest.config.js
+++ b/packages/cli/plugin-ssg/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-ssr/jest.config.js
+++ b/packages/cli/plugin-ssr/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-state/jest.config.js
+++ b/packages/cli/plugin-state/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-storybook/jest.config.js
+++ b/packages/cli/plugin-storybook/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-tailwind/jest.config.js
+++ b/packages/cli/plugin-tailwind/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-testing/jest.config.js
+++ b/packages/cli/plugin-testing/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/plugin-unbundle/jest.config.js
+++ b/packages/cli/plugin-unbundle/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/static-hosting/jest.config.js
+++ b/packages/cli/static-hosting/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/cli/webpack/jest.config.js
+++ b/packages/cli/webpack/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
   testEnvironment: 'node',

--- a/packages/generator/generator-cases/jest.config.js
+++ b/packages/generator/generator-cases/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generator-common/jest.config.js
+++ b/packages/generator/generator-common/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generator-plugin/jest.config.js
+++ b/packages/generator/generator-plugin/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generator-utils/jest.config.js
+++ b/packages/generator/generator-utils/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
   modulePathIgnorePatterns: [

--- a/packages/generator/generators/base-generator/jest.config.js
+++ b/packages/generator/generators/base-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/bff-generator/jest.config.js
+++ b/packages/generator/generators/bff-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/bff-refactor-generator/jest.config.js
+++ b/packages/generator/generators/bff-refactor-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/changeset-generator/jest.config.js
+++ b/packages/generator/generators/changeset-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/cloud-deploy-generator/jest.config.js
+++ b/packages/generator/generators/cloud-deploy-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/dependence-generator/jest.config.js
+++ b/packages/generator/generators/dependence-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/docsite-generator/jest.config.js
+++ b/packages/generator/generators/docsite-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/electron-generator/jest.config.js
+++ b/packages/generator/generators/electron-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/electron-independence-generator/jest.config.js
+++ b/packages/generator/generators/electron-independence-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/entry-generator/jest.config.js
+++ b/packages/generator/generators/entry-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/eslint-generator/jest.config.js
+++ b/packages/generator/generators/eslint-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/generator-generator/jest.config.js
+++ b/packages/generator/generators/generator-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/module-generator/jest.config.js
+++ b/packages/generator/generators/module-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/monorepo-generator/jest.config.js
+++ b/packages/generator/generators/monorepo-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/mwa-generator/jest.config.js
+++ b/packages/generator/generators/mwa-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/repo-generator/jest.config.js
+++ b/packages/generator/generators/repo-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/server-generator/jest.config.js
+++ b/packages/generator/generators/server-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/ssg-generator/jest.config.js
+++ b/packages/generator/generators/ssg-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/storybook-generator/jest.config.js
+++ b/packages/generator/generators/storybook-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/tailwindcss-generator/jest.config.js
+++ b/packages/generator/generators/tailwindcss-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/test-generator/jest.config.js
+++ b/packages/generator/generators/test-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/generators/unbundle-generator/jest.config.js
+++ b/packages/generator/generators/unbundle-generator/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/new-action/jest.config.js
+++ b/packages/generator/new-action/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/generator/plugins/generator-plugin/jest.config.js
+++ b/packages/generator/plugins/generator-plugin/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/review/eslint-config-app/jest.config.js
+++ b/packages/review/eslint-config-app/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/review/eslint-config/jest.config.js
+++ b/packages/review/eslint-config/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/review/testing-plugin-bff/jest.config.js
+++ b/packages/review/testing-plugin-bff/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/review/testing/jest.config.js
+++ b/packages/review/testing/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/review/tsconfig/jest.config.js
+++ b/packages/review/tsconfig/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/runtime/jest.config.js
+++ b/packages/runtime/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/server/adapter-helpers/jest.config.js
+++ b/packages/server/adapter-helpers/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/server/bff-runtime/jest.config.js
+++ b/packages/server/bff-runtime/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/server/bff-utils/jest.config.js
+++ b/packages/server/bff-utils/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/server/core/jest.config.js
+++ b/packages/server/core/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/server/create-request/jest.config.js
+++ b/packages/server/create-request/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
   modulePathIgnorePatterns: [

--- a/packages/server/hmr-client/jest.config.js
+++ b/packages/server/hmr-client/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/server/plugin-egg/jest.config.js
+++ b/packages/server/plugin-egg/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/server/plugin-express/jest.config.js
+++ b/packages/server/plugin-express/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/server/plugin-koa/jest.config.js
+++ b/packages/server/plugin-koa/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/server/plugin-nest/jest.config.js
+++ b/packages/server/plugin-nest/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/server/plugin-polyfill/jest.config.js
+++ b/packages/server/plugin-polyfill/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/server/prod-server/jest.config.js
+++ b/packages/server/prod-server/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   testEnvironment: 'node',
   rootDir: __dirname,

--- a/packages/server/server/jest.config.js
+++ b/packages/server/server/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   testEnvironment: 'node',
   rootDir: __dirname,

--- a/packages/server/utils/jest.config.js
+++ b/packages/server/utils/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/solutions/app-tools/jest.config.js
+++ b/packages/solutions/app-tools/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/solutions/module-tools/jest.config.js
+++ b/packages/solutions/module-tools/jest.config.js
@@ -1,10 +1,7 @@
 const sharedConfig = require('@scripts/jest-config');
 
-console.info(sharedConfig.coveragePathIgnorePatterns);
-
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/solutions/monorepo-tools/jest.config.js
+++ b/packages/solutions/monorepo-tools/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/babel-chain/jest.config.js
+++ b/packages/toolkit/babel-chain/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/compiler/babel/jest.config.js
+++ b/packages/toolkit/compiler/babel/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/compiler/esbuild/jest.config.js
+++ b/packages/toolkit/compiler/esbuild/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/compiler/style/jest.config.js
+++ b/packages/toolkit/compiler/style/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/create/jest.config.js
+++ b/packages/toolkit/create/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/doctor/jest.config.js
+++ b/packages/toolkit/doctor/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/esmpack/jest.config.js
+++ b/packages/toolkit/esmpack/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/freeze/jest.config.js
+++ b/packages/toolkit/freeze/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/load-config/jest.config.js
+++ b/packages/toolkit/load-config/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/load-config/tests/fixtures/config/es/dep-a.js
+++ b/packages/toolkit/load-config/tests/fixtures/config/es/dep-a.js
@@ -1,5 +1,5 @@
-/* eslint-disable filenames/match-exported, node/no-unsupported-features/es-syntax */
+/* eslint-disable filenames/match-exported */
 const source = { entries: { app: './src/App.jsx' } };
 
 export default source;
-/* eslint-enable filenames/match-exported, node/no-unsupported-features/es-syntax */
+/* eslint-enable filenames/match-exported */

--- a/packages/toolkit/load-config/tests/fixtures/config/es/modern.config.js
+++ b/packages/toolkit/load-config/tests/fixtures/config/es/modern.config.js
@@ -1,4 +1,4 @@
-/* eslint-disable filenames/match-exported, node/no-unsupported-features/es-syntax */
+/* eslint-disable filenames/match-exported */
 import source from './dep-a';
 
 const config = {
@@ -11,4 +11,4 @@ const config = {
 };
 
 export default config;
-/* eslint-enable filenames/match-exported, node/no-unsupported-features/es-syntax */
+/* eslint-enable filenames/match-exported */

--- a/packages/toolkit/load-config/tests/fixtures/config/file-param/a.config.js
+++ b/packages/toolkit/load-config/tests/fixtures/config/file-param/a.config.js
@@ -1,5 +1,5 @@
-/* eslint-disable filenames/match-exported,  node/no-unsupported-features/es-syntax */
+/* eslint-disable filenames/match-exported */
 const config = { output: { polyfill: 'off' } };
 
 export default config;
-/* eslint-enable filenames/match-exported,  node/no-unsupported-features/es-syntax */
+/* eslint-enable filenames/match-exported */

--- a/packages/toolkit/load-config/tests/fixtures/deps/a.js
+++ b/packages/toolkit/load-config/tests/fixtures/deps/a.js
@@ -1,8 +1,6 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 const b = require('./b');
 
 module.exports = {
   ...b,
   a: 'a',
 };
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/packages/toolkit/module-tools-hooks/jest.config.js
+++ b/packages/toolkit/module-tools-hooks/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/node-bundle-require/jest.config.js
+++ b/packages/toolkit/node-bundle-require/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/plugin/jest.config.js
+++ b/packages/toolkit/plugin/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/types/jest.config.js
+++ b/packages/toolkit/types/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/update/jest.config.js
+++ b/packages/toolkit/update/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
 };

--- a/packages/toolkit/utils/jest.config.js
+++ b/packages/toolkit/utils/jest.config.js
@@ -2,7 +2,6 @@ const sharedConfig = require('@scripts/jest-config');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
   ...sharedConfig,
   rootDir: __dirname,
   modulePathIgnorePatterns: [

--- a/tests/integration/alias-set/src/App.jsx
+++ b/tests/integration/alias-set/src/App.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 import React from 'react';
 import test from '@common/test';
 
@@ -7,4 +6,3 @@ function App() {
 }
 
 export default App;
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/tests/integration/alias-set/src/common/test.js
+++ b/tests/integration/alias-set/src/common/test.js
@@ -1,5 +1,3 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 const test = 1;
 
 export default test;
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/tests/integration/css-modules/fixtures/basic-module/src/App.jsx
+++ b/tests/integration/css-modules/fixtures/basic-module/src/App.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 import React from 'react';
 import styles from './index.module.css';
 
@@ -9,4 +8,3 @@ const App = () => (
 );
 
 export default App;
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/tests/integration/css-modules/fixtures/composes-basic/src/App.jsx
+++ b/tests/integration/css-modules/fixtures/composes-basic/src/App.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 import React from 'react';
 import styles from './index.module.css';
 
@@ -9,4 +8,3 @@ const App = () => (
 );
 
 export default App;
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/tests/integration/css-modules/fixtures/composes-external/src/App.jsx
+++ b/tests/integration/css-modules/fixtures/composes-external/src/App.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 import React from 'react';
 import styles from './index.module.css';
 
@@ -9,4 +8,3 @@ const App = () => (
 );
 
 export default App;
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/tests/integration/css-modules/fixtures/dev-module/src/App.jsx
+++ b/tests/integration/css-modules/fixtures/dev-module/src/App.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 import React from 'react';
 import styles from './index.module.css';
 
@@ -9,4 +8,3 @@ const App = () => (
 );
 
 export default App;
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/tests/integration/css-modules/fixtures/diff-suffix-module/src/App.jsx
+++ b/tests/integration/css-modules/fixtures/diff-suffix-module/src/App.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 import React from 'react';
 import blueStyles from './blue.module.sass';
 import greenStyles from './green.module.less';
@@ -11,4 +10,3 @@ const App = () => (
 );
 
 export default App;
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/tests/integration/css-modules/fixtures/global-module/src/App.jsx
+++ b/tests/integration/css-modules/fixtures/global-module/src/App.jsx
@@ -1,8 +1,6 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 import React from 'react';
 import styles from './index.module.css';
 
 const App = () => <div id="verify-div" className={styles.foo} />;
 
 export default App;
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/tests/integration/css-modules/fixtures/prod-module/src/App.jsx
+++ b/tests/integration/css-modules/fixtures/prod-module/src/App.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 import React from 'react';
 import styles from './index.module.css';
 
@@ -9,4 +8,3 @@ const App = () => (
 );
 
 export default App;
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/tests/integration/runtime/fixtures/use-loader/src/App.jsx
+++ b/tests/integration/runtime/fixtures/use-loader/src/App.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-/* eslint-disable node/no-unsupported-features/es-syntax */
 import React, { useState } from 'react';
 import { useLoader } from '@modern-js/runtime';
 
@@ -61,4 +60,3 @@ function App() {
 
 export default App;
 /* eslint-enable no-console */
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/tests/integration/server-prod/src/activity/App.jsx
+++ b/tests/integration/server-prod/src/activity/App.jsx
@@ -1,7 +1,5 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 import React from 'react';
 
 const App = () => <div>Activity page</div>;
 
 export default App;
-/* eslint-enable node/no-unsupported-features/es-syntax */

--- a/tests/integration/server-prod/src/server-prod/App.jsx
+++ b/tests/integration/server-prod/src/server-prod/App.jsx
@@ -1,7 +1,5 @@
-/* eslint-disable node/no-unsupported-features/es-syntax */
 import React from 'react';
 
 const App = () => <div className="text-center">Hello, Modern.js !</div>;
 
 export default App;
-/* eslint-enable node/no-unsupported-features/es-syntax */


### PR DESCRIPTION
# PR Details

Some rules is disabled but never reported, such as `node/no-unsupported-features/es-syntax`.

<img width="830" alt="截屏2022-04-01 下午9 05 53" src="https://user-images.githubusercontent.com/7237365/161359726-a4094fc5-1307-4e24-a4dc-8248fbb8c3ea.png">

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
