### PR TITLE
fix(plugin-garfish): should not import from @modern-js/utils

### DIFF
--- a/.changeset/twelve-paws-battle.md
+++ b/.changeset/twelve-paws-battle.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-garfish': patch
+---
+
+fix: should not import from @modern-js/utils

--- a/packages/cli/plugin-garfish/package.json
+++ b/packages/cli/plugin-garfish/package.json
@@ -59,7 +59,9 @@
   "dependencies": {
     "@babel/runtime": "^7",
     "@modern-js/utils": "workspace:^1.4.1",
+    "@types/debug": "^4.1.7",
     "@types/react-loadable": "^5.5.6",
+    "debug": "^4.3.2",
     "garfish": "^1.3.3",
     "hoist-non-react-statics": "^3.3.2",
     "react-loadable": "^5.5.0"

--- a/packages/cli/plugin-garfish/package.json
+++ b/packages/cli/plugin-garfish/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.4.6",
+  "version": "1.4.7",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "typesVersions": {

--- a/packages/cli/plugin-garfish/src/util.ts
+++ b/packages/cli/plugin-garfish/src/util.ts
@@ -1,7 +1,10 @@
-import { createDebugger } from '@modern-js/utils';
+/**
+ * Tips: this package will be bundled and running in the browser, do not import from `@modern-js/utils`.
+ */
+import createDebug from 'debug';
 import { ModuleInfo } from './runtime';
 
-export const logger = createDebugger('plugin-garfish');
+export const logger = createDebug('modern-js:plugin-garfish');
 
 export const SUBMODULE_APP_COMPONENT_KEY = 'SubModuleComponent';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -807,12 +807,14 @@ importers:
       '@testing-library/react': ^12.0.0
       '@testing-library/react-hooks': ^7.0.1
       '@testing-library/user-event': ^13.5.0
+      '@types/debug': ^4.1.7
       '@types/hoist-non-react-statics': ^3.3.1
       '@types/jest': ^26.0.24
       '@types/node': ^14
       '@types/react': ^17
       '@types/react-dom': ^17
       '@types/react-loadable': ^5.5.6
+      debug: ^4.3.2
       garfish: ^1.3.3
       hoist-non-react-statics: ^3.3.2
       jest: ^27
@@ -826,7 +828,9 @@ importers:
     dependencies:
       '@babel/runtime': 7.16.7
       '@modern-js/utils': link:../../toolkit/utils
+      '@types/debug': 4.1.7
       '@types/react-loadable': 5.5.6
+      debug: 4.3.4
       garfish: 1.3.3
       hoist-non-react-statics: 3.3.2
       react-loadable: 5.5.0_react@17.0.2
@@ -14777,7 +14781,6 @@ packages:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
     dependencies:
       '@types/ms': 0.7.31
-    dev: true
 
   /@types/depd/1.1.32:
     resolution: {integrity: sha512-kB2cpXs3A0TGWl4a4h74yIwvclYZUTW6Irpee/3Dc1s4Cr5rGPHtpGPpBBpEV1MaKH5z/oul+57oDkEkeRXRnw==}
@@ -15177,7 +15180,6 @@ packages:
 
   /@types/ms/0.7.31:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
-    dev: true
 
   /@types/node-fetch/2.5.12:
     resolution: {integrity: sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==}
@@ -20400,7 +20402,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /decamelize-keys/1.1.0:
     resolution: {integrity: sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=}


### PR DESCRIPTION
# PR Details

`plugin-garfish/utils.ts` will be bundled and running in the browser, should not import from `@modern-js/utils`.

## Related Issue

https://github.com/modern-js-dev/modern.js/issues/911

## Related PR

https://github.com/modern-js-dev/modern.js/pull/883

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
