### PR TITLE
fix(webpack): incorrect tapable version in some cases

### DIFF
--- a/.changeset/strong-shirts-count.md
+++ b/.changeset/strong-shirts-count.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix: incorrect tapable version in some cases

--- a/packages/cli/webpack/package.json
+++ b/packages/cli/webpack/package.json
@@ -55,6 +55,7 @@
     "regenerator-runtime": "^0.13.9",
     "schema-utils": "^3.1.1",
     "style-loader": "^3.3.1",
+    "tapable": "^2.2.1",
     "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.5",
     "tsconfig-paths": "^3.11.0",
@@ -73,7 +74,6 @@
     "@types/react": "^17",
     "@types/react-dom": "^17",
     "jest": "^27",
-    "tapable": "^2.2.1",
     "typescript": "^4"
   },
   "sideEffects": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1853,6 +1853,7 @@ importers:
       regenerator-runtime: 0.13.9
       schema-utils: 3.1.1
       style-loader: 3.3.1_webpack@5.71.0
+      tapable: 2.2.1
       terser-webpack-plugin: 5.3.0_esbuild@0.13.15+webpack@5.71.0
       ts-loader: 9.2.6_typescript@4.5.4+webpack@5.71.0
       tsconfig-paths: 3.12.0
@@ -1870,7 +1871,6 @@ importers:
       '@types/react': 17.0.38
       '@types/react-dom': 17.0.11
       jest: 27.4.5
-      tapable: 2.2.1
       typescript: 4.5.4
 
   packages/generator/generator-cases:


### PR DESCRIPTION
# PR Details

## Description

The `tapable` should be declared in `dependencies` rather than `devDependencies`, so that the prebundled `webpack-manifest-plugin` can solve the correct version of `tapable`.

![image](https://user-images.githubusercontent.com/7237365/167343611-c385be43-44d9-4882-861b-7b9e50fbf8fd.png)

## How Has This Been Tested

Tested in alpha version (1.6.2-alpha.0).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
