### PR TITLE
fix(core): commander.commandsMap typing not work

### DIFF
--- a/.changeset/tasty-ducks-bathe.md
+++ b/.changeset/tasty-ducks-bathe.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/core': patch
+'@modern-js/plugin-express': patch
+'@modern-js/app-tools': patch
+'@modern-js/module-tools': patch
+'@modern-js/monorepo-tools': patch
+---
+
+fix: commander.commandsMap typing not work

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.7.0",
+  "version": "1.7.1",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/core/src/index.ts
+++ b/packages/cli/core/src/index.ts
@@ -249,3 +249,9 @@ const createCli = () => {
 export const cli = createCli();
 
 export { initAppDir, initAppContext };
+
+declare module '@modern-js/utils/compiled/commander' {
+  export interface Command {
+    commandsMap: Map<string, Command>;
+  }
+}

--- a/packages/cli/core/src/utils/commander.ts
+++ b/packages/cli/core/src/utils/commander.ts
@@ -1,11 +1,5 @@
 import { program, Command } from '@modern-js/utils';
 
-declare module '@modern-js/utils/compiled/commander' {
-  export interface Command {
-    commandsMap: Map<string, Command>;
-  }
-}
-
 export function initCommandsMap() {
   if (!program.hasOwnProperty('commandsMap')) {
     Object.defineProperty(program, 'commandsMap', {

--- a/packages/server/plugin-express/package.json
+++ b/packages/server/plugin-express/package.json
@@ -52,7 +52,7 @@
     "type-is": "^1.6.18"
   },
   "devDependencies": {
-    "@modern-js/core": "workspace:^1.7.0",
+    "@modern-js/core": "workspace:^1.7.1",
     "@modern-js/server-core": "workspace:^1.3.0",
     "@modern-js/server-utils": "workspace:^1.2.2",
     "@scripts/build": "workspace:*",

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7",
-    "@modern-js/core": "workspace:^1.7.0",
+    "@modern-js/core": "workspace:^1.7.1",
     "@modern-js/i18n-cli-language-detector": "workspace:^1.2.1",
     "@modern-js/new-action": "workspace:^1.3.5",
     "@modern-js/node-bundle-require": "workspace:^1.3.0",

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -63,7 +63,7 @@
     "@babel/types": "^7.17.0",
     "@modern-js/babel-compiler": "workspace:^1.2.2",
     "@modern-js/babel-preset-module": "workspace:^1.3.1",
-    "@modern-js/core": "workspace:^1.7.0",
+    "@modern-js/core": "workspace:^1.7.1",
     "@modern-js/css-config": "workspace:^1.2.3",
     "@modern-js/i18n-cli-language-detector": "workspace:^1.2.1",
     "@modern-js/new-action": "workspace:^1.3.5",

--- a/packages/solutions/monorepo-tools/package.json
+++ b/packages/solutions/monorepo-tools/package.json
@@ -42,7 +42,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@modern-js/core": "workspace:^1.7.0",
+    "@modern-js/core": "workspace:^1.7.1",
     "@babel/runtime": "^7",
     "@modern-js/i18n-cli-language-detector": "workspace:^1.2.1",
     "@modern-js/new-action": "workspace:^1.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3285,7 +3285,7 @@ importers:
       '@modern-js/adapter-helpers': workspace:^1.2.1
       '@modern-js/bff-runtime': workspace:^1.2.1
       '@modern-js/bff-utils': workspace:^1.2.2
-      '@modern-js/core': workspace:^1.7.0
+      '@modern-js/core': workspace:^1.7.1
       '@modern-js/server-core': workspace:^1.3.0
       '@modern-js/server-utils': workspace:^1.2.2
       '@modern-js/types': workspace:^1.4.0
@@ -3730,7 +3730,7 @@ importers:
   packages/solutions/app-tools:
     specifiers:
       '@babel/runtime': ^7
-      '@modern-js/core': workspace:^1.7.0
+      '@modern-js/core': workspace:^1.7.1
       '@modern-js/i18n-cli-language-detector': workspace:^1.2.1
       '@modern-js/new-action': workspace:^1.3.5
       '@modern-js/node-bundle-require': workspace:^1.3.0
@@ -3797,7 +3797,7 @@ importers:
       '@modern-js/babel-chain': workspace:^1.2.1
       '@modern-js/babel-compiler': workspace:^1.2.2
       '@modern-js/babel-preset-module': workspace:^1.3.1
-      '@modern-js/core': workspace:^1.7.0
+      '@modern-js/core': workspace:^1.7.1
       '@modern-js/css-config': workspace:^1.2.3
       '@modern-js/i18n-cli-language-detector': workspace:^1.2.1
       '@modern-js/new-action': workspace:^1.3.5
@@ -3880,7 +3880,7 @@ importers:
   packages/solutions/monorepo-tools:
     specifiers:
       '@babel/runtime': ^7
-      '@modern-js/core': workspace:^1.7.0
+      '@modern-js/core': workspace:^1.7.1
       '@modern-js/i18n-cli-language-detector': workspace:^1.2.1
       '@modern-js/new-action': workspace:^1.3.5
       '@modern-js/plugin': workspace:^1.3.2


### PR DESCRIPTION
# PR Details

- Move `commandsMap` declaration to `index.ts`, makes it taking effect by default.
- Publish `@modern-js/core` v1.7.1

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
