### PR TITLE
fix: ignore initial watching add events

### DIFF
--- a/.changeset/cyan-walls-fly.md
+++ b/.changeset/cyan-walls-fly.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/core': patch
+---
+
+fix: ignore initial watching add event

--- a/packages/cli/core/src/initWatcher.ts
+++ b/packages/cli/core/src/initWatcher.ts
@@ -38,6 +38,7 @@ export const initWatcher = async (
 
     const watcher = chokidar.watch(watched, {
       cwd: appDirectory,
+      ignoreInitial: true,
       ignorePermissionErrors: true,
       ignored: [
         /node_modules/,


### PR DESCRIPTION
# PR Details

Ignore initial add events of watching files

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
