### PR TITLE
chore: fix esmpack tsconfig, add DOM lib

### DIFF
--- a/packages/toolkit/esmpack/tsconfig.json
+++ b/packages/toolkit/esmpack/tsconfig.json
@@ -8,6 +8,7 @@
     "target": "ES2019" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "lib": [
+      "DOM",
       "ES2019"
     ] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
# PR Details

esmpack 的 tsconfig.json 没有继承 `@modern-js/tsconfig`，而是单独写了一份配置。

该配置中缺少了 `DOM` lib 的定义，导致构建时提示 window 不存在：

![image](https://user-images.githubusercontent.com/7237365/162694084-42661592-7579-4641-997f-1ed63cae56d8.png)

修复方式为加上 `DOM` lib，使 window 类型可以被正确识别。

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
