### PR TITLE
fix: remove node-external for server bundle

### DIFF
--- a/.changeset/big-trains-compete.md
+++ b/.changeset/big-trains-compete.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/webpack': patch
+'@modern-js/create-request': patch
+---
+
+fix: remove webpack-node-external for server bundle

--- a/packages/cli/webpack/package.json
+++ b/packages/cli/webpack/package.json
@@ -70,7 +70,6 @@
     "webpack-chain": "^6.5.1",
     "webpack-manifest-plugin": "^4.0.2",
     "webpack-merge": "^5.8.0",
-    "webpack-node-externals": "^3.0.0",
     "webpackbar": "^5.0.0-3",
     "yaml-loader": "^0.6.0"
   },

--- a/packages/cli/webpack/src/config/node.ts
+++ b/packages/cli/webpack/src/config/node.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import path from 'path';
 import {
   applyOptionsChain,
@@ -6,7 +5,6 @@ import {
   isUseSSRBundle,
   SERVER_BUNDLE_DIRECTORY,
 } from '@modern-js/utils';
-import nodeExternals from 'webpack-node-externals';
 import { mergeRegex } from '../utils/mergeRegex';
 import { getSourceIncludes } from '../utils/getSourceIncludes';
 import { JS_RESOLVE_EXTENSIONS } from '../utils/constants';
@@ -159,17 +157,6 @@ class NodeWebpackConfig extends BaseWebpackConfig {
     // @modern-js/utils use typescript for peerDependency, but js project not depend it
     // if not externals, js ssr build error
     config.externals.push('typescript');
-
-    config.resolve?.modules?.forEach((dir: string) => {
-      if (fs.existsSync(dir)) {
-        (config.externals as any[]).push(
-          nodeExternals({
-            allowlist: this.externalsAllowlist as any,
-            modulesDir: dir,
-          }),
-        );
-      }
-    });
 
     return config;
   }

--- a/packages/server/create-request/src/node.ts
+++ b/packages/server/create-request/src/node.ts
@@ -1,6 +1,6 @@
 import nodeFetch from 'node-fetch';
 import { compile, pathToRegexp, Key } from 'path-to-regexp';
-import { useHeaders } from '@modern-js/utils';
+import { useHeaders } from '@modern-js/utils/ssr';
 import qs from 'query-string';
 import { handleRes } from './handleRes';
 import type {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1866,7 +1866,6 @@ importers:
       webpack-chain: ^6.5.1
       webpack-manifest-plugin: ^4.0.2
       webpack-merge: ^5.8.0
-      webpack-node-externals: ^3.0.0
       webpackbar: ^5.0.0-3
       yaml-loader: ^0.6.0
     dependencies:
@@ -1906,7 +1905,6 @@ importers:
       webpack-chain: 6.5.1
       webpack-manifest-plugin: 4.0.2_webpack@5.71.0
       webpack-merge: 5.8.0
-      webpack-node-externals: 3.0.0
       webpackbar: 5.0.2_webpack@5.71.0
       yaml-loader: 0.6.0
     devDependencies:
@@ -38221,13 +38219,6 @@ packages:
       clone-deep: 4.0.1
       esbuild: 0.13.15
       wildcard: 2.0.0
-
-  /webpack-node-externals/3.0.0:
-    resolution: {integrity: sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==}
-    engines: {node: '>=6'}
-    dependencies:
-      esbuild: 0.13.15
-    dev: false
 
   /webpack-sources/1.4.3:
     resolution: {integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==}


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

SSR 场景下，期望 server 端也 bundle 所有的代码及依赖，目前加的 node-external 在 pnpm 下是无效的，使用 yarn 的情况下生效。两者构建出的 bundle 体积有较大的差异，不符合预期。

dist/bundles/main.js (yarn): 278 k
dist/bundles/main.js (pnpm): 973 k

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
