### PR TITLE
chore: failed to search content in output directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,6 @@
   },
   "search.useIgnoreFiles": true,
   "search.exclude": {
-    "**/output": true,
     "**/dist": true,
     "**/yarn.lock": true,
     "**/package-lock.json": true,

--- a/monorepo.code-workspace
+++ b/monorepo.code-workspace
@@ -473,7 +473,6 @@
       "**/coverage": true,
       "**/dist": true,
       "**/node_modules": true,
-      "**/output": true,
       "**/package-lock.json": true,
       "**/yarn.lock": true
     },

--- a/website/docs/apis/config/output/css-module-localIdent-name.md
+++ b/website/docs/apis/config/output/css-module-localIdent-name.md
@@ -26,6 +26,6 @@ export default defineConfig({
 
 更多配置与解释参考：[css-loader#localIdentName](https://github.com/webpack-contrib/css-loader#localidentname)。
 
-:::note 注
+:::info 注
 使用 [babel-plugin-react-css-modules](https://github.com/gajus/babel-plugin-react-css-modules) 时，该插件的配置选项 `generateScopedName` 需要和 `output.cssModuleLocalIdentName` 保持一致。
 :::

--- a/website/docs/apis/config/output/enable-ts-loader.md
+++ b/website/docs/apis/config/output/enable-ts-loader.md
@@ -23,7 +23,7 @@ export default defineConfig({
 });
 ```
 
-:::note 注
+:::info 注
 默认情况下，Modern.js 使用 Babel 编译 TS 文件，由于一些已知问题例如：
 
 * 不支持 const enum

--- a/website/docs/apis/config/output/favicon-by-entries.md
+++ b/website/docs/apis/config/output/favicon-by-entries.md
@@ -14,7 +14,7 @@ sidebar_position: 7
 
 按入口设置网页的 favicon。
 
-:::note 注
+:::info 注
 「 入口名 」默认为目录名，少数情况下通过 `source.entries` 自定义入口时，入口名为 `source.entries` 对象的 `key`。
 :::
 

--- a/website/docs/apis/config/output/import-style.md
+++ b/website/docs/apis/config/output/import-style.md
@@ -24,7 +24,7 @@ sidebar_label: importStyle
 - `./src/index.tsx`
 - `./src/index.less`
 
-:::note 注
+:::info 注
 假设开启了处理 Less 的功能。
 :::
 

--- a/website/docs/apis/config/output/inject-by-entries.md
+++ b/website/docs/apis/config/output/inject-by-entries.md
@@ -16,7 +16,7 @@ sidebar_position: 36
 按入口设置 script 标签插入位置，对象的 `key` 为入口名，对应的值设置参考 [`output.inject`](./inject)。
 
 
-:::note 注
+:::info 注
 「 入口名 」默认为目录名，少数情况下通过 `source.entries` 自定义入口时，入口名为 `source.entries` 对象的 `key`。
 :::
 

--- a/website/docs/apis/config/output/meta-by-entries.md
+++ b/website/docs/apis/config/output/meta-by-entries.md
@@ -14,7 +14,7 @@ sidebar_position: 5
 
 按入口设置 `meta` 信息，对象的 `key` 为入口名，给定值会和 `output.meta` 合并。
 
-:::note 注
+:::info 注
 「 入口名 」默认为目录名，少数情况下通过 `source.entries` 自定义入口时，入口名为 `source.entries` 对象的 `key`。
 :::
 

--- a/website/docs/apis/config/output/ssg.md
+++ b/website/docs/apis/config/output/ssg.md
@@ -13,7 +13,7 @@ sidebar_position: 9
 
 开启**自控式路由**或**约定式路由** SSG 功能的配置。
 
-:::note 客户端路由
+:::info 客户端路由
 相关内容可以查看[自控式路由](/docs/guides/tutorials/c08-client-side-routing/8.1-code-based-routing)或[约定式路由](/docs/guides/tutorials/c08-client-side-routing/8.2-file-based-routing)。
 :::
 
@@ -157,7 +157,7 @@ module.exports = {
 };
 ```
 
-:::note
+:::info
 路由中设置的 `headers` 会覆盖入口中设置的 `headers`。
 :::
 
@@ -187,7 +187,7 @@ module.exports = {
 
 可以这样设置，禁用某一条客户端路由的默认行为：
 
-:::note 注
+:::info 注
 该配置仅在渲染动态路径的约定式路由时使用。
 :::
 

--- a/website/docs/apis/config/output/title-by-entries.md
+++ b/website/docs/apis/config/output/title-by-entries.md
@@ -15,7 +15,7 @@ sidebar_position: 3
 按入口设置 html 页面 `title` 标签，对象的 `key` 为入口名。
 
 
-:::note 注
+:::info 注
 「 入口名 」默认为目录名，少数情况下通过 `source.entries` 自定义入口时，入口名为 `source.entries` 对象的 `key`。
 :::
 


### PR DESCRIPTION
# PR Details

The `output` directory is excluded in VS Code setting, and we can not search its contents.

Currently there is no temp files that are placed in the `output` directory, so this configuration can be removed.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
