### PR TITLE
docs: fix output.inject default value

### DIFF
--- a/website/docs/apis/config/output/inject.md
+++ b/website/docs/apis/config/output/inject.md
@@ -21,7 +21,7 @@ MWA。
 
 ## 默认插入位置
 
-默认情况下，`dev` 可以看到 script 标签会插入到 `head` 中：
+执行 `dev` 命令，可以看到 script 标签默认在 `head` 标签内：
 
 ```html
 <html>
@@ -40,7 +40,7 @@ MWA。
 
 ## 插入至 body 标签
 
-配置如下时:
+按照如下配置，可以将 script 插入至 body 标签：
 
 ```javascript title="modern.config.js"
 import { defineConfig } from '@modern-js/app-tools';
@@ -52,7 +52,7 @@ export default defineConfig({
 });
 ```
 
-可以看到 script 标签会插入到 `body` 中：
+执行 `dev` 命令，可以看到 script 标签在 `body` 标签尾部：
 
 ```html
 <html>


### PR DESCRIPTION
# PR Details

The default value of `output.inject` is `head`, not `body`.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
