### PR TITLE
chore: extend @typescript-eslint/recommended-requiring-type-checking

### DIFF
--- a/.changeset/rich-beers-thank.md
+++ b/.changeset/rich-beers-thank.md
@@ -1,0 +1,5 @@
+---
+'@modern-js-app/eslint-config': patch
+---
+
+refactor: ts type checking extends `@typescript-eslint/recommended-requiring-type-checking`

--- a/packages/review/eslint-config-app/ts.withType.js
+++ b/packages/review/eslint-config-app/ts.withType.js
@@ -9,48 +9,14 @@ module.exports = {
         // don't set tsconfigRootDir, using the path relative to the cwd
         project: ['./tsconfig.json'],
       },
+      extends: [
+        'plugin:@typescript-eslint/recommended-requiring-type-checking',
+      ],
       rules: {
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/await-thenable.md
-        '@typescript-eslint/await-thenable': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-for-in-array.md
-        '@typescript-eslint/no-for-in-array': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-implied-eval.md
-        'no-implied-eval': 'off',
-        '@typescript-eslint/no-implied-eval': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-promises.md
         '@typescript-eslint/no-misused-promises': [
           'error',
           { checksVoidReturn: false },
         ],
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md
-        '@typescript-eslint/no-unnecessary-type-assertion': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-base-to-string.md
-        '@typescript-eslint/no-base-to-string': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md
-        '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-qualifier.md
-        '@typescript-eslint/no-unnecessary-qualifier': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin//docs/rules/no-unnecessary-type-arguments.md
-        '@typescript-eslint/no-unnecessary-type-arguments': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/pull/294
-        '@typescript-eslint/prefer-includes': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/pull/289
-        '@typescript-eslint/prefer-string-starts-ends-with': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-regexp-exec.md
-        '@typescript-eslint/prefer-regexp-exec': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-readonly.md
-        '@typescript-eslint/prefer-readonly': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.md
-        '@typescript-eslint/switch-exhaustiveness-check': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/55eb0cfac20ccbc2e954083dd554dbcfcbed64fb/packages/eslint-plugin/docs/rules/return-await.md
-        'no-return-await': 'off',
-        '@typescript-eslint/return-await': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/dot-notation.md
-        'dot-notation': 'off',
-        '@typescript-eslint/dot-notation': ['error', { allowKeywords: true }],
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-throw-literal.md
-        'no-throw-literal': 'off',
-        '@typescript-eslint/no-throw-literal': 'error',
       },
     },
   ],


### PR DESCRIPTION

Extends `@typescript-eslint/recommended-requiring-type-checking` rules instead of custom configs. 

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
