### PR TITLE
refactor(webpack): remove @modern-js/core

### DIFF
--- a/.changeset/many-dingos-promise.md
+++ b/.changeset/many-dingos-promise.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/plugin-docsite': patch
+'@modern-js/plugin-nocode': patch
+'@modern-js/plugin-testing': patch
+'@modern-js/webpack': patch
+'@modern-js/app-tools': patch
+---
+
+refactor(webpack): remove `@modern-js/core`

--- a/packages/cli/plugin-docsite/src/features/utils/webpack.ts
+++ b/packages/cli/plugin-docsite/src/features/utils/webpack.ts
@@ -14,7 +14,12 @@ export function generatorWebpackConfig(
   tmpDir: string,
   isDev: boolean,
 ): Configuration {
-  const originConfig: any = getWebpackConfig(WebpackConfigTarget.CLIENT);
+  // FIXME: 这个包现在没有使用，待使用时再重构 webpack 配置的获取
+  const originConfig: any = getWebpackConfig(
+    WebpackConfigTarget.CLIENT,
+    {} as any,
+    {} as any,
+  );
   const plugins = (
     (originConfig.plugins || []) as WebpackPluginInstance[]
   ).filter(p => p.constructor !== webpack.HotModuleReplacementPlugin);

--- a/packages/cli/plugin-nocode/src/build-task.ts
+++ b/packages/cli/plugin-nocode/src/build-task.ts
@@ -11,12 +11,14 @@ const core: typeof import('@modern-js/core') = Import.lazy(
 const build: typeof import('./compiler') = Import.lazy('./compiler', require);
 
 (async () => {
-  const { appContext } = await core.cli.init();
+  const { appContext, resolved } = await core.cli.init();
   await core.manager.run(async () => {
     try {
       const { appDirectory, internalDirectory } = appContext;
       const webpackConfig = getWebpackConfig(
         WebpackConfigTarget.CLIENT,
+        appContext,
+        resolved,
       ) as Configuration;
       build.default(webpackConfig, {
         appDirectory,

--- a/packages/cli/plugin-nocode/src/cli.ts
+++ b/packages/cli/plugin-nocode/src/cli.ts
@@ -40,12 +40,15 @@ export default (): CliPlugin => ({
         });
 
       const devCommand = program.commandsMap.get('dev');
-      const { appDirectory, internalDirectory } = api.useAppContext();
+      const appContext = api.useAppContext();
+      const { appDirectory, internalDirectory } = appContext;
       const modernConfig = api.useResolvedConfigContext();
       if (devCommand) {
         devCommand.command('nocode').action(async () => {
           const webpackConfig = getWebpackConfig(
             WebpackConfigTarget.CLIENT,
+            appContext,
+            modernConfig,
           ) as Configuration;
           await dev(
             appDirectory,
@@ -77,10 +80,13 @@ export default (): CliPlugin => ({
         }: {
           isTsProject: boolean;
         }) => {
-          const { appDirectory, internalDirectory } = api.useAppContext();
+          const appContext = api.useAppContext();
+          const { appDirectory, internalDirectory } = appContext;
           const modernConfig = api.useResolvedConfigContext();
           const webpackConfig = getWebpackConfig(
             WebpackConfigTarget.CLIENT,
+            appContext,
+            modernConfig,
           ) as Configuration;
           await dev(
             appDirectory,

--- a/packages/cli/plugin-testing/src/cli/index.ts
+++ b/packages/cli/plugin-testing/src/cli/index.ts
@@ -92,7 +92,11 @@ export default (): CliPlugin => {
             return next(utils);
           }
 
-          const webpackConfig = getWebpackConfig(WebpackConfigTarget.CLIENT);
+          const webpackConfig = getWebpackConfig(
+            WebpackConfigTarget.CLIENT,
+            appContext,
+            userConfig,
+          );
           const {
             resolve: { alias = {} },
           } = webpackConfig;

--- a/packages/cli/webpack/package.json
+++ b/packages/cli/webpack/package.json
@@ -92,9 +92,6 @@
     "tapable": "^2.2.1",
     "typescript": "^4"
   },
-  "peerDependencies": {
-    "@modern-js/core": "workspace:^1.8.0"
-  },
   "sideEffects": false,
   "modernConfig": {
     "output": {

--- a/packages/cli/webpack/src/index.ts
+++ b/packages/cli/webpack/src/index.ts
@@ -1,5 +1,5 @@
 import webpack from 'webpack';
-import { useAppContext, useResolvedConfigContext } from '@modern-js/core';
+import type { IAppContext, NormalizedConfig } from '@modern-js/core';
 import {
   ClientWebpackConfig,
   ModernWebpackConfig,
@@ -21,7 +21,11 @@ export enum WebpackConfigTarget {
   MODERN,
 }
 
-export const getWebpackConfig = (target: WebpackConfigTarget) => {
+export const getWebpackConfig = (
+  target: WebpackConfigTarget,
+  appContext: IAppContext,
+  resolvedConfig: NormalizedConfig,
+) => {
   let Config = null;
 
   switch (target) {
@@ -42,10 +46,7 @@ export const getWebpackConfig = (target: WebpackConfigTarget) => {
     return null;
   }
 
-  const appContext = useAppContext();
-  const options = useResolvedConfigContext();
-
-  const config = new Config(appContext, options);
+  const config = new Config(appContext, resolvedConfig);
 
   return config.config();
 };

--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -118,20 +118,32 @@ export const build = async (api: PluginAPI, options?: BuildOptions) => {
   const buildConfigs: Array<{ type: string; config: any }> = [];
   buildConfigs.push({
     type: 'legacy',
-    config: getWebpackConfig(WebpackConfigTarget.CLIENT)!,
+    config: getWebpackConfig(
+      WebpackConfigTarget.CLIENT,
+      appContext,
+      resolvedConfig,
+    )!,
   });
 
   if (resolvedConfig.output.enableModernMode) {
     buildConfigs.push({
       type: 'modern',
-      config: getWebpackConfig(WebpackConfigTarget.MODERN)!,
+      config: getWebpackConfig(
+        WebpackConfigTarget.MODERN,
+        appContext,
+        resolvedConfig,
+      )!,
     });
   }
 
   if (isUseSSRBundle(resolvedConfig)) {
     buildConfigs.push({
       type: 'ssr',
-      config: getWebpackConfig(WebpackConfigTarget.NODE)!,
+      config: getWebpackConfig(
+        WebpackConfigTarget.NODE,
+        appContext,
+        resolvedConfig,
+      )!,
     });
   }
 

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -63,8 +63,9 @@ export const dev = async (api: PluginAPI, options: DevOptions) => {
       '@modern-js/webpack'
     );
     const webpackConfigs = [
-      isSSR(userConfig) && getWebpackConfig(WebpackConfigTarget.NODE),
-      getWebpackConfig(WebpackConfigTarget.CLIENT),
+      isSSR(userConfig) &&
+        getWebpackConfig(WebpackConfigTarget.NODE, appContext, userConfig),
+      getWebpackConfig(WebpackConfigTarget.CLIENT, appContext, userConfig),
     ].filter(Boolean) as Configuration[];
 
     compiler = await createCompiler({


### PR DESCRIPTION
# PR Details

`@modern-js/webpack` wouldn't depend on `@modern-js/core` to avoid potential multiple `@modern-js/core` issue.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
