### PR TITLE
fix(webpack): fix the recompile issue after running dev command

### DIFF
--- a/.changeset/blue-emus-matter.md
+++ b/.changeset/blue-emus-matter.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix: should not trigger recompile after running dev command


### PR DESCRIPTION
# PR Details

## Description

Fix the recompile issue after running dev command (the TypeChecker is also triggered twice):

![image](https://user-images.githubusercontent.com/7237365/167781482-5eded486-9cbe-44fb-8761-9d16fa83ec64.png)

This problem is caused by the incorrect `copy-webpack-plugin` configuration, we add a copy configuration when the `upload/public`directory does not exist, which eventually triggers webpack removedFiles detection.

![image](https://user-images.githubusercontent.com/7237365/167781738-fde9575b-f7eb-4033-8468-75e9fac32e2a.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
