### PR TITLE
fix: setJestConfig before jestConfig hook execute

### DIFF
--- a/.changeset/four-bees-compete.md
+++ b/.changeset/four-bees-compete.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/testing': patch
+'@modern-js/testing-plugin-bff': patch
+---
+
+fix: setJestConfig before jestConfig hook execute

--- a/packages/review/testing-plugin-bff/tests/.eslintrc.js
+++ b/packages/review/testing-plugin-bff/tests/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: ['@modern-js'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.json'],
+  },
+};

--- a/packages/review/testing-plugin-bff/tests/__snapshots__/index.test.ts.snap
+++ b/packages/review/testing-plugin-bff/tests/__snapshots__/index.test.ts.snap
@@ -27,3 +27,32 @@ Object {
   ],
 }
 `;
+
+exports[`testing-plugin-bff testTimeout should not set in projects 1`] = `
+Object {
+  "projects": Array [
+    Object {
+      "globals": Object {
+        "modern_bff_info": Object {
+          "appDir": "/packages/review/testing-plugin-bff/tests/fixtures/bff1",
+          "modernUserConfig": Object {},
+          "plugins": Array [],
+          "routes": Array [],
+        },
+      },
+      "moduleNameMapper": Object {},
+      "resolver": "/packages/review/testing/src/config/resolver.ts",
+      "rootDir": "/packages/review/testing-plugin-bff/tests/fixtures/bff1/api",
+      "setupFilesAfterEnv": Array [
+        "/packages/review/testing-plugin-bff/src/setup.ts",
+      ],
+      "testEnvironment": "/packages/review/testing-plugin-bff/src/env.ts",
+      "testMatch": Array [
+        "**/api/**/*.test.[jt]s",
+      ],
+      "transform": undefined,
+    },
+  ],
+  "testTimeout": 1000,
+}
+`;

--- a/packages/review/testing-plugin-bff/tests/index.test.ts
+++ b/packages/review/testing-plugin-bff/tests/index.test.ts
@@ -11,23 +11,41 @@ expect.addSnapshotSerializer({
 });
 
 describe('testing-plugin-bff', () => {
+  const appDir = path.normalize(path.resolve(__dirname, './fixtures/bff1'));
+  const mockUtils = {
+    _jestConfig: {},
+    get jestConfig() {
+      return this._jestConfig;
+    },
+    setJestConfig(config: any, options: { force?: boolean } = {}) {
+      if (options.force) {
+        this._jestConfig = config;
+      }
+      this._jestConfig = Object.assign(this._jestConfig, config);
+    },
+  };
+
   test('plugin', async () => {
     expect(createPlugin).toBeDefined();
     expect(createPlugin).toBeInstanceOf(Function);
   });
 
   test('setJestConfigForBFF', async () => {
-    const appDir = path.normalize(path.resolve(__dirname, './fixtures/bff1'));
-    const mockUtils = {
-      _jestConfig: {},
-      get jestConfig() {
-        return this._jestConfig;
-      },
-      setJestConfig(config: any) {
-        this._jestConfig = config;
-      },
-    };
+    await setJestConfigForBFF({
+      pwd: appDir,
+      userConfig: {},
+      plugins: [],
+      routes: [],
+      utils: mockUtils,
+    });
 
+    expect(mockUtils.jestConfig).toMatchSnapshot();
+  });
+
+  test('testTimeout should not set in projects', async () => {
+    mockUtils.setJestConfig({
+      testTimeout: 1000,
+    });
     await setJestConfigForBFF({
       pwd: appDir,
       userConfig: {},

--- a/packages/review/testing/src/config/testConfigOperator.ts
+++ b/packages/review/testing/src/config/testConfigOperator.ts
@@ -35,6 +35,11 @@ class TestConfigOperator {
     this._jestConfig = merge({}, this._jestConfig, sourceConfig);
   }
 
+  public setJestUserConfig() {
+    const { userJestConfig } = this;
+    this.setJestConfig(userJestConfig);
+  }
+
   public setJestConfig(sourceConfig: JestConfig, options?: { force: boolean }) {
     if (options) {
       const { force } = options;
@@ -56,9 +61,6 @@ class TestConfigOperator {
     if (typeof userJestConfig === 'function') {
       return userJestConfig(this._jestConfig);
     }
-
-    // 确保用户设置的配置在jest配置最外层一定存在，避免有些配置在 projects 配置内不生效(https://github.com/facebook/jest/issues/9696)
-    this.setJestConfig(userJestConfig);
 
     return this.jestConfig;
   }

--- a/packages/review/testing/src/runJest.ts
+++ b/packages/review/testing/src/runJest.ts
@@ -118,6 +118,9 @@ export async function runTest(
 
   await patchConfig(jestUtils);
 
+  // 确保用户设置的配置可以被插件处理，比如设置在 projects 中
+  jestUtils.setJestUserConfig();
+
   const hookRunners = api.useHookRunners();
   const testConfigOperator = await hookRunners.jestConfig(jestUtils, {
     onLast: input => input,


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

如果用户配置是对象，会在 jestConfig 钩子执行之前合并，这样测试插件可以处理用户的配置。

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
