### PR TITLE
fix(server): remove unused webpack/hot/dev-server entry

### DIFF
--- a/.changeset/thin-impalas-talk.md
+++ b/.changeset/thin-impalas-talk.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/server': patch
+---
+
+fix: remove unused webpack/hot/dev-server entry

--- a/packages/server/server/src/dev-tools/dev-server-plugin.ts
+++ b/packages/server/server/src/dev-tools/dev-server-plugin.ts
@@ -22,8 +22,7 @@ export default class DevServerPlugin {
     const clientEntry = `${require.resolve(
       '@modern-js/hmr-client',
     )}?${host}${path}${port}`;
-    const hotEntry = require.resolve('webpack/hot/dev-server');
-    const additionalEntries = [clientEntry, hotEntry];
+    const additionalEntries = [clientEntry];
 
     // use a hook to add entries if available
     for (const additionalEntry of additionalEntries) {
@@ -37,7 +36,6 @@ export default class DevServerPlugin {
     compilerOptions.plugins = compilerOptions.plugins || [];
 
     if (
-      hotEntry &&
       !compilerOptions.plugins.find(
         p => p.constructor === Webpack.HotModuleReplacementPlugin,
       )

--- a/packages/server/server/tests/dev.test.ts
+++ b/packages/server/server/tests/dev.test.ts
@@ -88,14 +88,13 @@ describe('test dev tools', () => {
       liveReload: true,
     }).apply(compiler);
 
-    // expect(compiler.options.entry)
     const entryPluginHook = compiler.hooks.compilation.taps.filter(
       tap => tap.name === 'EntryPlugin',
     );
     const hotPluginHook = compiler.hooks.compilation.taps.filter(
       tap => tap.name === 'HotModuleReplacementPlugin',
     );
-    expect(entryPluginHook.length).toBe(3);
+    expect(entryPluginHook.length).toBe(2);
     expect(hotPluginHook.length).toBe(1);
   });
 
@@ -117,14 +116,13 @@ describe('test dev tools', () => {
       liveReload: true,
     }).apply(compiler);
 
-    // expect(compiler.options.entry)
     const entryPluginHook = compiler.hooks.compilation.taps.filter(
       tap => tap.name === 'EntryPlugin',
     );
     const hotPluginHook = compiler.hooks.compilation.taps.filter(
       tap => tap.name === 'HotModuleReplacementPlugin',
     );
-    expect(entryPluginHook.length).toBe(3);
+    expect(entryPluginHook.length).toBe(2);
     expect(hotPluginHook.length).toBe(1);
   });
 });


### PR DESCRIPTION
# PR Details

## Details

移除 `webpack/hot/dev-server`。

## Reason

`webpack/hot/dev-server` 中包含了一段与 `webpack-dev-server` 配套的运行时代码，由于 modern.js 未使用 `webpack-dev-server`，因此这段代码没有实际的作用（反而会影响依赖预打包）。

移除后，HMR 功能依然由 `hmr-client` 正常提供。

`create-react-app` 中默认也不需要引入这段代码：

![image](https://user-images.githubusercontent.com/7237365/163911576-3ba60667-facb-4fdf-8a4f-22bdc0218ba8.png)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
