### PR TITLE
fix: remove hmr log breaks integration test

### DIFF
--- a/tests/integration/alias-set/test/index.test.js
+++ b/tests/integration/alias-set/test/index.test.js
@@ -34,12 +34,10 @@ describe('test build', () => {
         FAST_REFRESH: 'false',
       },
     );
-    const logs = [];
     const errors = [];
 
     const browser = await puppeteer.launch({ headless: true, dumpio: true });
     const page = await browser.newPage();
-    page.on('console', msg => logs.push(msg.text()));
     page.on('pageerror', error => errors.push(error.text));
     await page.goto(`http://localhost:${appPort}`, {
       waitUntil: ['networkidle0'],
@@ -49,7 +47,6 @@ describe('test build', () => {
     const targetText = await page.evaluate(el => el.textContent, root);
     expect(targetText.trim()).toEqual('Hello Modern.js! 1');
     expect(errors.length).toEqual(0);
-    expect(logs[0]).toEqual('[HMR] Waiting for update signal from WDS...');
 
     browser.close();
     await killApp(app);

--- a/tests/integration/new-mwa-app/tests/index.test.js
+++ b/tests/integration/new-mwa-app/tests/index.test.js
@@ -20,12 +20,8 @@ describe('test dev', () => {
   it(`should render page correctly`, async () => {
     const appPort = await getPort();
     const app = await launchApp(appDir, appPort, {}, {});
-    const logs = [];
     const errors = [];
 
-    page.on('console', msg => {
-      logs.push(msg.text());
-    });
     page.on('pageerror', error => {
       errors.push(error.message);
     });
@@ -37,7 +33,6 @@ describe('test dev', () => {
     const targetText = await page.evaluate(el => el.textContent, root);
     expect(targetText.trim()).toEqual('Get started by editing src/App.tsx');
     expect(errors.length).toEqual(0);
-    expect(logs).toEqual(['[HMR] Waiting for update signal from WDS...']);
 
     await killApp(app);
   });


### PR DESCRIPTION
# PR Details

This [PR](https://github.com/modern-js-dev/modern.js/pull/915) removed `webpack/hot/dev-server`，and the related test cases in integration tests should be removed too.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
