### PR TITLE
fix(eslint-config): remove max-params and max-statements rules

### DIFF
--- a/.changeset/serious-bottles-give.md
+++ b/.changeset/serious-bottles-give.md
@@ -1,0 +1,5 @@
+---
+'@modern-js-app/eslint-config': patch
+---
+
+feat: remove max-params and max-statements rule

--- a/packages/cli/babel-preset-base/src/plugins.ts
+++ b/packages/cli/babel-preset-base/src/plugins.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-statements */
 import { createBabelChain } from '@modern-js/babel-chain';
 import { IBaseBabelConfigOption } from '.';
 
@@ -187,5 +186,3 @@ export const getPluginsChain = (option: IBaseBabelConfigOption) => {
 
   return chain;
 };
-
-/* eslint-enable max-statements */

--- a/packages/cli/core/src/config/index.ts
+++ b/packages/cli/core/src/config/index.ts
@@ -83,7 +83,6 @@ const showAdditionalPropertiesError = (error: ErrorObject) => {
   }
 };
 
-/* eslint-disable  max-statements, max-params */
 export const resolveConfig = async (
   loaded: LoadedConfig,
   configs: UserConfig[],
@@ -163,5 +162,3 @@ export const resolveConfig = async (
 
   return resolved;
 };
-
-/* eslint-enable max-statements, max-params */

--- a/packages/cli/plugin-analyze/src/getClientRoutes.ts
+++ b/packages/cli/plugin-analyze/src/getClientRoutes.ts
@@ -57,7 +57,7 @@ const replaceWithAlias = (base: string, filePath: string, alias: string) =>
 
 const parents: Route[] = [];
 
-/* eslint-disable max-statements, no-param-reassign */
+/* eslint-disable no-param-reassign */
 const recursiveReadDir = ({
   dir,
   routes,
@@ -165,7 +165,7 @@ const recursiveReadDir = ({
     }
   }
 };
-/* eslint-enable max-statements, no-param-reassign */
+/* eslint-enable  no-param-reassign */
 
 const normalizeNestedRoutes = (
   nested: Route[],

--- a/packages/cli/plugin-analyze/src/index.ts
+++ b/packages/cli/plugin-analyze/src/index.ts
@@ -74,7 +74,6 @@ export default (): CliPlugin => ({
     let originEntrypoints: any[] = [];
 
     return {
-      // eslint-disable-next-line max-statements
       async prepare() {
         const appContext = api.useAppContext();
         const resolvedConfig = api.useResolvedConfigContext();

--- a/packages/cli/plugin-cdn-cos/src/index.ts
+++ b/packages/cli/plugin-cdn-cos/src/index.ts
@@ -9,7 +9,6 @@ export default (): CliPlugin => ({
   name: '@modern-js/plugin-cdn-cos',
 
   setup: api => ({
-    // eslint-disable-next-line max-statements
     async beforeDeploy() {
       console.info('');
       logger.info('Uploading resource to COS...');

--- a/packages/cli/plugin-cdn-oss/src/index.ts
+++ b/packages/cli/plugin-cdn-oss/src/index.ts
@@ -17,7 +17,6 @@ export default (): CliPlugin => ({
     const defaultRegion = 'cn-hangzhou';
 
     return {
-      // eslint-disable-next-line max-statements
       async beforeDeploy() {
         console.info('');
         logger.info('Uploading resource to OSS...');

--- a/packages/cli/plugin-changeset/src/commands/release.ts
+++ b/packages/cli/plugin-changeset/src/commands/release.ts
@@ -8,7 +8,7 @@ interface PublishOptions {
   ignoreScripts: boolean;
   gitChecks: boolean;
 }
-// eslint-disable-next-line max-statements
+
 export async function release(options: PublishOptions) {
   const appDir = process.cwd();
   const isMonorepo = isModernjsMonorepo(appDir);

--- a/packages/cli/plugin-docsite/src/features/build.ts
+++ b/packages/cli/plugin-docsite/src/features/build.ts
@@ -10,7 +10,6 @@ const gen: typeof import('./utils/generate-files') = Import.lazy(
   require,
 );
 
-// eslint-disable-next-line max-params
 export async function build(
   appDirectory: string,
   tmpDir: string,

--- a/packages/cli/plugin-docsite/src/features/dev.ts
+++ b/packages/cli/plugin-docsite/src/features/dev.ts
@@ -5,7 +5,6 @@ import WebpackDevServer from 'webpack-dev-server';
 import { chokidarFile } from './utils/chokidar';
 import { generateFiles } from './utils/generate-files';
 
-// eslint-disable-next-line max-params
 export async function dev(
   appDirectory: string,
   tmpDir: string,

--- a/packages/cli/plugin-docsite/src/features/utils/generate-files.ts
+++ b/packages/cli/plugin-docsite/src/features/utils/generate-files.ts
@@ -39,7 +39,6 @@ interface Node {
   children?: Node[];
 }
 
-// eslint-disable-next-line max-statements
 async function handleFile(
   appDirectory: string,
   tmpDir: string,

--- a/packages/cli/plugin-lambda-fc/src/index.ts
+++ b/packages/cli/plugin-lambda-fc/src/index.ts
@@ -10,7 +10,6 @@ export default (): CliPlugin => ({
 
   setup: api => {
     return {
-      // eslint-disable-next-line max-statements
       async afterDeploy() {
         console.info('');
         logger.info('Deploying application to Aliyun FC...');

--- a/packages/cli/plugin-lambda-scf/src/index.ts
+++ b/packages/cli/plugin-lambda-scf/src/index.ts
@@ -12,7 +12,6 @@ export default (): CliPlugin => ({
 
   setup: api => {
     return {
-      // eslint-disable-next-line max-statements
       async afterDeploy() {
         console.info('');
         logger.info('Deploying application to Tencent SCF...');

--- a/packages/cli/plugin-multiprocess/src/index.ts
+++ b/packages/cli/plugin-multiprocess/src/index.ts
@@ -37,7 +37,6 @@ export default (): CliPlugin => {
 
     setup: api => {
       return {
-        // eslint-disable-next-line max-statements
         afterBuild() {
           const { distDirectory, plugins } = api.useAppContext();
           const serverPluginPkgs = plugins

--- a/packages/cli/plugin-nocode/src/dev/proxy/index.ts
+++ b/packages/cli/plugin-nocode/src/dev/proxy/index.ts
@@ -2,7 +2,6 @@
 /* eslint-disable eslint-comments/disable-enable-pair */
 /* eslint-disable consistent-return */
 /* eslint-disable node/no-deprecated-api */
-/* eslint-disable max-statements */
 /**
  * create-react-app
  * Configuring the Proxy Manually

--- a/packages/cli/plugin-nocode/src/register/index.ts
+++ b/packages/cli/plugin-nocode/src/register/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-statements */
 import { promisify } from 'util';
 import path from 'path';
 import { fs, glob as globModule } from '@modern-js/utils';
@@ -212,5 +211,3 @@ export const register = async (
     process.exit(1);
   }
 };
-
-/* eslint-enable max-statements */

--- a/packages/cli/plugin-nocode/src/register/pre-validate.ts
+++ b/packages/cli/plugin-nocode/src/register/pre-validate.ts
@@ -1,6 +1,5 @@
 /* eslint-disable eslint-comments/disable-enable-pair */
 /* eslint-disable no-proto */
-/* eslint-disable max-params */
 /* eslint-disable func-name-matching */
 /* eslint-disable no-eval */
 import path from 'path';

--- a/packages/cli/plugin-ssg/src/index.ts
+++ b/packages/cli/plugin-ssg/src/index.ts
@@ -43,7 +43,6 @@ export default (): CliPlugin => ({
 
         return { entrypoint, routes };
       },
-      // eslint-disable-next-line max-statements
       async afterBuild() {
         const resolvedConfig = api.useResolvedConfigContext();
         const appContext = api.useAppContext();

--- a/packages/cli/plugin-ssg/tests/util.test.ts
+++ b/packages/cli/plugin-ssg/tests/util.test.ts
@@ -74,7 +74,6 @@ describe('test ssg util function', () => {
     expect(replaceWithAlias('/src', '/src/app.js', '@src')).toBe('@src/app.js');
   });
 
-  // eslint-disable-next-line max-statements
   it('should starndar user config correctly', () => {
     const opt0 = standardOptions(false, []);
     expect(opt0).toBeFalsy();

--- a/packages/cli/plugin-storybook/src/features/utils/webpackConfig.ts
+++ b/packages/cli/plugin-storybook/src/features/utils/webpackConfig.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-statements */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import path from 'path';
 import { fs, Import } from '@modern-js/utils';
@@ -270,4 +269,3 @@ export const getCustomWebpackConfigHandle: any = ({
   };
 };
 /* eslint-enable @typescript-eslint/no-unused-vars */
-/* eslint-enable max-statements */

--- a/packages/cli/plugin-unbundle/src/.eslintrc.json
+++ b/packages/cli/plugin-unbundle/src/.eslintrc.json
@@ -4,7 +4,6 @@
     "@typescript-eslint/no-loop-func": "off",
     "prefer-destructuring": "off",
     "consistent-return": "off",
-    "max-statements": "off",
     "max-depth": "off",
     "@typescript-eslint/member-ordering": "off",
     "max-lines": "off",

--- a/packages/cli/plugin-unbundle/src/client/.eslintrc.json
+++ b/packages/cli/plugin-unbundle/src/client/.eslintrc.json
@@ -2,7 +2,6 @@
   "extends": ["@modern-js-app"],
   "rules": {
     "babel/no-unused-expressions": "off",
-    "callback-return": "off",
-    "max-statements": "off"
+    "callback-return": "off"
   }
 }

--- a/packages/cli/plugin-unbundle/tests/client.test.ts
+++ b/packages/cli/plugin-unbundle/tests/client.test.ts
@@ -5,7 +5,6 @@ const { __addQuery__, updateStyle, removeStyle } = require('../src/client');
 
 // const MockedWebSocket = jest.mocked(WebSocket);
 
-// eslint-disable-next-line max-statements
 describe('plugin-unbundled client test', () => {
   let OriginalWebSocket: any;
   let originalLocation: any;
@@ -259,7 +258,6 @@ describe('plugin-unbundled client test', () => {
   });
 
   it('test "createHotContext"', () => {
-    // eslint-disable-next-line max-statements
     jest.isolateModules(() => {
       const { createHotContext } = require('../src/client');
       const hotmodule = createHotContext('myModule');

--- a/packages/cli/plugin-unbundle/tests/index.test.ts
+++ b/packages/cli/plugin-unbundle/tests/index.test.ts
@@ -40,7 +40,6 @@ describe('plugin-unbundle', () => {
     expect(result).toMatchSnapshot();
   });
 
-  // eslint-disable-next-line max-statements
   it('commands', async () => {
     const main = manager.clone().usePlugin(plugin);
     const runner = await main.init();

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -220,7 +220,6 @@ class BaseWebpackConfig {
     return publicPath;
   }
 
-  /* eslint-disable max-statements */
   loaders() {
     this.chain.module
       .rule('mjs')
@@ -465,7 +464,6 @@ class BaseWebpackConfig {
     return loaders;
   }
 
-  /* eslint-enable max-statements */
   plugins() {
     // progress bar
     process.stdout.isTTY &&
@@ -516,7 +514,6 @@ class BaseWebpackConfig {
     }
   }
 
-  /* eslint-disable  max-statements */
   resolve() {
     // resolve extensions
     const extensions = JS_RESOLVE_EXTENSIONS.filter(
@@ -591,8 +588,6 @@ class BaseWebpackConfig {
         .use(TsConfigPathsPlugin, [this.appDirectory]);
     }
   }
-
-  /* eslint-enable  max-statements */
 
   cache() {
     this.chain.cache({

--- a/packages/cli/webpack/src/config/client.ts
+++ b/packages/cli/webpack/src/config/client.ts
@@ -121,7 +121,6 @@ export class ClientWebpackConfig extends BaseWebpackConfig {
     ]);
   }
 
-  // eslint-disable-next-line max-statements
   plugins() {
     super.plugins();
 
@@ -222,7 +221,6 @@ export class ClientWebpackConfig extends BaseWebpackConfig {
         },
       ]);
     }
-    // eslint-enable-next-line max-statements
 
     this.chain
       .plugin('bottom-template')

--- a/packages/cli/webpack/src/plugins/module-scope-plugin.ts
+++ b/packages/cli/webpack/src/plugins/module-scope-plugin.ts
@@ -8,7 +8,6 @@
 import path from 'path';
 import { chalk } from '@modern-js/utils';
 
-/* eslint-disable max-statements */
 export class ModuleScopePlugin {
   appSrcs: Array<string | RegExp>;
 
@@ -128,4 +127,3 @@ export class ModuleScopePlugin {
     );
   }
 }
-/* eslint-enable max-statements */

--- a/packages/generator/generator-plugin/src/context/index.ts
+++ b/packages/generator/generator-plugin/src/context/index.ts
@@ -144,7 +144,6 @@ export class PluginContext {
     };
   }
 
-  // eslint-disable-next-line max-params
   handlePrepareContext(
     generator: GeneratorCore,
     solution: Solution | 'custom',

--- a/packages/generator/generator-plugin/src/context/input.ts
+++ b/packages/generator/generator-plugin/src/context/input.ts
@@ -176,7 +176,6 @@ export class PluginInputContext {
     }
   }
 
-  // eslint-disable-next-line max-statements
   setInput(
     key: string,
     field: string,

--- a/packages/generator/generator-plugin/src/index.ts
+++ b/packages/generator/generator-plugin/src/index.ts
@@ -150,7 +150,6 @@ export class GeneratorPlugin {
     return result;
   }
 
-  // eslint-disable-next-line max-params
   async handleForged(
     solution: Solution | 'custom',
     basePath: string,

--- a/packages/generator/generator-utils/src/index.ts
+++ b/packages/generator/generator-utils/src/index.ts
@@ -25,7 +25,6 @@ export {
 
 export { i18n } from './locale';
 
-// eslint-disable-next-line max-statements
 export async function getPackageVersion(
   packageName: string,
   registry?: string,

--- a/packages/generator/generators/bff-generator/src/index.ts
+++ b/packages/generator/generators/bff-generator/src/index.ts
@@ -31,7 +31,6 @@ function isEmptyApiDir(apiDir: string) {
   });
 }
 
-// eslint-disable-next-line max-statements
 export const handleTemplateFile = async (
   context: GeneratorContext,
   generator: GeneratorCore,

--- a/packages/generator/generators/electron-generator/src/index.ts
+++ b/packages/generator/generators/electron-generator/src/index.ts
@@ -11,7 +11,6 @@ import {
 } from '@modern-js/generator-utils';
 import { i18n, localeKeys } from './locale';
 
-// eslint-disable-next-line max-statements
 const handleTemplateFile = async (
   context: GeneratorContext,
   generator: GeneratorCore,

--- a/packages/generator/generators/module-generator/src/index.ts
+++ b/packages/generator/generators/module-generator/src/index.ts
@@ -35,7 +35,6 @@ const getGeneratorPath = (generator: string, distTag: string) => {
   return generator;
 };
 
-// eslint-disable-next-line max-statements
 export const handleTemplateFile = async (
   context: GeneratorContext,
   generator: GeneratorCore,
@@ -231,7 +230,6 @@ export const handleTemplateFile = async (
   return { projectPath };
 };
 
-// eslint-disable-next-line max-statements
 export default async (context: GeneratorContext, generator: GeneratorCore) => {
   const appApi = new AppAPI(context, generator);
 

--- a/packages/generator/generators/monorepo-generator/src/index.ts
+++ b/packages/generator/generators/monorepo-generator/src/index.ts
@@ -112,7 +112,6 @@ export const handleTemplateFile = async (
   );
 };
 
-// eslint-disable-next-line max-statements
 export default async (context: GeneratorContext, generator: GeneratorCore) => {
   const appApi = new AppAPI(context, generator);
 

--- a/packages/generator/generators/mwa-generator/src/index.ts
+++ b/packages/generator/generators/mwa-generator/src/index.ts
@@ -38,7 +38,6 @@ const getGeneratorPath = (generator: string, distTag: string) => {
   return generator;
 };
 
-// eslint-disable-next-line max-statements
 export const handleTemplateFile = async (
   context: GeneratorContext,
   generator: GeneratorCore,
@@ -250,7 +249,6 @@ export const handleTemplateFile = async (
   return { projectPath, isElectron: runWay === RunWay.Electron };
 };
 
-// eslint-disable-next-line max-statements
 export default async (context: GeneratorContext, generator: GeneratorCore) => {
   const appApi = new AppAPI(context, generator);
 

--- a/packages/generator/generators/server-generator/src/index.ts
+++ b/packages/generator/generators/server-generator/src/index.ts
@@ -30,7 +30,6 @@ function isEmptyServerDir(serverDir: string) {
   });
 }
 
-// eslint-disable-next-line max-statements
 const handleTemplateFile = async (
   context: GeneratorContext,
   generator: GeneratorCore,

--- a/packages/generator/new-action/src/module.ts
+++ b/packages/generator/new-action/src/module.ts
@@ -30,7 +30,7 @@ interface IModuleNewActionOption {
   config?: string;
   cwd?: string;
 }
-// eslint-disable-next-line max-statements
+
 export const ModuleNewAction = async (options: IModuleNewActionOption) => {
   const {
     locale = 'zh',

--- a/packages/generator/new-action/src/mwa.ts
+++ b/packages/generator/new-action/src/mwa.ts
@@ -31,7 +31,6 @@ interface IMWANewActionOption {
   cwd?: string;
 }
 
-// eslint-disable-next-line max-statements
 export const MWANewAction = async (options: IMWANewActionOption) => {
   const {
     locale = 'zh',

--- a/packages/generator/new-action/src/utils/index.ts
+++ b/packages/generator/new-action/src/utils/index.ts
@@ -23,7 +23,6 @@ export const readJson = (jsonPath: string) => {
   }
 };
 
-// eslint-disable-next-line max-params
 export function hasEnabledFunction(
   action: ActionFunction,
   dependencies: Record<string, string>,
@@ -37,13 +36,13 @@ export function hasEnabledFunction(
     return false;
   }
   if (dependencies[action]) {
-    return (packageJson.dependencies || {})[dependencies[action]];
+    return packageJson.dependencies?.[dependencies[action]];
   }
   if (peerDependencies[action]) {
-    return (packageJson.peerDependencies || {})[peerDependencies[action]];
+    return packageJson.peerDependencies?.[peerDependencies[action]];
   }
   if (!peerDependencies[action] && devDependencies[action]) {
-    return (packageJson.devDependencies || {})[devDependencies[action]];
+    return packageJson.devDependencies?.[devDependencies[action]];
   }
   return false;
 }

--- a/packages/review/eslint-config-app/base.js
+++ b/packages/review/eslint-config-app/base.js
@@ -1,5 +1,4 @@
-/* eslint-disable max-lines, no-magic-numbers */
-
+/* eslint-disable max-lines */
 const { jsExtensions } = require('./utils');
 
 module.exports = {
@@ -619,28 +618,11 @@ module.exports = {
         skipComments: true,
       },
     ],
-    // https://eslint.org/docs/rules/max-lines-per-function
-    'max-lines-per-function': 'off',
 
     /*
-     * 'max-lines-per-function': [
-     *   'error',
-     *   {
-     *     max: 50,
-     *     skipBlankLines: true,
-     *     skipComments: true,
-     *     IIFEs: true,
-     *   },
-     * ],
      * https://eslint.org/docs/rules/max-nested-callbacks
      */
     'max-nested-callbacks': ['warn', 4],
-    // https://eslint.org/docs/rules/max-params
-    'max-params': ['warn', 4],
-    // https://eslint.org/docs/rules/max-statements
-    'max-statements': ['warn', 20],
-    // https://eslint.org/docs/rules/max-statements-per-line
-    'max-statements-per-line': ['error', { max: 1 }],
     // https://eslint.org/docs/rules/multiline-comment-style
     // @TODO bug:
     // // class Foo {
@@ -1560,4 +1542,4 @@ module.exports = {
     },
   ],
 };
-/* eslint-enable max-lines, no-magic-numbers */
+/* eslint-enable max-lines */

--- a/packages/server/bff-utils/src/client/generate-client.ts
+++ b/packages/server/bff-utils/src/client/generate-client.ts
@@ -21,8 +21,6 @@ export type GenClientOptions = {
 
 export const DEFAULT_CLIENT_REQUEST_CREATOR = '@modern-js/create-request';
 
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable max-statements */
 export const generateClient = async ({
   resourcePath,
   source,

--- a/packages/server/bff-utils/tests/client.test.ts
+++ b/packages/server/bff-utils/tests/client.test.ts
@@ -110,7 +110,6 @@ export const post = createRequest('/:id/origin/foo', 'POST', process.env.PORT ||
   });
 
   describe('getMethodAndStatementFromName', () => {
-    // eslint-disable-next-line max-statements
     it('should support normal http method', () => {
       const result0 = getMethodAndStatementFromName('get');
 
@@ -187,7 +186,6 @@ export const post = createRequest('/:id/origin/foo', 'POST', process.env.PORT ||
       expect(result.value[1]).toBe('default');
     });
 
-    // eslint-disable-next-line max-statements
     it('should case insensitive at method and case sensitive at valuable name', () => {
       const result0 = getMethodAndStatementFromName('Get');
 

--- a/packages/server/create-request/src/node.ts
+++ b/packages/server/create-request/src/node.ts
@@ -16,9 +16,9 @@ let realAllowedHeaders: string[] = [];
 const originFetch = (...params: Parameters<typeof nodeFetch>) =>
   nodeFetch(...params).then(handleRes);
 
-export const configure = (options: IOptions<typeof nodeFetch>) => {
+export const configure = (options: IOptions) => {
   const { request, interceptor, allowedHeaders } = options;
-  realRequest = (request as Fetch) || originFetch;
+  realRequest = request || originFetch;
   if (interceptor && !request) {
     realRequest = interceptor(nodeFetch);
   }
@@ -39,7 +39,6 @@ export const createRequest: RequestCreator = (
   const keys: Key[] = [];
   pathToRegexp(path, keys);
 
-  // eslint-disable-next-line max-statements
   const sender: Sender = (...args) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const webRequestHeaders = useHeaders();

--- a/packages/server/plugin-egg/src/plugin.ts
+++ b/packages/server/plugin-egg/src/plugin.ts
@@ -37,7 +37,6 @@ const mockFn = (
   };
 };
 
-// eslint-disable-next-line max-statements
 const initApp = async (options: StartOptions): Promise<Application> => {
   options.baseDir = options.baseDir || process.cwd();
   options.mode = 'single';

--- a/packages/server/prod-server/src/server/modern-server.ts
+++ b/packages/server/prod-server/src/server/modern-server.ts
@@ -379,7 +379,6 @@ export class ModernServer implements ModernServerInterface {
 
   /* —————————————————————— private function —————————————————————— */
   // handler route.json, include api / csr / ssr
-  // eslint-disable-next-line max-statements
   private async routeHandler(context: ModernServerContext) {
     const { req, res } = context;
 
@@ -460,7 +459,6 @@ export class ModernServer implements ModernServerInterface {
     res.end(response);
   }
 
-  // eslint-disable-next-line max-statements
   private async injectMicroFE(
     context: ModernServerContext,
     templateAPI: ReturnType<typeof createTemplateAPI>,

--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -17,7 +17,6 @@ import type { BuildOptions } from '../utils/types';
 const WARN_AFTER_BUNDLE_GZIP_SIZE = 512 * 1024;
 const WARN_AFTER_CHUNK_GZIP_SIZE = 1024 * 1024;
 
-// eslint-disable-next-line max-statements
 export const build = async (api: PluginAPI, options?: BuildOptions) => {
   const resolvedConfig = api.useResolvedConfigContext();
   const appContext = api.useAppContext();

--- a/packages/solutions/module-tools/src/features/build/build.ts
+++ b/packages/solutions/module-tools/src/features/build/build.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-statements */
 import * as path from 'path';
 import * as os from 'os';
 import { execa, Import } from '@modern-js/utils';
@@ -103,5 +102,3 @@ export const buildSourceCode = async (
     process.exit(1);
   }
 };
-
-/* eslint-enable max-statements */

--- a/packages/solutions/module-tools/src/tasks/build-watch-style.ts
+++ b/packages/solutions/module-tools/src/tasks/build-watch-style.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-statements */
 import * as path from 'path';
 import type {
   NormalizedConfig,
@@ -264,4 +263,3 @@ const taskMain = async ({
     }
   });
 })();
-/* eslint-enable max-statements */

--- a/packages/solutions/module-tools/src/utils/copy.ts
+++ b/packages/solutions/module-tools/src/utils/copy.ts
@@ -9,7 +9,6 @@ const normalizePath: typeof import('normalize-path') = Import.lazy(
   require,
 );
 
-// eslint-disable-next-line max-statements
 export const copyTask = async (option: {
   modernConfig: NormalizedConfig;
   appContext: IAppContext;

--- a/packages/solutions/monorepo-tools/src/dag/utils.ts
+++ b/packages/solutions/monorepo-tools/src/dag/utils.ts
@@ -71,7 +71,6 @@ export const recursiveGetDependency = (
 };
 
 // 拓扑排序
-// eslint-disable-next-line max-statements
 export const sortProjects = (projects: IProjectNode[]) => {
   const sortedQueue = []; // 排好序的队列
   let readyIntoSortedQueue = []; // 用来准备放入 sortedQueue的数组

--- a/packages/solutions/monorepo-tools/src/features/build/index.ts
+++ b/packages/solutions/monorepo-tools/src/features/build/index.ts
@@ -22,7 +22,7 @@ const createTask = (
     disableContentHash = false,
     enableGitHash = false,
   } = config;
-  // eslint-disable-next-line max-statements
+
   const task = async (project: IProjectNode) => {
     console.info('run ', project.name);
     // const taskTimeLog = timeLog.initTimeLog({ scope: '' });

--- a/packages/toolkit/create/src/createAction.ts
+++ b/packages/toolkit/create/src/createAction.ts
@@ -22,7 +22,6 @@ type RunnerTask = Array<{
 const REPO_GENERAROE = '@modern-js/repo-generator';
 // const GENERATOR_PLUGIN = '@modern-js/generator-plugin-plugin';
 
-// eslint-disable-next-line max-statements
 function getDefaultConfing(
   projectDir: string = path.basename(process.cwd()),
   options: Options,

--- a/packages/toolkit/esmpack/.eslintrc.json
+++ b/packages/toolkit/esmpack/.eslintrc.json
@@ -7,7 +7,6 @@
     "import/no-commonjs": "off",
     "prefer-arrow-callback": "off",
     "prefer-destructuring": "off",
-    "max-statements": "off",
     "max-classes-per-file": "off",
     "no-inner-declarations": "off",
     "max-depth": "off",

--- a/packages/toolkit/esmpack/e2e/utils/e2ePlugin.ts
+++ b/packages/toolkit/esmpack/e2e/utils/e2ePlugin.ts
@@ -57,7 +57,6 @@ class E2EPlguin implements EsmpackPlugin {
       await this.initP;
     });
 
-    // eslint-disable-next-line max-statements
     compiler.hooks.afterCompile.tapPromise(pluginName, async compilation => {
       const spec = compilation.specifier;
       if (!compilation.manifest?.version) {

--- a/packages/toolkit/freeze/src/index.ts
+++ b/packages/toolkit/freeze/src/index.ts
@@ -194,7 +194,6 @@ const fillObjectBistate = (
   target: any,
   scapegoat: any,
   previousProxy: any,
-  // eslint-disable-next-line max-params
 ) => {
   for (const key in initialObject) {
     const value = getBistateValue(
@@ -213,7 +212,6 @@ const fillArrayBistate = (
   target: any,
   scapegoat: any,
   previousProxy: any,
-  // eslint-disable-next-line max-params
 ) => {
   for (let i = 0; i < initialArray.length; i++) {
     const item = getBistateValue(initialArray[i], currentProxy, previousProxy);

--- a/packages/toolkit/utils/src/format.ts
+++ b/packages/toolkit/utils/src/format.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-param-reassign */
-/* eslint-disable max-statements */
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
  *
@@ -128,7 +127,6 @@ function formatWebpackMessages(json: StatsCompilation): {
 }
 
 export { formatWebpackMessages };
-/* eslint-enable max-statements */
 /* eslint-enable no-param-reassign */
 
 function formatProxyOptions(proxyOptions: BffProxyOptions) {

--- a/packages/toolkit/utils/src/logger.ts
+++ b/packages/toolkit/utils/src/logger.ts
@@ -94,7 +94,6 @@ class Logger {
     }
   }
 
-  // eslint-disable-next-line max-statements
   private _log(type: string, message?: LogMsg) {
     if (message === undefined) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
# PR Details

Remove `max-params` and `max-statements` rules

These two rules are disabled in the popular eslint libraries:

- https://github.com/airbnb/javascript/blob/d8cb404da74c302506f91e5928f30cc75109e74d/packages/eslint-config-airbnb-base/rules/style.js#L228
- https://github.com/google/eslint-config-google/blob/cc39cf57d36b071985a15ccc97594cf12f52ef41/index.js#L244
- https://github.com/standard/eslint-config-standard

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
