### PR TITLE
chore: adjust webpack version

### DIFF
--- a/packages/cli/plugin-docsite/package.json
+++ b/packages/cli/plugin-docsite/package.json
@@ -45,7 +45,7 @@
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
     "@modern-js/utils": "workspace:^1.5.0",
-    "@modern-js/webpack": "workspace:^1.5.5",
+    "@modern-js/webpack": "workspace:^1.5.6",
     "antd": "^4.16.13",
     "core-js": "^3.17.2",
     "github-slugger": "^1.4.0",

--- a/packages/cli/plugin-nocode/package.json
+++ b/packages/cli/plugin-nocode/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@babel/runtime": "^7",
     "@modern-js/utils": "workspace:^1.5.0",
-    "@modern-js/webpack": "workspace:^1.5.5",
+    "@modern-js/webpack": "workspace:^1.5.6",
     "axios": "^0.24.0",
     "axios-retry": "^3.2.4",
     "body-parser": "^1.19.0",

--- a/packages/cli/plugin-storybook/package.json
+++ b/packages/cli/plugin-storybook/package.json
@@ -49,7 +49,7 @@
     "@modern-js/plugin-router": "workspace:^1.2.10",
     "@modern-js/plugin-state": "workspace:^1.2.4",
     "@modern-js/utils": "workspace:^1.5.0",
-    "@modern-js/webpack": "workspace:^1.5.5",
+    "@modern-js/webpack": "workspace:^1.5.6",
     "@storybook/addon-actions": "^6.3.8",
     "@storybook/addon-essentials": "^6.3.8",
     "@storybook/addon-links": "^6.3.8",

--- a/packages/cli/plugin-testing/package.json
+++ b/packages/cli/plugin-testing/package.json
@@ -94,7 +94,7 @@
     "@modern-js/babel-compiler": "workspace:^1.2.3",
     "@modern-js/testing": "workspace:^1.4.3",
     "@modern-js/utils": "workspace:^1.5.0",
-    "@modern-js/webpack": "workspace:^1.5.5",
+    "@modern-js/webpack": "workspace:^1.5.6",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
     "@modern-js/testing-plugin-bff": "workspace:^1.4.0"

--- a/packages/cli/webpack/package.json
+++ b/packages/cli/webpack/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.5.5",
+  "version": "1.5.6",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/review/testing/package.json
+++ b/packages/review/testing/package.json
@@ -40,7 +40,7 @@
     "@modern-js/babel-preset-app": "workspace:^1.2.7",
     "@modern-js/plugin": "workspace:^1.3.3",
     "@modern-js/utils": "workspace:^1.5.0",
-    "@modern-js/webpack": "workspace:^1.5.5",
+    "@modern-js/webpack": "workspace:^1.5.6",
     "babel-jest": "^27.0.6",
     "enhanced-resolve": "^5.8.3",
     "identity-obj-proxy": "^3.0.0",

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -77,7 +77,7 @@
     "@modern-js/server": "workspace:^1.4.10",
     "@modern-js/types": "workspace:^1.5.0",
     "@modern-js/utils": "workspace:^1.5.0",
-    "@modern-js/webpack": "workspace:^1.5.5",
+    "@modern-js/webpack": "workspace:^1.5.6",
     "inquirer": "^8.2.0",
     "webpack": "^5.71.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -625,7 +625,7 @@ importers:
       '@mdx-js/react': ^1.6.22
       '@modern-js/core': workspace:*
       '@modern-js/utils': workspace:^1.5.0
-      '@modern-js/webpack': workspace:^1.5.5
+      '@modern-js/webpack': workspace:^1.5.6
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@types/core-js': ^2.5.5
@@ -1079,7 +1079,7 @@ importers:
       '@babel/runtime': ^7
       '@modern-js/core': workspace:*
       '@modern-js/utils': workspace:^1.5.0
-      '@modern-js/webpack': workspace:^1.5.5
+      '@modern-js/webpack': workspace:^1.5.6
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@types/body-parser': ^1.19.1
@@ -1515,7 +1515,7 @@ importers:
       '@modern-js/runtime': workspace:^1.2.6
       '@modern-js/runtime-core': workspace:*
       '@modern-js/utils': workspace:^1.5.0
-      '@modern-js/webpack': workspace:^1.5.5
+      '@modern-js/webpack': workspace:^1.5.6
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@storybook/addon-actions': ^6.3.8
@@ -1627,7 +1627,7 @@ importers:
       '@modern-js/testing': workspace:^1.4.3
       '@modern-js/testing-plugin-bff': workspace:^1.4.0
       '@modern-js/utils': workspace:^1.5.0
-      '@modern-js/webpack': workspace:^1.5.5
+      '@modern-js/webpack': workspace:^1.5.6
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@testing-library/jest-dom': ^5.14.1
@@ -2910,7 +2910,7 @@ importers:
       '@modern-js/core': workspace:*
       '@modern-js/plugin': workspace:^1.3.3
       '@modern-js/utils': workspace:^1.5.0
-      '@modern-js/webpack': workspace:^1.5.5
+      '@modern-js/webpack': workspace:^1.5.6
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@types/jest': ^27.4.0
@@ -3750,7 +3750,7 @@ importers:
       '@modern-js/server-core': workspace:^1.3.1
       '@modern-js/types': workspace:^1.5.0
       '@modern-js/utils': workspace:^1.5.0
-      '@modern-js/webpack': workspace:^1.5.5
+      '@modern-js/webpack': workspace:^1.5.6
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@types/inquirer': ^8.2.0


### PR DESCRIPTION
# PR Details

I released 1.5.5 to beta by mistake, so adjust the next version to 1.5.6.

![image](https://user-images.githubusercontent.com/7237365/164485599-b4f850a9-31bb-488e-b787-c59ad353f1e9.png)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
