### PR TITLE
chore: lock pnpm to v6 in CI config

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Pnpm
         uses: pnpm/action-setup@v2.2.1
         with:
-          version: latest
+          version: 6
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/integration-test-Windows.yml
+++ b/.github/workflows/integration-test-Windows.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Pnpm
         uses: pnpm/action-setup@v2.2.1
         with:
-          version: latest
+          version: 6
 
       - name: Check docs only change
         run: echo "::set-output name=DOCS_CHANGE::$(node ./scripts/skip-docs-change.js echo 'not-docs-only-change')"

--- a/.github/workflows/integration-test-macOS.yml
+++ b/.github/workflows/integration-test-macOS.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Pnpm
         uses: pnpm/action-setup@v2.2.1
         with:
-          version: latest
+          version: 6
 
       - name: Check docs only change
         run: echo ::set-output name=DOCS_CHANGE::$(node ./scripts/skip-docs-change.js echo 'not-docs-only-change')

--- a/.github/workflows/lint-Linux.yml
+++ b/.github/workflows/lint-Linux.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Pnpm
         uses: pnpm/action-setup@v2.2.1
         with:
-          version: latest
+          version: 6
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/reset-prepare.yml
+++ b/.github/workflows/reset-prepare.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Pnpm
         uses: pnpm/action-setup@v2.2.1
         with:
-          version: latest
+          version: 6
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/test-Windows.yml
+++ b/.github/workflows/test-Windows.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Pnpm
         uses: pnpm/action-setup@v2.2.1
         with:
-          version: latest
+          version: 6
 
       - name: Check docs only change
         run: echo "::set-output name=DOCS_CHANGE::$(node ./scripts/skip-docs-change.js echo 'not-docs-only-change')"

--- a/.github/workflows/test-macOS.yml
+++ b/.github/workflows/test-macOS.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Pnpm
         uses: pnpm/action-setup@v2.2.1
         with:
-          version: latest
+          version: 6
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/fast-lint.sh
+++ b/fast-lint.sh
@@ -7,7 +7,7 @@ if [ ! -z ${GITHUB_BASE_REF+x} ]; then
 fi
 
 # build @modern-js/eslint-config and related packages
-pnpm --filter @modern-js/eslint-config... build
+pnpm run build --filter @modern-js/eslint-config...
 
 # run eslint --no-fix
 env \

--- a/fast-lint.sh
+++ b/fast-lint.sh
@@ -7,7 +7,7 @@ if [ ! -z ${GITHUB_BASE_REF+x} ]; then
 fi
 
 # build @modern-js/eslint-config and related packages
-pnpm run build --filter @modern-js/eslint-config...
+pnpm --filter @modern-js/eslint-config... build
 
 # run eslint --no-fix
 env \


### PR DESCRIPTION
# PR Details

pnpm released v7 and have some [breaking changes](https://github.com/pnpm/pnpm/releases) (or bugs).

For example, `pnpm run build --filter @modern-js/eslint-config...` is not working, and  `pnpm --filter @modern-js/eslint-config.. build` can work as before.

I think we should lock the pnpm version in CI until pnpm v7 become stable.

The `lint` CI is broken:

![image](https://user-images.githubusercontent.com/7237365/166141795-eb3e1db1-6e1c-4eb6-a972-167b78e1dc00.png)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
