### PR TITLE
fix(unbundle): incorrect react-refrech entry path

### DIFF
--- a/.changeset/wise-spiders-drive.md
+++ b/.changeset/wise-spiders-drive.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-unbundle': patch
+---
+
+fix(unbundle): incorrect react-refrech entry path

--- a/packages/cli/plugin-unbundle/src/create-entry.ts
+++ b/packages/cli/plugin-unbundle/src/create-entry.ts
@@ -52,9 +52,7 @@ const injectScripts = (
   ];
 
   if (isFastRefresh()) {
-    const runtimePath = require.resolve(
-      'react-refresh/cjs/react-refresh-runtime.development.js',
-    );
+    const runtimePath = require.resolve('react-refresh/runtime');
 
     const reactRefreshCode = fs
       .readFileSync(runtimePath, { encoding: 'utf-8' })

--- a/packages/cli/plugin-unbundle/src/create-entry.ts
+++ b/packages/cli/plugin-unbundle/src/create-entry.ts
@@ -52,7 +52,13 @@ const injectScripts = (
   ];
 
   if (isFastRefresh()) {
-    const runtimePath = require.resolve('react-refresh/runtime');
+    const reactFreshEntry = path.dirname(
+      require.resolve('react-refresh/package.json'),
+    );
+    const runtimePath = path.join(
+      reactFreshEntry,
+      'cjs/react-refresh-runtime.development.js',
+    );
 
     const reactRefreshCode = fs
       .readFileSync(runtimePath, { encoding: 'utf-8' })


### PR DESCRIPTION
# PR Details

`react-refresh` added `exports` field and breaks the unbundle plugin:

![image](https://user-images.githubusercontent.com/7237365/164969657-fbdf5308-d0e2-473f-a0ec-9f24d50af9a7.png)

![image](https://user-images.githubusercontent.com/7237365/164969679-aedf2c99-512b-40e0-8ba1-209752b1d0eb.png)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
