### PR TITLE
fix(webpack): output.polyfill usage not work

### DIFF
--- a/.changeset/spicy-melons-glow.md
+++ b/.changeset/spicy-melons-glow.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): tools.polyfill usage not work

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -33,7 +33,7 @@ import {
 import { createCSSRule, enableCssExtract } from '../utils/createCSSRule';
 import { mergeRegex } from '../utils/mergeRegex';
 import { getWebpackLogging } from '../utils/getWebpackLogging';
-import { getBabelOptions } from '../utils/getBabelOptions';
+import { getBabelOptions, getUseBuiltIns } from '../utils/getBabelOptions';
 import { ModuleScopePlugin } from '../plugins/module-scope-plugin';
 import { getSourceIncludes } from '../utils/getSourceIncludes';
 import { TsConfigPathsPlugin } from '../plugins/ts-config-paths-plugin';
@@ -265,10 +265,7 @@ class BaseWebpackConfig {
                 appDirectory: this.appDirectory,
                 target: 'client',
                 useTsLoader: true,
-                useBuiltIns:
-                  this.options.output.polyfill === 'ua'
-                    ? false
-                    : this.options.output.polyfill,
+                useBuiltIns: getUseBuiltIns(this.options),
                 userBabelConfig: this.options.tools.babel,
               },
             ],

--- a/packages/cli/webpack/src/config/client.ts
+++ b/packages/cli/webpack/src/config/client.ts
@@ -49,10 +49,10 @@ export class ClientWebpackConfig extends BaseWebpackConfig {
   entry() {
     super.entry();
 
-    const entrypoints = Object.keys(this.chain.entryPoints.entries() || {});
+    if (this.options.output.polyfill === 'entry') {
+      const entryPoints = Object.keys(this.chain.entryPoints.entries() || {});
 
-    for (const name of entrypoints) {
-      if (this.options.output.polyfill !== 'off') {
+      for (const name of entryPoints) {
         this.chain
           .entry(name)
           .prepend(require.resolve('regenerator-runtime/runtime'))

--- a/packages/cli/webpack/src/utils/getBabelOptions.ts
+++ b/packages/cli/webpack/src/utils/getBabelOptions.ts
@@ -3,6 +3,14 @@ import type { NormalizedConfig } from '@modern-js/core';
 import { Options as BabelPresetAppOptions } from '@modern-js/babel-preset-app';
 import type { BabelChain } from '@modern-js/babel-chain';
 
+export const getUseBuiltIns = (config: NormalizedConfig) => {
+  const { polyfill } = config.output || {};
+  if (polyfill === 'ua' || polyfill === 'off') {
+    return false;
+  }
+  return polyfill;
+};
+
 export const getBabelOptions = (
   metaName: string,
   appDirectory: string,
@@ -24,10 +32,7 @@ export const getBabelOptions = (
           config.tools?.lodash as any,
         ),
         useLegacyDecorators: !config.output?.enableLatestDecorators,
-        useBuiltIns:
-          config.output?.polyfill === 'ua' || config.output?.polyfill === 'off'
-            ? false
-            : config.output?.polyfill,
+        useBuiltIns: getUseBuiltIns(config),
         chain,
         styledComponents: applyOptionsChain(
           {


### PR DESCRIPTION
# PR Details

## Description

We should not require entire `core-js` and `regenerator-runtime` when `output.polyfill` is `ua` or `usage`, otherwise the polyfill will be fully imported.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
