### PR TITLE
fix(webpack): failed to read property of compileOptions

### DIFF
--- a/.changeset/purple-dancers-rescue.md
+++ b/.changeset/purple-dancers-rescue.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): failed to read property of compileOptions

--- a/packages/cli/webpack/src/plugins/ts-config-paths-plugin.ts
+++ b/packages/cli/webpack/src/plugins/ts-config-paths-plugin.ts
@@ -33,7 +33,7 @@ export class TsConfigPathsPlugin {
 
     this.target = 'resolve';
 
-    this.compilerOptions = readTsConfig(cwd).compilerOptions;
+    this.compilerOptions = readTsConfig(cwd).compilerOptions || {};
 
     this.absoluteBaseUrl = path.resolve(
       cwd,


### PR DESCRIPTION
# PR Details

## Description

Fix following error (occurs when compileOptions is not defined in `tsconfig.json`): 

![image](https://user-images.githubusercontent.com/7237365/164967464-9ffd381f-59a5-4d3b-9b94-3705e7c2ed80.png)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
