### PR TITLE
feat(eslint): remove some overly restrictive rules

### DIFF
--- a/.changeset/few-shoes-confess.md
+++ b/.changeset/few-shoes-confess.md
@@ -1,0 +1,5 @@
+---
+'@modern-js-app/eslint-config': patch
+---
+
+feat: disable promise/prefer-await-to-then

--- a/.changeset/five-bears-brush.md
+++ b/.changeset/five-bears-brush.md
@@ -1,0 +1,5 @@
+---
+'@modern-js-app/eslint-config': patch
+---
+
+feat: disable require-atomic-updates

--- a/.changeset/khaki-bottles-collect.md
+++ b/.changeset/khaki-bottles-collect.md
@@ -1,0 +1,5 @@
+---
+'@modern-js-app/eslint-config': patch
+---
+
+feat: disable no-shadow

--- a/.changeset/short-roses-destroy.md
+++ b/.changeset/short-roses-destroy.md
@@ -1,0 +1,5 @@
+---
+'@modern-js-app/eslint-config': patch
+---
+
+feat: disable @typescript-eslint/no-base-to-string

--- a/.changeset/wild-impalas-pay.md
+++ b/.changeset/wild-impalas-pay.md
@@ -1,0 +1,5 @@
+---
+'@modern-js-app/eslint-config': patch
+---
+
+feat: disable filenames/match-exported

--- a/packages/cli/plugin-bff/tests/compiler.ts
+++ b/packages/cli/plugin-bff/tests/compiler.ts
@@ -12,7 +12,6 @@ global.setImmediate = setTimeout;
 global.clearImmediate = clearTimeout;
 
 export const compiler = (fixture: string, options: APILoaderOptions) => {
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   const compiler = webpack({
     context: __dirname,
     entry: fixture,

--- a/packages/cli/plugin-cdn-oss/src/index.ts
+++ b/packages/cli/plugin-cdn-oss/src/index.ts
@@ -113,14 +113,11 @@ export default (): CliPlugin => ({
         // upload files
         const uploadPromise = fl.map(filepath => {
           const uploadPath = path.relative(distDirectory, filepath);
-          return (
-            ossClient
-              .put(path.join(prefix, uploadPath), filepath)
-              // eslint-disable-next-line promise/prefer-await-to-then
-              .then(() => {
-                logger.info(`Upload ${uploadPath} success`);
-              })
-          );
+          return ossClient
+            .put(path.join(prefix, uploadPath), filepath)
+            .then(() => {
+              logger.info(`Upload ${uploadPath} success`);
+            });
         });
 
         await Promise.all(uploadPromise);

--- a/packages/cli/plugin-design-token/src/runtime/index.tsx
+++ b/packages/cli/plugin-design-token/src/runtime/index.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line filenames/match-exported
 import designTokenPlugin from './plugin';
 
 export * from './plugin';

--- a/packages/cli/plugin-design-token/tests/postcss.test.ts
+++ b/packages/cli/plugin-design-token/tests/postcss.test.ts
@@ -12,7 +12,6 @@ describe('postcss', () => {
     `,
         { from: '', to: undefined },
       )
-      // eslint-disable-next-line promise/prefer-await-to-then
       .then((result: Result) => {
         expect(result.css).toMatchSnapshot();
       });

--- a/packages/cli/plugin-docsite/src/features/utils/chokidar.ts
+++ b/packages/cli/plugin-docsite/src/features/utils/chokidar.ts
@@ -33,7 +33,6 @@ export function chokidarFile(
           await generateFiles(appDirectory, tmpDir, files, isDev);
           logger.info('built');
         }
-        // eslint-disable-next-line require-atomic-updates
         building = false;
 
         if (dirty) {

--- a/packages/cli/plugin-esbuild/src/esbuild-webpack-plugin.ts
+++ b/packages/cli/plugin-esbuild/src/esbuild-webpack-plugin.ts
@@ -58,9 +58,7 @@ export class ESBuildPlugin {
     const plugin = 'ESBuild Plugin';
     compiler.hooks.compilation.tap(plugin, (compilation: Compilation) => {
       if (isWebpack5) {
-        // eslint-disable @typescript-eslint/no-shadow
         const { Compilation } = compiler.webpack;
-        // eslint-enable @typescript-eslint/no-shadow
 
         compilation.hooks.processAssets.tapPromise(
           {

--- a/packages/cli/plugin-fetch/src/index.ts
+++ b/packages/cli/plugin-fetch/src/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line filenames/match-exported
 import { fetchPlugin } from './plugin';
 
 export default fetchPlugin;

--- a/packages/cli/plugin-garfish/src/runtime/utils/apps.tsx
+++ b/packages/cli/plugin-garfish/src/runtime/utils/apps.tsx
@@ -119,7 +119,6 @@ function getAppInstance(
     async componentWillUnmount() {
       const { appInstance } = this.state;
       if (appInstance) {
-        // eslint-disable-next-line @typescript-eslint/no-shadow
         const { appInfo } = appInstance;
         if (appInfo.cache) {
           logger(`MicroApp Garfish.loadApp "${appInfo.name}" hide`);

--- a/packages/cli/plugin-nocode/src/dev/server.ts
+++ b/packages/cli/plugin-nocode/src/dev/server.ts
@@ -43,7 +43,6 @@ export default ({
 
   // Reload code here
   (reload as any)(app)
-    // eslint-disable-next-line promise/prefer-await-to-then
     .then((reloadReturned: any) => {
       // reloadReturned is documented in the returns API in the README
       setReloadReturned(reloadReturned);
@@ -61,7 +60,6 @@ export default ({
         });
       }
     })
-    // eslint-disable-next-line promise/prefer-await-to-then
     .catch((err: any) => {
       console.error(
         'Reload could not start, could not start server/sample app',

--- a/packages/cli/plugin-nocode/src/register/butter.ts
+++ b/packages/cli/plugin-nocode/src/register/butter.ts
@@ -50,7 +50,6 @@ const generateSource = async (
       react: '^16.12.0',
       'react-dom': '^16.12.0',
     },
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     maintainers: maintainers.map(name => ({ name })),
     meta: {
       title,
@@ -63,7 +62,6 @@ const generateSource = async (
 
   const entryFile = path.resolve(tmpDir, 'src/index.ts');
   const entryContent = Object.keys(comps)
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     .map(name => {
       const lastName = _.last(name.split('/'));
       const importName = _.upperFirst(_.camelCase(lastName));
@@ -148,7 +146,6 @@ const registerPackage = async ({ name, version }, options) => {
         JSON.stringify(res.data, null, 4),
       );
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       const { name, version, _id, packageType } = pkg;
       logger.success(
         `package registered ${chalk.blue(`${name}@${version}`)} / ${chalk.grey(

--- a/packages/cli/plugin-router/src/runtime/index.ts
+++ b/packages/cli/plugin-router/src/runtime/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line filenames/match-exported
 import { routerPlugin } from './plugin';
 
 export default routerPlugin;

--- a/packages/cli/plugin-ssr/src/index.node.tsx
+++ b/packages/cli/plugin-ssr/src/index.node.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line filenames/match-exported
 import path from 'path';
 import { registerPrefetch } from '@modern-js/runtime-core';
 import type { Plugin } from '@modern-js/runtime-core';

--- a/packages/cli/plugin-ssr/src/index.tsx
+++ b/packages/cli/plugin-ssr/src/index.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line filenames/match-exported
 import ReactDOM from 'react-dom';
 import type { Plugin } from '@modern-js/runtime-core';
 import { loadableReady } from '@loadable/component';

--- a/packages/cli/plugin-ssr/src/serverRender/index.ts
+++ b/packages/cli/plugin-ssr/src/serverRender/index.ts
@@ -28,7 +28,6 @@ export const render = async (
     const html = await entry.renderToHtml(ctx);
     const cacheConfig = PreRender.config();
     if (cacheConfig) {
-      // eslint-disable-next-line require-atomic-updates
       ctx.ssrContext.cacheConfig = cacheConfig;
     }
 

--- a/packages/cli/plugin-state/src/runtime/plugin.tsx
+++ b/packages/cli/plugin-state/src/runtime/plugin.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line filenames/match-exported
 import { useContext } from 'react';
 import { RuntimeReactContext } from '@modern-js/runtime-core';
 import { createStore, Store } from '@modern-js-reduck/store';

--- a/packages/cli/plugin-unbundle/src/.eslintrc.json
+++ b/packages/cli/plugin-unbundle/src/.eslintrc.json
@@ -1,7 +1,6 @@
 {
   "rules": {
     "no-param-reassign": "off",
-    "filenames/match-exported": "off",
     "@typescript-eslint/no-loop-func": "off",
     "prefer-destructuring": "off",
     "consistent-return": "off",

--- a/packages/cli/plugin-unbundle/src/.eslintrc.json
+++ b/packages/cli/plugin-unbundle/src/.eslintrc.json
@@ -5,7 +5,6 @@
     "prefer-destructuring": "off",
     "consistent-return": "off",
     "max-statements": "off",
-    "@typescript-eslint/no-shadow": "off",
     "max-depth": "off",
     "@typescript-eslint/member-ordering": "off",
     "max-lines": "off",

--- a/packages/cli/plugin-unbundle/src/.eslintrc.json
+++ b/packages/cli/plugin-unbundle/src/.eslintrc.json
@@ -6,7 +6,6 @@
     "prefer-destructuring": "off",
     "consistent-return": "off",
     "max-statements": "off",
-    "require-atomic-updates": "off",
     "@typescript-eslint/no-shadow": "off",
     "max-depth": "off",
     "@typescript-eslint/member-ordering": "off",

--- a/packages/cli/plugin-unbundle/src/client/.eslintrc.json
+++ b/packages/cli/plugin-unbundle/src/client/.eslintrc.json
@@ -1,7 +1,6 @@
 {
   "extends": ["@modern-js-app"],
   "rules": {
-    "require-atomic-updates": "off",
     "babel/no-unused-expressions": "off",
     "callback-return": "off",
     "max-statements": "off"

--- a/packages/cli/plugin-unbundle/src/utils.ts
+++ b/packages/cli/plugin-unbundle/src/utils.ts
@@ -95,7 +95,6 @@ export const replaceAsync = (
         values.push(replacer.apply(undefined, args as any));
         return '';
       });
-      // eslint-disable-next-line promise/prefer-await-to-then
       return Promise.all(values).then(resolvedValues =>
         String.prototype.replace.call(str, searchValue, () =>
           resolvedValues.shift(),

--- a/packages/cli/webpack/src/plugins/plugin.type.ts
+++ b/packages/cli/webpack/src/plugins/plugin.type.ts
@@ -1,4 +1,4 @@
-/* eslint-disable  @typescript-eslint/no-unused-vars, node/prefer-global/buffer,@typescript-eslint/ban-types */
+/* eslint-disable  @typescript-eslint/no-unused-vars, node/prefer-global/buffer */
 /*
  * This file was copied from Webpack : "version": "1.0.0-rc.2",
  * It is copied here as necessary types are not exported from webpack yet
@@ -473,4 +473,4 @@ declare interface UserResolveOptions {
 declare interface WriteOnlySet<T> {
   add: (T?: any) => void;
 }
-/* eslint-enable @typescript-eslint/no-unused-vars, node/prefer-global/buffer,@typescript-eslint/ban-types */
+/* eslint-enable @typescript-eslint/no-unused-vars, node/prefer-global/buffer */

--- a/packages/generator/generator-common/src/mwa/bff.ts
+++ b/packages/generator/generator-common/src/mwa/bff.ts
@@ -4,7 +4,6 @@ import { FrameworkSchema, Framework } from './common';
 
 export enum BFFType {
   Func = 'func',
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   Framework = 'framework',
 }
 

--- a/packages/generator/generators/module-generator/src/index.ts
+++ b/packages/generator/generators/module-generator/src/index.ts
@@ -73,7 +73,6 @@ export const handleTemplateFile = async (
     await generatorPlugin.installPlugins(Solution.Module, extra);
     schema = generatorPlugin.getInputSchema(Solution.Module);
     inputValue = generatorPlugin.getInputValue();
-    // eslint-disable-next-line require-atomic-updates
     context.config.gitCommitMessage =
       generatorPlugin.getGitMessage() || context.config.gitCommitMessage;
   }

--- a/packages/generator/generators/monorepo-generator/src/index.ts
+++ b/packages/generator/generators/monorepo-generator/src/index.ts
@@ -40,7 +40,6 @@ export const handleTemplateFile = async (
     await generatorPlugin.installPlugins(Solution.Monorepo, extra);
     schema = generatorPlugin.getInputSchema(Solution.Monorepo);
     inputValue = generatorPlugin.getInputValue();
-    // eslint-disable-next-line require-atomic-updates
     context.config.gitCommitMessage =
       generatorPlugin.getGitMessage() || context.config.gitCommitMessage;
   }

--- a/packages/generator/generators/mwa-generator/src/index.ts
+++ b/packages/generator/generators/mwa-generator/src/index.ts
@@ -70,7 +70,6 @@ export const handleTemplateFile = async (
     await generatorPlugin.installPlugins(Solution.MWA, extra);
     schema = generatorPlugin.getInputSchema(Solution.MWA);
     inputValue = generatorPlugin.getInputValue();
-    // eslint-disable-next-line require-atomic-updates
     context.config.gitCommitMessage =
       generatorPlugin.getGitMessage() || context.config.gitCommitMessage;
   }

--- a/packages/review/eslint-config-app/base.js
+++ b/packages/review/eslint-config-app/base.js
@@ -423,17 +423,6 @@ module.exports = {
       // @CUSTOM
     ],
 
-    /*
-     * https://eslint.org/docs/rules/no-shadow
-     * "no-shadow": "off",
-     */
-    'no-shadow': [
-      'error',
-      {
-        builtinGlobals: false,
-        allow: [],
-      },
-    ],
     // https://eslint.org/docs/rules/no-shadow-restricted-names
     'no-shadow-restricted-names': 'error',
     // https://eslint.org/docs/rules/no-undef

--- a/packages/review/eslint-config-app/base.js
+++ b/packages/review/eslint-config-app/base.js
@@ -1359,8 +1359,6 @@ module.exports = {
      * use Camel Case for others
      */
     'filenames/match-regex': ['error', '^[\\[\\]_a-zA-Z0-9.-]+$'],
-    // https://www.npmjs.com/package/eslint-plugin-filenames#matching-exported-values-match-exported
-    'filenames/match-exported': ['error', ['kebab', 'camel', 'pascal']],
     // https://www.npmjs.com/package/eslint-plugin-filenames#dont-allow-indexjs-files-no-index
     'filenames/no-index': 'off',
 
@@ -1554,7 +1552,6 @@ module.exports = {
       files: ['**/pages/**/_*', '**/pages/**/index.*', '**/pages/**/\\[**'],
       rules: {
         'filenames/match-regex': 'off',
-        'filenames/match-exported': 'off',
       },
     },
     {

--- a/packages/review/eslint-config-app/base.js
+++ b/packages/review/eslint-config-app/base.js
@@ -155,10 +155,6 @@ module.exports = {
     'no-unsafe-finally': 'error',
     // https://eslint.org/docs/rules/no-unsafe-negation
     'no-unsafe-negation': 'error',
-    // https://eslint.org/docs/rules/require-atomic-updates
-    // @bug https://github.com/eslint/eslint/issues/11899
-    'require-atomic-updates': 'warn',
-    // 'require-atomic-updates': 'error',
     // https://eslint.org/docs/rules/use-isnan
     'use-isnan': 'error',
     // https://eslint.org/docs/rules/valid-typeof

--- a/packages/review/eslint-config-app/base.js
+++ b/packages/review/eslint-config-app/base.js
@@ -1395,12 +1395,6 @@ module.exports = {
     'promise/valid-params': 'error',
 
     /*
-     * https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/prefer-await-to-then.md
-     * @CUSTOM
-     */
-    'promise/prefer-await-to-then': 'error',
-
-    /*
      * https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/prefer-await-to-callbacks.md
      * @CUSTOM
      */

--- a/packages/review/eslint-config-app/ts.js
+++ b/packages/review/eslint-config-app/ts.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 const { jsExtensions } = require('./utils');
 
 module.exports = {
@@ -391,15 +390,6 @@ module.exports = {
         // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-redeclare.md
         'no-redeclare': 'off',
         '@typescript-eslint/no-redeclare': ['error', { builtinGlobals: true }],
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-shadow.md
-        'no-shadow': 'off',
-        '@typescript-eslint/no-shadow': [
-          'error',
-          {
-            builtinGlobals: false,
-            allow: [],
-          },
-        ],
 
         // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/space-before-function-paren.md
         'space-before-function-paren': 'off',
@@ -418,4 +408,3 @@ module.exports = {
     },
   ],
 };
-/* eslint-enable max-lines */

--- a/packages/review/eslint-config-app/ts.withType.js
+++ b/packages/review/eslint-config-app/ts.withType.js
@@ -24,11 +24,6 @@ module.exports = {
         ],
         // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md
         '@typescript-eslint/no-unnecessary-type-assertion': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/restrict-template-expressions.md
-        '@typescript-eslint/restrict-template-expressions': [
-          'error',
-          { allowNumber: true, allowAny: true },
-        ],
         // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-base-to-string.md
         '@typescript-eslint/no-base-to-string': 'error',
         // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md

--- a/packages/review/testing-plugin-bff/src/mockAPI.ts
+++ b/packages/review/testing-plugin-bff/src/mockAPI.ts
@@ -97,7 +97,6 @@ export default (
                 return test;
               }
 
-              // eslint-disable-next-line promise/prefer-await-to-then
               return test.then((value: any) => {
                 try {
                   return JSON.parse(value.text);

--- a/packages/runtime/src/compatible.tsx
+++ b/packages/runtime/src/compatible.tsx
@@ -36,7 +36,6 @@ export const createApp = ({ plugins }: CreateAppOptions) => {
         { element, props: { ...props }, context },
         {
           container,
-          // eslint-disable-next-line @typescript-eslint/no-shadow
           onLast: ({ element }) => element,
         },
       );
@@ -50,7 +49,6 @@ export const createApp = ({ plugins }: CreateAppOptions) => {
       { App: WrapperComponent },
       {
         container,
-        // eslint-disable-next-line @typescript-eslint/no-shadow
         onLast: ({ App }: any) => {
           const WrapComponent = ({ context, ...props }: any) => {
             let contextValue = context;
@@ -159,7 +157,6 @@ export const bootstrap: BootStrap = async (
           typeof id !== 'string' ? id : document.getElementById(id || 'root')!,
       },
       {
-        // eslint-disable-next-line @typescript-eslint/no-shadow
         onLast: async ({ App, rootElement }) => {
           ReactDOM.render(React.createElement(App, { context }), rootElement);
         },

--- a/packages/runtime/src/loader/loaderManager.ts
+++ b/packages/runtime/src/loader/loaderManager.ts
@@ -73,7 +73,6 @@ const createLoader = (
 
     promise = new Promise(resolve => {
       loaderFn()
-        // eslint-disable-next-line promise/prefer-await-to-then
         .then(value => {
           data = value;
           error = null;
@@ -81,7 +80,6 @@ const createLoader = (
           notify();
           resolve(value);
         })
-        // eslint-disable-next-line promise/prefer-await-to-then
         .catch(e => {
           error = e instanceof Error ? `${e.message}` : e;
           data = null;
@@ -89,7 +87,6 @@ const createLoader = (
           notify();
           resolve(e);
         })
-        // eslint-disable-next-line promise/prefer-await-to-then
         .finally(() => {
           promise = null;
           hasLoaded = true;

--- a/packages/runtime/src/render.ts
+++ b/packages/runtime/src/render.ts
@@ -26,7 +26,6 @@ export const clientRender = (
   return runner.client(
     { App, rootElement },
     {
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       onLast: async ({ App, rootElement }) => {
         ReactDOM.render(React.createElement(App), rootElement);
       },

--- a/packages/runtime/src/wrap.ts
+++ b/packages/runtime/src/wrap.ts
@@ -3,19 +3,18 @@ import { createContainer } from '@modern-js/plugin';
 import { runtime, Plugin, AppComponentContext } from './plugin';
 import { RuntimeReactContext } from './runtime-context';
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type WrapOptions = {};
+export type WrapOptions = Record<string, unknown>;
 
 export const initialWrapper = (plugins: Plugin[], manager = runtime) => {
   manager.usePlugin(...plugins);
 
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  return <P = {}>(App: React.ComponentType<P>, config: WrapOptions) =>
-    wrap(App, config, manager);
+  return <P = Record<string, unknown>>(
+    App: React.ComponentType<P>,
+    config: WrapOptions,
+  ) => wrap(App, config, manager);
 };
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export const wrap = <P = {}>(
+export const wrap = <P = Record<string, unknown>>(
   App: React.ComponentType<P>,
   // eslint-disable-next-line no-empty-pattern
   {}: WrapOptions,

--- a/packages/runtime/src/wrap.ts
+++ b/packages/runtime/src/wrap.ts
@@ -31,7 +31,6 @@ export const wrap = <P = Record<string, unknown>>(
       { element, props: { ...props }, context: {} as any },
       {
         container,
-        // eslint-disable-next-line @typescript-eslint/no-shadow
         onLast: ({ element }) => element,
       },
     );
@@ -41,7 +40,6 @@ export const wrap = <P = Record<string, unknown>>(
     { App: WrapperComponent },
     {
       container,
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       onLast: ({ App }) => {
         const WrapComponent = ({ context, ...props }: any) =>
           React.createElement(

--- a/packages/server/core/src/plugin.ts
+++ b/packages/server/core/src/plugin.ts
@@ -65,14 +65,12 @@ const prepareApiServer = createAsyncPipeline<APIServerStartInput, Adapter>();
 
 const beforeDevServer = createParallelWorkflow<NormalizedConfig, any>();
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-const setupCompiler = createParallelWorkflow<{}, any[]>();
+const setupCompiler = createParallelWorkflow<Record<string, unknown>, any[]>();
 
 const afterDevServer = createParallelWorkflow<NormalizedConfig, any>();
 
 // TODO FIXME
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type Route = {};
+export type Route = Record<string, unknown>;
 const beforeRouteSet = createAsyncPipeline<Route[], Route[]>();
 
 const afterRouteSet = createAsyncPipeline();
@@ -114,15 +112,13 @@ const afterMatch = createAsyncPipeline<
 >();
 
 // TODO FIXME
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type SSRServerContext = {};
+export type SSRServerContext = Record<string, unknown>;
 const prefetch = createParallelWorkflow<{
   context: SSRServerContext;
 }>();
 
 // TODO FIXME
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type RenderContext = {};
+export type RenderContext = Record<string, unknown>;
 const renderToString = createAsyncPipeline<
   { App: Component; context: RenderContext },
   string

--- a/packages/server/create-request/src/browser.ts
+++ b/packages/server/create-request/src/browser.ts
@@ -10,9 +10,7 @@ import type {
 let realRequest: typeof fetch;
 let realAllowedHeaders: string[];
 const originFetch = (...params: Parameters<typeof fetch>) =>
-  fetch(...params)
-    // eslint-disable-next-line promise/prefer-await-to-then
-    .then(handleRes);
+  fetch(...params).then(handleRes);
 
 export const configure = (options: IOptions) => {
   const { request, interceptor, allowedHeaders } = options;

--- a/packages/server/create-request/src/index.ts
+++ b/packages/server/create-request/src/index.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable filenames/match-exported */
 import { isBrowser } from '@modern-js/utils';
 import { createRequest as browser } from './browser';
 import { createRequest as node } from './node';

--- a/packages/server/create-request/src/node.ts
+++ b/packages/server/create-request/src/node.ts
@@ -14,13 +14,11 @@ import type {
 let realRequest: Fetch;
 let realAllowedHeaders: string[] = [];
 const originFetch = (...params: Parameters<typeof nodeFetch>) =>
-  nodeFetch(...params)
-    // eslint-disable-next-line promise/prefer-await-to-then
-    .then(handleRes);
+  nodeFetch(...params).then(handleRes);
 
-export const configure = (options: IOptions<typeof nodeFetch>) => {
+export const configure = (options: IOptions) => {
   const { request, interceptor, allowedHeaders } = options;
-  realRequest = (request as Fetch) || originFetch;
+  realRequest = request || originFetch;
   if (interceptor && !request) {
     realRequest = interceptor(nodeFetch);
   }
@@ -35,7 +33,7 @@ export const createRequest: RequestCreator = (
   port: number,
   // 后续可能要修改，暂时先保留
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  fetch = nodeFetch as any,
+  fetch = nodeFetch,
 ) => {
   const getFinalPath = compile(path, { encode: encodeURIComponent });
   const keys: Key[] = [];

--- a/packages/server/create-request/tests/node.test.ts
+++ b/packages/server/create-request/tests/node.test.ts
@@ -26,7 +26,6 @@ describe('configure', () => {
   // });
 
   test('should support custom request', done => {
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     const url = 'http://localhost:9090';
     const port = 9090;
 

--- a/packages/server/hmr-client/src/.eslintrc
+++ b/packages/server/hmr-client/src/.eslintrc
@@ -1,7 +1,6 @@
 {
   "extends": ["@modern-js-app"],
   "rules": {
-    "no-console": "off",
-    "promise/prefer-await-to-then": "off"
+    "no-console": "off"
   }
 }

--- a/packages/server/plugin-egg/src/index.ts
+++ b/packages/server/plugin-egg/src/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line filenames/match-exported
 import plugin from './plugin';
 import './runtime';
 

--- a/packages/server/plugin-egg/src/plugin.ts
+++ b/packages/server/plugin-egg/src/plugin.ts
@@ -69,9 +69,7 @@ const initApp = async (options: StartOptions): Promise<Application> => {
 
   agent = new Agent({ ...options });
   await agent.ready();
-  // eslint-disable-next-line require-atomic-updates
   application = new App({ ...options });
-  // eslint-disable-next-line require-atomic-updates
   application.agent = agent;
   agent.application = application;
   await application.ready();

--- a/packages/server/plugin-egg/src/runtime/index.ts
+++ b/packages/server/plugin-egg/src/runtime/index.ts
@@ -3,7 +3,6 @@ import { useContext, Context } from '../context';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 declare module '@modern-js/runtime/server' {
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   export function useContext(): Context;
 }
 

--- a/packages/server/plugin-egg/src/utils/registerMiddleware.ts
+++ b/packages/server/plugin-egg/src/utils/registerMiddleware.ts
@@ -10,7 +10,6 @@ const registerMiddleware = (app: Application, middleware: Middleware) => {
   }
 
   if (!Array.isArray(middleware)) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`middleware must be a array, but found ${middleware}`);
   }
 

--- a/packages/server/plugin-egg/src/utils/registerRoutes.ts
+++ b/packages/server/plugin-egg/src/utils/registerRoutes.ts
@@ -23,21 +23,16 @@ const registerRoutes = (router: Router, prefix?: string) => {
         const result = await run(ctx, () => handler(input));
         if (result.type !== 'HandleSuccess') {
           if (result.type === 'InputValidationError') {
-            // eslint-disable-next-line require-atomic-updates
             ctx.status = 400;
           } else {
-            // eslint-disable-next-line require-atomic-updates
             ctx.status = 500;
           }
-          // eslint-disable-next-line require-atomic-updates
           ctx.body = result.message;
         } else {
-          // eslint-disable-next-line require-atomic-updates
           ctx.body = result.value;
         }
       } else {
         const args = Object.values(input.params as any).concat(input);
-        // eslint-disable-next-line require-atomic-updates
         ctx.body = await run(ctx, () => handler(...args));
       }
     };

--- a/packages/server/plugin-egg/tests/fixtures/lambda-mode/api/app/controller/home.js
+++ b/packages/server/plugin-egg/tests/fixtures/lambda-mode/api/app/controller/home.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable filenames/match-exported */
 const { Controller } = require('egg');
 
 class HomeController extends Controller {

--- a/packages/server/plugin-egg/tests/fixtures/lambda-mode/api/lambda/nest/user.ts
+++ b/packages/server/plugin-egg/tests/fixtures/lambda-mode/api/lambda/nest/user.ts
@@ -1,7 +1,6 @@
 import { match } from '@modern-js/bff-runtime';
 import { useContext } from '../../../../../../src/context';
 
-// eslint-disable-next-line arrow-body-style
 export const get = ({ query }: { query: Record<string, unknown> }) => {
   return { query };
 };

--- a/packages/server/plugin-express/src/index.ts
+++ b/packages/server/plugin-express/src/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line filenames/match-exported
 import plugin from './plugin';
 
 export * from './context';

--- a/packages/server/plugin-express/tests/fixtures/function-mode/api/nest/user.ts
+++ b/packages/server/plugin-express/tests/fixtures/function-mode/api/nest/user.ts
@@ -3,7 +3,6 @@
 import { match } from '@modern-js/bff-runtime';
 import { useContext } from '../../../../../src/context';
 
-// eslint-disable-next-line arrow-body-style
 export const get = ({ query }: { query: Record<string, unknown> }) => {
   return { query };
 };

--- a/packages/server/plugin-koa/src/index.ts
+++ b/packages/server/plugin-koa/src/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line filenames/match-exported
 import plugin from './plugin';
 
 export * from './context';

--- a/packages/server/plugin-koa/src/registerRoutes.ts
+++ b/packages/server/plugin-koa/src/registerRoutes.ts
@@ -26,23 +26,18 @@ const registerRoutes = (router: Router, prefix?: string) => {
         const result = await handler(input);
         if (result.type !== 'HandleSuccess') {
           if (result.type === 'InputValidationError') {
-            // eslint-disable-next-line require-atomic-updates
             ctx.status = 400;
           } else {
-            // eslint-disable-next-line require-atomic-updates
             ctx.status = 500;
           }
-          // eslint-disable-next-line require-atomic-updates
           ctx.body = result.message;
         } else {
-          // eslint-disable-next-line require-atomic-updates
           ctx.body = result.value;
         }
       } else {
         const args = Object.values(input.params as any).concat(input);
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
-        // eslint-disable-next-line require-atomic-updates
         ctx.body = await handler(...args);
       }
     };

--- a/packages/server/plugin-nest/src/runtime/index.ts
+++ b/packages/server/plugin-nest/src/runtime/index.ts
@@ -3,7 +3,6 @@ import { useContext, NestContext } from '../context';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 declare module '@modern-js/runtime/server' {
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   export function useContext(): NestContext;
 }
 

--- a/packages/server/prod-server/src/libs/render/cache/index.ts
+++ b/packages/server/prod-server/src/libs/render/cache/index.ts
@@ -49,7 +49,6 @@ export default (renderFn: RenderFunction, ctx: ModernServerContext) => {
       );
 
       render()
-        // eslint-disable-next-line promise/prefer-await-to-then
         .then(res => {
           if (res.value && res.isOrigin) {
             const { cacheConfig } = context;
@@ -60,7 +59,6 @@ export default (renderFn: RenderFunction, ctx: ModernServerContext) => {
             }
           }
         })
-        // eslint-disable-next-line promise/prefer-await-to-then
         .catch(e => {
           sprCache.del(cacheContext, cacheHash);
           ctx.error(ERROR_DIGEST.ERENDER, e);

--- a/packages/server/prod-server/src/libs/render/cache/spr.ts
+++ b/packages/server/prod-server/src/libs/render/cache/spr.ts
@@ -236,7 +236,6 @@ class CacheManager {
     let data = this.cache.get(cacheKey);
     if (!data) {
       const caches = await createPageCaches(MAX_CACHE_EACH_REQ);
-      // eslint-disable-next-line require-atomic-updates
       data = this.createCacheContent(cacheConfig, caches);
     }
 

--- a/packages/server/prod-server/src/libs/render/cache/util.ts
+++ b/packages/server/prod-server/src/libs/render/cache/util.ts
@@ -58,7 +58,6 @@ export function withCoalescedInvoke<F extends (...args: any[]) => Promise<any>>(
   return async function (key: string, args: Parameters<F>) {
     const entry = globalInvokeCache.get(key);
     if (entry) {
-      // eslint-disable-next-line promise/prefer-await-to-then
       return entry.then(res => ({
         isOrigin: false,
         value: res.value as UnwrapPromise<ReturnType<F>>,
@@ -70,12 +69,10 @@ export function withCoalescedInvoke<F extends (...args: any[]) => Promise<any>>(
     }
 
     const future = __wrapper()
-      // eslint-disable-next-line promise/prefer-await-to-then
       .then(res => {
         globalInvokeCache.delete(key);
         return { isOrigin: true, value: res as UnwrapPromise<ReturnType<F>> };
       })
-      // eslint-disable-next-line promise/prefer-await-to-then
       .catch(err => {
         globalInvokeCache.delete(key);
         throw err;

--- a/packages/server/prod-server/src/server/modern-server.ts
+++ b/packages/server/prod-server/src/server/modern-server.ts
@@ -547,7 +547,6 @@ export class ModernServer implements ModernServerInterface {
           return next();
         }
 
-        // eslint-disable-next-line promise/prefer-await-to-then
         return handler(context, dispatch as NextFunction).catch(onError);
       };
 

--- a/packages/solutions/app-tools/src/utils/createCompiler.ts
+++ b/packages/solutions/app-tools/src/utils/createCompiler.ts
@@ -68,7 +68,6 @@ export const createCompiler = async ({
         }
         await printInstructions(api, appContext, userConfig);
       }
-      // eslint-disable-next-line require-atomic-updates
       isFirstCompile = false;
     });
 

--- a/packages/solutions/app-tools/src/utils/createServer.ts
+++ b/packages/solutions/app-tools/src/utils/createServer.ts
@@ -16,7 +16,6 @@ export const createServer = async (options: ModernDevServerOptions) => {
     await server.close();
   }
 
-  // eslint-disable-next-line require-atomic-updates
   server = new Server(options);
 
   const app = await server.init();

--- a/packages/solutions/app-tools/tests/utils.test.ts
+++ b/packages/solutions/app-tools/tests/utils.test.ts
@@ -40,7 +40,6 @@ describe('test app-tools utils', () => {
     getSpecifiedEntries(['c'], [
       { entryName: 'a' },
       { entryName: 'b' },
-      // eslint-disable-next-line promise/prefer-await-to-then
     ] as any).catch(e => {
       expect((e as Error).message).toMatch('can not found entry c');
       resolve();

--- a/packages/toolkit/babel-chain/src/plugin.ts
+++ b/packages/toolkit/babel-chain/src/plugin.ts
@@ -31,7 +31,6 @@ export const createBabelPluginChain = (): BabelPluginChain => {
   const plugin = (name: string) => {
     const pluginExist = plugins.find(plugin => plugin.name === name);
     const isExist = Boolean(pluginExist);
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     const plugin = pluginExist || { name, options: [] };
 
     const tap = (options: any[]) => {
@@ -43,7 +42,6 @@ export const createBabelPluginChain = (): BabelPluginChain => {
 
     const del = () => {
       if (isExist) {
-        // eslint-disable-next-line @typescript-eslint/no-shadow
         plugins = plugins.filter(plugin => !plugin.name.includes(name));
       }
     };
@@ -67,7 +65,6 @@ export const createBabelPluginChain = (): BabelPluginChain => {
       }
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     const use = (path: string, options?: any[]) => {
       plugin.path = path;
       plugin.options = options || [];
@@ -85,7 +82,6 @@ export const createBabelPluginChain = (): BabelPluginChain => {
   };
 
   const toJSON = (): PluginItem[] =>
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     plugins.map(plugin =>
       plugin.options
         ? [plugin.path || plugin.name, ...plugin.options]
@@ -95,7 +91,6 @@ export const createBabelPluginChain = (): BabelPluginChain => {
   // merge preset with replacing
   // see https://babeljs.io/docs/en/configuration#how-babel-merges-config-items
   const merge = (other: BabelPluginChain): BabelPluginChain => {
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     for (const plugin of other.plugins) {
       if (plugin.path) {
         chain.plugin(plugin.name).use(plugin.path, plugin.options);

--- a/packages/toolkit/babel-chain/src/preset.ts
+++ b/packages/toolkit/babel-chain/src/preset.ts
@@ -30,7 +30,6 @@ export const createBabelPresetChain = (): BabelPresetChain => {
 
   const preset = (name: string) => {
     const isExist = presets.some(plugin => plugin.name === name);
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     const preset: Preset = { name, options: [] };
 
     const tap = (options: any[]) => {
@@ -42,7 +41,6 @@ export const createBabelPresetChain = (): BabelPresetChain => {
 
     const del = () => {
       if (isExist) {
-        // eslint-disable-next-line @typescript-eslint/no-shadow
         presets = presets.filter(preset => !preset.name.includes(name));
       }
     };
@@ -66,7 +64,6 @@ export const createBabelPresetChain = (): BabelPresetChain => {
       }
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     const use = (path: string, options?: any[]) => {
       preset.path = path;
       preset.options = options || [];
@@ -84,7 +81,6 @@ export const createBabelPresetChain = (): BabelPresetChain => {
   };
 
   const toJSON = (): PluginItem[] =>
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     presets.map(preset =>
       preset.options
         ? [preset.path || preset.name, ...preset.options]
@@ -94,7 +90,6 @@ export const createBabelPresetChain = (): BabelPresetChain => {
   // merge preset with replacing
   // see https://babeljs.io/docs/en/configuration#how-babel-merges-config-items
   const merge = (other: BabelPresetChain): BabelPresetChain => {
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     for (const preset of other.presets) {
       if (preset.path) {
         chain.preset(preset.name).use(preset.path, preset.options);

--- a/packages/toolkit/esmpack/.eslintrc.json
+++ b/packages/toolkit/esmpack/.eslintrc.json
@@ -30,7 +30,6 @@
     "@typescript-eslint/lines-between-class-members": "off",
     "@typescript-eslint/prefer-readonly": "off",
     "@typescript-eslint/prefer-includes": "off",
-    "@typescript-eslint/no-shadow": "off",
     "@typescript-eslint/require-await": "off",
     "@typescript-eslint/prefer-string-starts-ends-with": "off",
     "@typescript-eslint/prefer-regexp-exec": "off",

--- a/packages/toolkit/esmpack/.eslintrc.json
+++ b/packages/toolkit/esmpack/.eslintrc.json
@@ -16,7 +16,6 @@
     "no-param-reassign": "off",
     "no-lonely-if": "off",
     "no-useless-escape": "off",
-    "promise/prefer-await-to-then": "off",
     "require-atomic-updates": "off",
     "prefer-template": "off",
     "consistent-return": "off",

--- a/packages/toolkit/esmpack/.eslintrc.json
+++ b/packages/toolkit/esmpack/.eslintrc.json
@@ -16,7 +16,6 @@
     "no-param-reassign": "off",
     "no-lonely-if": "off",
     "no-useless-escape": "off",
-    "require-atomic-updates": "off",
     "prefer-template": "off",
     "consistent-return": "off",
     "object-shorthand": "off",

--- a/packages/toolkit/esmpack/e2e/utils/e2ePlugin.ts
+++ b/packages/toolkit/esmpack/e2e/utils/e2ePlugin.ts
@@ -73,9 +73,7 @@ class E2EPlguin implements EsmpackPlugin {
 
       const importerPackageName = normalizePackageName(spec);
       const importer = compilation.inputOptions.input![spec];
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       const resolve = async (id: string, importer: string) =>
-        // eslint-disable-next-line @typescript-eslint/no-shadow
         new Promise<string | undefined>((resolve, reject) =>
           this.resolver.resolve({}, importer, id, {}, (err, filePath) => {
             if (err) {
@@ -120,7 +118,6 @@ class E2EPlguin implements EsmpackPlugin {
         const other = hash(depSpec, depVersion);
         if (!this.finishTasks.has(other) && !this.pendingTasks.has(other)) {
           this.pendingTasks.add(other);
-          // eslint-disable-next-line @typescript-eslint/no-shadow
           const depName = normalizePackageName(depSpec);
           try {
             const dir = require.resolve(`${depName}/package.json`, {

--- a/packages/toolkit/freeze/src/index.ts
+++ b/packages/toolkit/freeze/src/index.ts
@@ -27,7 +27,6 @@ export const createBistate = <State extends Record<string, any>>(
   };
 
   const handlers: ProxyHandler<State> = {
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     get: (target, key) => {
       if (key === BISTATE) {
         return internal;
@@ -54,7 +53,6 @@ export const createBistate = <State extends Record<string, any>>(
     deleteProperty: (current, key) => {
       throw new Error(`It's not allowed to delete property: ${key.toString()}`);
     },
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     has: (target, key) => {
       if (scapegoat) {
         return Reflect.has(scapegoat, key);
@@ -62,7 +60,6 @@ export const createBistate = <State extends Record<string, any>>(
         return Reflect.has(target, key);
       }
     },
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     ownKeys: target => {
       if (scapegoat) {
         return Reflect.ownKeys(scapegoat);
@@ -70,7 +67,6 @@ export const createBistate = <State extends Record<string, any>>(
         return Reflect.ownKeys(target);
       }
     },
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     getPrototypeOf: target => {
       if (scapegoat) {
         return Reflect.getPrototypeOf(scapegoat);
@@ -83,7 +79,6 @@ export const createBistate = <State extends Record<string, any>>(
         `bistate only supports plain object or array, it's not allowed to setPrototypeOf`,
       );
     },
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     getOwnPropertyDescriptor: (target, prop) => {
       if (scapegoat) {
         return Reflect.getOwnPropertyDescriptor(scapegoat, prop);
@@ -307,7 +302,6 @@ const getPathAndTop = <I>(
   const path: (string | symbol)[] = [key as any];
   let top: null | symbol = null;
 
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   const getParantpath = (current: any, parent: any) => {
     if (!parent) {
       return;
@@ -317,7 +311,6 @@ const getPathAndTop = <I>(
       return;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     for (const key in parent) {
       if (parent[key] === current) {
         path.push(key);

--- a/packages/toolkit/freeze/src/index.ts
+++ b/packages/toolkit/freeze/src/index.ts
@@ -4,7 +4,6 @@ export const createBistate = <State extends Record<string, any>>(
 ): State => {
   if (!isArray(initialState) && !isObject(initialState)) {
     throw new Error(
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `Expected initialState to be array or object, but got ${initialState}`,
     );
   }
@@ -288,7 +287,6 @@ export const freeze = <I>(input: I, key: keyof I) => {
   if (top) {
     store.freeze(top, path);
   } else {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`input: ${input} is not bistate`);
   }
 };
@@ -298,7 +296,6 @@ export const hasFreezed = <I>(input: I, key: keyof I) => {
   if (top) {
     return store.hasFreezed(top, path);
   } else {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`input: ${input} is not bistate`);
   }
 };

--- a/packages/toolkit/freeze/src/index.ts
+++ b/packages/toolkit/freeze/src/index.ts
@@ -155,7 +155,6 @@ export const isObject = (input: any): input is Record<string, any> => {
 };
 
 export const isThenable = (input: any): input is PromiseLike<any> =>
-  // eslint-disable-next-line promise/prefer-await-to-then
   Boolean(input && typeof input.then === 'function');
 
 const getBistateValue = (value: any, currentProxy: any, previousProxy: any) => {

--- a/packages/toolkit/load-config/tests/fixtures/config/es/dep-a.js
+++ b/packages/toolkit/load-config/tests/fixtures/config/es/dep-a.js
@@ -1,5 +1,3 @@
-/* eslint-disable filenames/match-exported */
 const source = { entries: { app: './src/App.jsx' } };
 
 export default source;
-/* eslint-enable filenames/match-exported */

--- a/packages/toolkit/load-config/tests/fixtures/config/es/modern.config.js
+++ b/packages/toolkit/load-config/tests/fixtures/config/es/modern.config.js
@@ -1,4 +1,3 @@
-/* eslint-disable filenames/match-exported */
 import source from './dep-a';
 
 const config = {
@@ -11,4 +10,3 @@ const config = {
 };
 
 export default config;
-/* eslint-enable filenames/match-exported */

--- a/packages/toolkit/load-config/tests/fixtures/config/file-param/a.config.js
+++ b/packages/toolkit/load-config/tests/fixtures/config/file-param/a.config.js
@@ -1,5 +1,3 @@
-/* eslint-disable filenames/match-exported */
 const config = { output: { polyfill: 'off' } };
 
 export default config;
-/* eslint-enable filenames/match-exported */

--- a/packages/toolkit/load-config/tests/fixtures/config/ts/modern.config.ts
+++ b/packages/toolkit/load-config/tests/fixtures/config/ts/modern.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable filenames/match-exported */
 import { source, runtime } from './dep-a';
 
 const config = {
@@ -8,4 +7,3 @@ const config = {
 };
 
 export default config;
-/* eslint-enable filenames/match-exported */

--- a/packages/toolkit/node-bundle-require/src/index.ts
+++ b/packages/toolkit/node-bundle-require/src/index.ts
@@ -71,7 +71,6 @@ export async function bundleRequire(filepath: string, options?: Options) {
       // https://github.com/evanw/esbuild/issues/1051#issuecomment-806325487
       {
         name: 'native-node-modules',
-        // eslint-disable-next-line @typescript-eslint/no-shadow
         setup(build) {
           // If a ".node" file is imported within a module in the "file" namespace, resolve
           // it to an absolute path and put it into the "node-file" virtual namespace.

--- a/packages/toolkit/plugin/src/manager/sync.ts
+++ b/packages/toolkit/plugin/src/manager/sync.ts
@@ -314,7 +314,6 @@ export const cloneHook = (hook: Hook): Hook => {
     return createPipeline();
   }
 
-  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   throw new Error(`Unknown hook: ${hook}`);
 };
 

--- a/packages/toolkit/plugin/src/waterfall/async.ts
+++ b/packages/toolkit/plugin/src/waterfall/async.ts
@@ -21,7 +21,7 @@ export const getAsyncBrook = <I>(input: AsyncBrookInput<I>) => {
   } else if (input && typeof input.middleware === 'function') {
     return input.middleware;
   }
-  // eslint-disable-next-line @typescript-eslint/no-base-to-string,@typescript-eslint/restrict-template-expressions
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string
   throw new Error(`${input} is not a AsyncBrook or { brook: AsyncBrook }`);
 };
 

--- a/packages/toolkit/plugin/src/waterfall/async.ts
+++ b/packages/toolkit/plugin/src/waterfall/async.ts
@@ -72,13 +72,11 @@ export const createAsyncWaterfall = <I = void>(): AsyncWaterfall<I> => {
   };
 
   const run: AsyncWaterfall<I>['run'] = (input, options) =>
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     pipeline.run(input, { ...options, onLast: input => input });
 
   const middleware: AsyncWaterfall<I>['middleware'] = input => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const container = useContainer();
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     return pipeline.run(input, { container, onLast: input => input });
   };
 

--- a/packages/toolkit/plugin/src/waterfall/sync.ts
+++ b/packages/toolkit/plugin/src/waterfall/sync.ts
@@ -73,13 +73,11 @@ export const createWaterfall = <I = void>(): Waterfall<I> => {
   };
 
   const run: Waterfall<I>['run'] = (input, options) =>
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     pipeline.run(input, { ...options, onLast: input => input });
 
   const middleware: Waterfall<I>['middleware'] = input => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const container = useContainer();
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     return pipeline.run(input, { container, onLast: input => input });
   };
 

--- a/packages/toolkit/plugin/src/waterfall/sync.ts
+++ b/packages/toolkit/plugin/src/waterfall/sync.ts
@@ -18,7 +18,7 @@ export const getBrook = <I>(input: BrookInput<I>) => {
   } else if (input && typeof input.middleware === 'function') {
     return input.middleware;
   }
-  // eslint-disable-next-line @typescript-eslint/no-base-to-string,@typescript-eslint/restrict-template-expressions
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string
   throw new Error(`${input} is not a Brook or { brook: Brook }`);
 };
 

--- a/packages/toolkit/plugin/src/workflow/async.ts
+++ b/packages/toolkit/plugin/src/workflow/async.ts
@@ -56,7 +56,6 @@ export const createAsyncWorkflow = <I = void, O = unknown>(): AsyncWorkflow<
   const run: AsyncWorkflow<I, O>['run'] = async (input, options) => {
     const result = pipeline.run(input, { ...options, onLast: () => [] });
     if (isPromise(result)) {
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       return result.then(result => result.filter(Boolean));
     } else {
       return result.filter(Boolean);

--- a/packages/toolkit/plugin/src/workflow/async.ts
+++ b/packages/toolkit/plugin/src/workflow/async.ts
@@ -56,7 +56,7 @@ export const createAsyncWorkflow = <I = void, O = unknown>(): AsyncWorkflow<
   const run: AsyncWorkflow<I, O>['run'] = async (input, options) => {
     const result = pipeline.run(input, { ...options, onLast: () => [] });
     if (isPromise(result)) {
-      // eslint-disable-next-line @typescript-eslint/no-shadow,promise/prefer-await-to-then
+      // eslint-disable-next-line @typescript-eslint/no-shadow
       return result.then(result => result.filter(Boolean));
     } else {
       return result.filter(Boolean);
@@ -79,11 +79,9 @@ const mapAsyncWorkerToAsyncMiddleware =
     [await worker(input), ...(await next(input))];
 
 function isPromise(obj: any): obj is Promise<any> {
-  /* eslint-disable promise/prefer-await-to-then */
   return (
     Boolean(obj) &&
     (typeof obj === 'object' || typeof obj === 'function') &&
     typeof obj.then === 'function'
   );
-  /* eslint-enable promise/prefer-await-to-then */
 }

--- a/packages/toolkit/plugin/src/workflow/parallel.ts
+++ b/packages/toolkit/plugin/src/workflow/parallel.ts
@@ -66,7 +66,6 @@ export const createParallelWorkflow = <
   };
 
   const run: ParallelWorkflow<I, O>['run'] = async (input, options) =>
-    // eslint-disable-next-line promise/prefer-await-to-then
     Promise.all(pipeline.run(input, { ...options, onLast: () => [] })).then(
       result => result.filter(Boolean),
     );

--- a/packages/toolkit/plugin/tests/async.test.ts
+++ b/packages/toolkit/plugin/tests/async.test.ts
@@ -81,7 +81,6 @@ describe('async manager', () => {
   });
 
   it('could without progress hook in plugin', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     const foo = createWaterfall<number>();
     const manager = createAsyncManager({ foo });
 
@@ -522,9 +521,7 @@ describe('async manager', () => {
 
   describe('useRunner', () => {
     it('should work well', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       const foo = createAsyncPipeline();
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       const bar = createAsyncPipeline();
       const manager = createAsyncManager({ foo, bar });
 
@@ -553,9 +550,7 @@ describe('async manager', () => {
     });
 
     it('should throw error useRunner out plugin hook', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       const foo = createAsyncPipeline();
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       const bar = createAsyncPipeline();
       const manager = createAsyncManager({ foo, bar });
 

--- a/packages/toolkit/plugin/tests/fixtures/async/base/fooManager.ts
+++ b/packages/toolkit/plugin/tests/fixtures/async/base/fooManager.ts
@@ -6,15 +6,14 @@ import {
 } from '../../../../src';
 
 // foo plugin
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type Config = {};
+export type Config = Record<string, unknown>;
 const defaultConfig = {};
 const ConfigContext = createContext<Config>(defaultConfig);
 export const useConfig = (): Config => {
   const config = ConfigContext.use().value;
 
   if (!config) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions,@typescript-eslint/no-base-to-string
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected modern config, but got: ${config}`);
   }
 

--- a/packages/toolkit/plugin/tests/fixtures/async/base/fooManager.ts
+++ b/packages/toolkit/plugin/tests/fixtures/async/base/fooManager.ts
@@ -13,7 +13,6 @@ export const useConfig = (): Config => {
   const config = ConfigContext.use().value;
 
   if (!config) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected modern config, but got: ${config}`);
   }
 

--- a/packages/toolkit/plugin/tests/fixtures/async/core/index.ts
+++ b/packages/toolkit/plugin/tests/fixtures/async/core/index.ts
@@ -14,7 +14,6 @@ export const useContext = (): CTX => {
   const context = CTXContext.use().value;
 
   if (!context) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected modern context, but got: ${context}`);
   }
 
@@ -28,7 +27,6 @@ export const useConfig = (): Config => {
   const config = ConfigContext.use().value;
 
   if (!config) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected modern config, but got: ${config}`);
   }
 
@@ -42,7 +40,6 @@ export const useWebpackConfig = (): WebpackConfig => {
   const webpackConfig = WebpackConfigContext.use().value;
 
   if (!webpackConfig) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected webpack config, but got: ${webpackConfig}`);
   }
 
@@ -56,7 +53,6 @@ export const useBabelConfig = (): BabelConfig => {
   const babelConfig = BabelConfigContext.use().value;
 
   if (!babelConfig) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected babel config, but got: ${babelConfig}`);
   }
 

--- a/packages/toolkit/plugin/tests/fixtures/async/core/index.ts
+++ b/packages/toolkit/plugin/tests/fixtures/async/core/index.ts
@@ -125,7 +125,6 @@ export const develop = async (context: CTX) => {
   });
   runner.prepare();
 
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   const { config, webpackConfig, babelConfig } = runner.config({
     config: defaultConfig,
     webpackConfig: defaultWebpackConfig,
@@ -149,7 +148,6 @@ export const build = async (context: CTX) => {
   });
   runner.prepare();
 
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   const { config, webpackConfig, babelConfig } = runner.config({
     config: defaultConfig,
     webpackConfig: defaultWebpackConfig,

--- a/packages/toolkit/plugin/tests/fixtures/async/core/index.ts
+++ b/packages/toolkit/plugin/tests/fixtures/async/core/index.ts
@@ -7,60 +7,56 @@ import {
   AsyncSetup,
 } from '../../../../src';
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type CTX = {};
+export type CTX = Record<string, unknown>;
 const defaultContext = {};
 const CTXContext = createContext<CTX>(defaultContext);
 export const useContext = (): CTX => {
   const context = CTXContext.use().value;
 
   if (!context) {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string,@typescript-eslint/restrict-template-expressions
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected modern context, but got: ${context}`);
   }
 
   return context;
 };
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type Config = {};
+export type Config = Record<string, unknown>;
 const defaultConfig = {};
 const ConfigContext = createContext<Config>(defaultConfig);
 export const useConfig = (): Config => {
   const config = ConfigContext.use().value;
 
   if (!config) {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string,@typescript-eslint/restrict-template-expressions
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected modern config, but got: ${config}`);
   }
 
   return config;
 };
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type WebpackConfig = {};
+export type WebpackConfig = Record<string, unknown>;
 const defaultWebpackConfig = {};
 const WebpackConfigContext = createContext<WebpackConfig>(defaultWebpackConfig);
 export const useWebpackConfig = (): WebpackConfig => {
   const webpackConfig = WebpackConfigContext.use().value;
 
   if (!webpackConfig) {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string,@typescript-eslint/restrict-template-expressions
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected webpack config, but got: ${webpackConfig}`);
   }
 
   return webpackConfig;
 };
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type BabelConfig = {};
+export type BabelConfig = Record<string, unknown>;
 const defaultBabelConfig = {};
 const BabelConfigContext = createContext<BabelConfig>(defaultBabelConfig);
 export const useBabelConfig = (): BabelConfig => {
   const babelConfig = BabelConfigContext.use().value;
 
   if (!babelConfig) {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string,@typescript-eslint/restrict-template-expressions
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected babel config, but got: ${babelConfig}`);
   }
 

--- a/packages/toolkit/plugin/tests/fixtures/sync/base/fooManager.ts
+++ b/packages/toolkit/plugin/tests/fixtures/sync/base/fooManager.ts
@@ -6,15 +6,14 @@ import {
 } from '../../../../src';
 
 // foo plugin
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type Config = {};
+export type Config = Record<string, unknown>;
 const defaultConfig = {};
 const ConfigContext = createContext<Config>(defaultConfig);
 export const useConfig = (): Config => {
   const config = ConfigContext.use().value;
 
   if (!config) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions,@typescript-eslint/no-base-to-string
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected modern config, but got: ${config}`);
   }
 

--- a/packages/toolkit/plugin/tests/fixtures/sync/base/fooManager.ts
+++ b/packages/toolkit/plugin/tests/fixtures/sync/base/fooManager.ts
@@ -13,7 +13,6 @@ export const useConfig = (): Config => {
   const config = ConfigContext.use().value;
 
   if (!config) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected modern config, but got: ${config}`);
   }
 

--- a/packages/toolkit/plugin/tests/fixtures/sync/core/index.ts
+++ b/packages/toolkit/plugin/tests/fixtures/sync/core/index.ts
@@ -7,60 +7,56 @@ import {
   PluginOptions,
 } from '../../../../src';
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type CTX = {};
+export type CTX = Record<string, unknown>;
 const defaultContext = {};
 const CTXContext = createContext<CTX>(defaultContext);
 export const useContext = (): CTX => {
   const context = CTXContext.use().value;
 
   if (!context) {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string,@typescript-eslint/restrict-template-expressions
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected modern context, but got: ${context}`);
   }
 
   return context;
 };
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type Config = {};
+export type Config = Record<string, unknown>;
 const defaultConfig = {};
 const ConfigContext = createContext<Config>(defaultConfig);
 export const useConfig = (): Config => {
   const config = ConfigContext.use().value;
 
   if (!config) {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string,@typescript-eslint/restrict-template-expressions
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected modern config, but got: ${config}`);
   }
 
   return config;
 };
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type WebpackConfig = {};
+export type WebpackConfig = Record<string, unknown>;
 const defaultWebpackConfig = {};
 const WebpackConfigContext = createContext<WebpackConfig>(defaultWebpackConfig);
 export const useWebpackConfig = (): WebpackConfig => {
   const webpackConfig = WebpackConfigContext.use().value;
 
   if (!webpackConfig) {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string,@typescript-eslint/restrict-template-expressions
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected webpack config, but got: ${webpackConfig}`);
   }
 
   return webpackConfig;
 };
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type BabelConfig = {};
+export type BabelConfig = Record<string, unknown>;
 const defaultBabelConfig = {};
 const BabelConfigContext = createContext<BabelConfig>(defaultBabelConfig);
 export const useBabelConfig = (): BabelConfig => {
   const babelConfig = BabelConfigContext.use().value;
 
   if (!babelConfig) {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string,@typescript-eslint/restrict-template-expressions
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected babel config, but got: ${babelConfig}`);
   }
 

--- a/packages/toolkit/plugin/tests/fixtures/sync/core/index.ts
+++ b/packages/toolkit/plugin/tests/fixtures/sync/core/index.ts
@@ -14,7 +14,6 @@ export const useContext = (): CTX => {
   const context = CTXContext.use().value;
 
   if (!context) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected modern context, but got: ${context}`);
   }
 
@@ -28,7 +27,6 @@ export const useConfig = (): Config => {
   const config = ConfigContext.use().value;
 
   if (!config) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected modern config, but got: ${config}`);
   }
 
@@ -42,7 +40,6 @@ export const useWebpackConfig = (): WebpackConfig => {
   const webpackConfig = WebpackConfigContext.use().value;
 
   if (!webpackConfig) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected webpack config, but got: ${webpackConfig}`);
   }
 
@@ -56,7 +53,6 @@ export const useBabelConfig = (): BabelConfig => {
   const babelConfig = BabelConfigContext.use().value;
 
   if (!babelConfig) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected babel config, but got: ${babelConfig}`);
   }
 

--- a/packages/toolkit/plugin/tests/fixtures/sync/core/index.ts
+++ b/packages/toolkit/plugin/tests/fixtures/sync/core/index.ts
@@ -120,7 +120,6 @@ export const develop = (context: CTX) => {
   });
   runner.prepare();
 
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   const { config, webpackConfig, babelConfig } = runner.config({
     config: defaultConfig,
     webpackConfig: defaultWebpackConfig,
@@ -144,7 +143,6 @@ export const build = (context: CTX) => {
   });
   runner.prepare();
 
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   const { config, webpackConfig, babelConfig } = runner.config({
     config: defaultConfig,
     webpackConfig: defaultWebpackConfig,

--- a/packages/toolkit/plugin/tests/pipeline.test.ts
+++ b/packages/toolkit/plugin/tests/pipeline.test.ts
@@ -588,7 +588,6 @@ describe('createPipeline', () => {
     it('should throw error when all middlewares calling next() and onLast is not exist', async () => {
       const pipeline = createAsyncPipeline<number, number>();
 
-      // eslint-disable-next-line promise/prefer-await-to-then
       pipeline.use((input, next) => Promise.resolve().then(() => next(input)));
 
       await expect(() => pipeline.run(0)).rejects.toThrowError();

--- a/packages/toolkit/plugin/tests/sync.test.ts
+++ b/packages/toolkit/plugin/tests/sync.test.ts
@@ -74,7 +74,6 @@ describe('sync manager', () => {
   });
 
   it('could without progress hook in plugin', () => {
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     const foo = createWaterfall<number>();
     const manager = createManager({ foo });
 
@@ -529,9 +528,7 @@ describe('sync manager', () => {
 
   describe('useRunner', () => {
     it('base usage', () => {
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       const foo = createPipeline();
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       const bar = createPipeline();
       const manager = createManager({ foo, bar });
 

--- a/packages/toolkit/utils/src/is/type.ts
+++ b/packages/toolkit/utils/src/is/type.ts
@@ -26,13 +26,11 @@ export function isPlainObject(obj: unknown): obj is Record<string, any> {
 }
 
 export function isPromise(obj: any): obj is Promise<any> {
-  /* eslint-disable promise/prefer-await-to-then */
   return (
     Boolean(obj) &&
     (typeof obj === 'object' || typeof obj === 'function') &&
     typeof obj.then === 'function'
   );
-  /* eslint-enable promise/prefer-await-to-then */
 }
 
 export function isRegExp(obj: any): obj is RegExp {

--- a/scripts/codemod/.eslintrc.js
+++ b/scripts/codemod/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: ['@modern-js'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.json'],
+  },
+};

--- a/scripts/codemod/src/main.ts
+++ b/scripts/codemod/src/main.ts
@@ -317,7 +317,6 @@ function fixTypesField(file: string) {
     return;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   const { types, publishConfig, main } = c;
   if (publishConfig?.main) {
     // 恢复之前的 main 配置

--- a/tests/utils/puppeteer_environment.js
+++ b/tests/utils/puppeteer_environment.js
@@ -1,4 +1,4 @@
-/* eslint-disable filenames/match-exported,no-useless-constructor */
+/* eslint-disable no-useless-constructor */
 // puppeteer_environment.js
 const { readFile } = require('fs').promises;
 const os = require('os');
@@ -37,4 +37,4 @@ class PuppeteerEnvironment extends NodeEnvironment {
 }
 
 module.exports = PuppeteerEnvironment;
-/* eslint-enable filenames/match-exported,no-useless-constructor */
+/* eslint-enable no-useless-constructor */

--- a/website/.eslintrc.js
+++ b/website/.eslintrc.js
@@ -7,7 +7,6 @@ module.exports = {
   },
   rules: {
     'babel/no-unused-expressions': 0,
-    'filenames/match-exported': 0,
     'react/jsx-filename-extension': 0,
   },
 };

--- a/website/docs/.eslintrc.json
+++ b/website/docs/.eslintrc.json
@@ -2,7 +2,6 @@
   "extends": ["@modern-js-app"],
   "rules": {
     "babel/no-unused-expressions": 0,
-    "filenames/match-exported": 0,
     "react/jsx-filename-extension": 0
   }
 }


### PR DESCRIPTION
# PR Details

1. remove some overly restrictive rules:

- `no-shadow`: this is not a recommended rule of typescript-eslint (https://typescript-eslint.io/rules/no-shadow/)
- `require-atomic-updates`: this rule is too complicated and not really useful.
- `promise/prefer-await-to-then`: `promise.then` is very common, we should not disable it.
- `filenames/match-exported`: there is no need to keep the variable name of export default consistent with the file name.
- `@typescript-eslint/restrict-template-expressions`: should allow `never` type.

2. optimize types for ban-types

## Motivation and Context

Simplify eslint config.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
