### PR TITLE
fix(hmr-client): should not bundle all utils

### DIFF
--- a/.changeset/clever-steaks-peel.md
+++ b/.changeset/clever-steaks-peel.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/hmr-client': patch
+---
+
+fix: should not bundle all utils

--- a/packages/server/hmr-client/src/index.ts
+++ b/packages/server/hmr-client/src/index.ts
@@ -1,8 +1,11 @@
 /**
  * This has been adapted from `create-react-app`, authored by Facebook, Inc.
  * see: https://github.com/facebookincubator/create-react-app/tree/master/packages/react-dev-utils
+ *
+ * Tips: this package will be bundled and running in the browser, do not import from the entry of @modern-js/utils.
  */
-import { stripAnsi, formatWebpackMessages } from '@modern-js/utils';
+import stripAnsi from '@modern-js/utils/strip-ansi';
+import { formatWebpackMessages } from '@modern-js/utils/format';
 import type webpack from 'webpack';
 import { createSocketUrl } from './createSocketUrl';
 

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -29,6 +29,10 @@
     "./constants": {
       "jsnext:source": "./src/constants.ts",
       "default": "./dist/constants.js"
+    },
+    "./strip-ansi": {
+      "jsnext:source": "./compiled/strip-ansi/index.js",
+      "default": "./compiled/strip-ansi/index.js"
     }
   },
   "typesVersions": {
@@ -38,6 +42,9 @@
       ],
       "constants": [
         "./dist/constants.d.ts"
+      ],
+      "strip-ansi": [
+        "./compiled/strip-ansi/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
# PR Details

The `hmr-client` package will be bundled and running in the browser, do not import from the entry of @modern-js/utils.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
