### PR TITLE
fix(webpack): remove console polyfill to reduce bundle size

### DIFF
--- a/.changeset/light-crabs-perform.md
+++ b/.changeset/light-crabs-perform.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix: remove console polyfill for performance

--- a/packages/cli/webpack/src/config/client.ts
+++ b/packages/cli/webpack/src/config/client.ts
@@ -293,7 +293,6 @@ export class ClientWebpackConfig extends BaseWebpackConfig {
       this.chain.plugin('node-polyfill-provide').use(ProvidePlugin, [
         {
           Buffer: [nodeLibsBrowser.buffer, 'Buffer'],
-          console: [nodeLibsBrowser.console],
           process: [nodeLibsBrowser.process],
         },
       ]);


### PR DESCRIPTION
# PR Details

## Description

`console.xx` polyfill is unnecessary, remove it to reduce bundle size (20kb)

![image](https://user-images.githubusercontent.com/7237365/167986107-e9c7426e-799d-4405-a924-4552af6fed19.png)

`require('console')` will still be polyfilled by `resolve.fallback`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
