### PR TITLE
fix(app-tools): build command params not work

### DIFF
--- a/.changeset/four-plums-approve.md
+++ b/.changeset/four-plums-approve.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: build commands not work

--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -23,7 +23,7 @@ const WARN_AFTER_BUNDLE_GZIP_SIZE = 512 * 1024;
 const WARN_AFTER_CHUNK_GZIP_SIZE = 1024 * 1024;
 
 export const build = async (api: PluginAPI, options?: BuildOptions) => {
-  const resolvedConfig = api.useResolvedConfigContext();
+  let resolvedConfig = api.useResolvedConfigContext();
   const appContext = api.useAppContext();
   const hookRunners = api.useHookRunners();
   const { apiOnly } = appContext;
@@ -102,7 +102,8 @@ export const build = async (api: PluginAPI, options?: BuildOptions) => {
   };
 
   manager.run(() => {
-    ResolvedConfigContext.set({ ...resolvedConfig, cliOptions: options });
+    resolvedConfig = { ...resolvedConfig, cliOptions: options };
+    ResolvedConfigContext.set(resolvedConfig);
   });
 
   const { distDirectory, appDirectory, serverConfigFile } = appContext;


### PR DESCRIPTION
# PR Details

## Description

修复 build 命令的参数不生效的问题 (比如`build --analyze`).

原因是 `getWebpackConfig` 改成了外部传入 `resolvedConfig`，而 build 命令的实现中，先读取了 `resolvedConfig`，再对 `resolvedConfig` 添加了 `cliOptions` 属性，导致 `getWebpackConfig` 中无法获取到 `cliOptions` 属性。

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
