### PR TITLE
fix: hoc hook break in conventional routes

### DIFF
--- a/.changeset/dull-nails-wink.md
+++ b/.changeset/dull-nails-wink.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-router': patch
+'@modern-js/runtime-core': patch
+---
+
+fix: hoc hook break in conventional routes

--- a/packages/cli/plugin-router/src/runtime/plugin.tsx
+++ b/packages/cli/plugin-router/src/runtime/plugin.tsx
@@ -96,11 +96,9 @@ export const routerPlugin = ({
 
               return (props: any) => (
                 <Router history={history}>
-                  {routesConfig ? (
-                    renderRoutes(routesConfig, props)
-                  ) : (
-                    <App {...props} />
-                  )}
+                  <App {...props}>
+                    {routesConfig ? renderRoutes(routesConfig, props) : null}
+                  </App>
                 </Router>
               );
             }
@@ -121,11 +119,9 @@ export const routerPlugin = ({
                   basename={basename === '/' ? '' : basename}
                   location={location}
                   context={routerContext}>
-                  {routesConfig ? (
-                    renderRoutes(routesConfig, props)
-                  ) : (
-                    <App {...props} />
-                  )}
+                  <App {...props}>
+                    {routesConfig ? renderRoutes(routesConfig, props) : null}
+                  </App>
                 </StaticRouter>
               );
             };

--- a/packages/runtime/src/compatible.tsx
+++ b/packages/runtime/src/compatible.tsx
@@ -29,7 +29,11 @@ export const createApp = ({ plugins }: CreateAppOptions) => {
     const container = createContainer({ App: AppComponentContext.create(App) });
 
     const WrapperComponent: React.ComponentType<any> = props => {
-      const element = React.createElement(App, { ...props }, props.children);
+      const element = React.createElement(
+        App || React.Fragment,
+        { ...props },
+        props.children,
+      );
       const context = useContext(RuntimeReactContext);
 
       return runner.provide(


### PR DESCRIPTION
# PR Details

Hoc hook of the runtime plugin would break now in conventional routes. This PR would fix it. 

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
