### PR TITLE
chore: add ".wireit/" to npmignore

### DIFF
--- a/packages/cli/babel-preset-app/.npmignore
+++ b/packages/cli/babel-preset-app/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/babel-preset-base/.npmignore
+++ b/packages/cli/babel-preset-base/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/babel-preset-lib/.npmignore
+++ b/packages/cli/babel-preset-lib/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/babel-preset-module/.npmignore
+++ b/packages/cli/babel-preset-module/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/core/.npmignore
+++ b/packages/cli/core/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/css-config/.npmignore
+++ b/packages/cli/css-config/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/i18n-cli-language-detector/.npmignore
+++ b/packages/cli/i18n-cli-language-detector/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-analyze/.npmignore
+++ b/packages/cli/plugin-analyze/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-bff/.npmignore
+++ b/packages/cli/plugin-bff/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-cdn-cos/.npmignore
+++ b/packages/cli/plugin-cdn-cos/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-cdn-oss/.npmignore
+++ b/packages/cli/plugin-cdn-oss/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-changeset/.npmignore
+++ b/packages/cli/plugin-changeset/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-design-token/.npmignore
+++ b/packages/cli/plugin-design-token/.npmignore
@@ -44,3 +44,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-docsite/.npmignore
+++ b/packages/cli/plugin-docsite/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-esbuild/.npmignore
+++ b/packages/cli/plugin-esbuild/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-fast-refresh/.npmignore
+++ b/packages/cli/plugin-fast-refresh/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-fetch/.npmignore
+++ b/packages/cli/plugin-fetch/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-garfish/.npmignore
+++ b/packages/cli/plugin-garfish/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-i18n/.npmignore
+++ b/packages/cli/plugin-i18n/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-jarvis/.npmignore
+++ b/packages/cli/plugin-jarvis/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-lambda-fc/.npmignore
+++ b/packages/cli/plugin-lambda-fc/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-lambda-scf/.npmignore
+++ b/packages/cli/plugin-lambda-scf/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-less/.npmignore
+++ b/packages/cli/plugin-less/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-multiprocess/.npmignore
+++ b/packages/cli/plugin-multiprocess/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-nocode/.npmignore
+++ b/packages/cli/plugin-nocode/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-proxy/.npmignore
+++ b/packages/cli/plugin-proxy/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-router/.npmignore
+++ b/packages/cli/plugin-router/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-runtime/.npmignore
+++ b/packages/cli/plugin-runtime/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-sass/.npmignore
+++ b/packages/cli/plugin-sass/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-server-build/.npmignore
+++ b/packages/cli/plugin-server-build/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-ssg/.npmignore
+++ b/packages/cli/plugin-ssg/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-state/.npmignore
+++ b/packages/cli/plugin-state/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-storybook/.npmignore
+++ b/packages/cli/plugin-storybook/.npmignore
@@ -47,3 +47,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-tailwind/.npmignore
+++ b/packages/cli/plugin-tailwind/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/plugin-testing/.npmignore
+++ b/packages/cli/plugin-testing/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/static-hosting/.npmignore
+++ b/packages/cli/static-hosting/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/cli/webpack/.npmignore
+++ b/packages/cli/webpack/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/generator/generator-cases/.npmignore
+++ b/packages/generator/generator-cases/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/generator/generator-common/.npmignore
+++ b/packages/generator/generator-common/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/generator/generator-plugin/.npmignore
+++ b/packages/generator/generator-plugin/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/generator/generator-utils/.npmignore
+++ b/packages/generator/generator-utils/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/generator/new-action/.npmignore
+++ b/packages/generator/new-action/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/review/testing-plugin-bff/.npmignore
+++ b/packages/review/testing-plugin-bff/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/review/testing/.npmignore
+++ b/packages/review/testing/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/runtime/.npmignore
+++ b/packages/runtime/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/adapter-helpers/.npmignore
+++ b/packages/server/adapter-helpers/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/bff-runtime/.npmignore
+++ b/packages/server/bff-runtime/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/bff-utils/.npmignore
+++ b/packages/server/bff-utils/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/core/.npmignore
+++ b/packages/server/core/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/create-request/.npmignore
+++ b/packages/server/create-request/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/hmr-client/.npmignore
+++ b/packages/server/hmr-client/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/plugin-egg/.npmignore
+++ b/packages/server/plugin-egg/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/plugin-express/.npmignore
+++ b/packages/server/plugin-express/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/plugin-koa/.npmignore
+++ b/packages/server/plugin-koa/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/plugin-nest/.npmignore
+++ b/packages/server/plugin-nest/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/plugin-polyfill/.npmignore
+++ b/packages/server/plugin-polyfill/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/plugin-server/.npmignore
+++ b/packages/server/plugin-server/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/prod-server/.npmignore
+++ b/packages/server/prod-server/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/server/.npmignore
+++ b/packages/server/server/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/server/utils/.npmignore
+++ b/packages/server/utils/.npmignore
@@ -47,3 +47,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/solutions/app-tools/.npmignore
+++ b/packages/solutions/app-tools/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/solutions/module-tools/.npmignore
+++ b/packages/solutions/module-tools/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/solutions/monorepo-tools/.npmignore
+++ b/packages/solutions/monorepo-tools/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/toolkit/babel-chain/.npmignore
+++ b/packages/toolkit/babel-chain/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/toolkit/compiler/babel/.npmignore
+++ b/packages/toolkit/compiler/babel/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/toolkit/compiler/esbuild/.npmignore
+++ b/packages/toolkit/compiler/esbuild/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/toolkit/compiler/style/.npmignore
+++ b/packages/toolkit/compiler/style/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/toolkit/doctor/.npmignore
+++ b/packages/toolkit/doctor/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/toolkit/freeze/.npmignore
+++ b/packages/toolkit/freeze/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/toolkit/load-config/.npmignore
+++ b/packages/toolkit/load-config/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/toolkit/node-bundle-require/.npmignore
+++ b/packages/toolkit/node-bundle-require/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/toolkit/plugin/.npmignore
+++ b/packages/toolkit/plugin/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/toolkit/types/.npmignore
+++ b/packages/toolkit/types/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/toolkit/update/.npmignore
+++ b/packages/toolkit/update/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/

--- a/packages/toolkit/utils/.npmignore
+++ b/packages/toolkit/utils/.npmignore
@@ -45,3 +45,5 @@ jest.config.js
 .eslintrc.js
 .eslintrc
 tsconfig.json
+
+.wireit/


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

我们有些包有 .npmignore，应该把".wireit/" 目录加入到 .npmignore  中，避免发布的 npm 包中有缓存文件。

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
