### PR TITLE
fix(eslint): remove eslint-import-resolver-webpack

### DIFF
--- a/.changeset/tender-beans-shake.md
+++ b/.changeset/tender-beans-shake.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-jarvis': patch
+'@modern-js-app/eslint-config': patch
+---
+
+fix(eslint): remove eslint-import-resolver-webpack

--- a/packages/cli/plugin-jarvis/package.json
+++ b/packages/cli/plugin-jarvis/package.json
@@ -52,7 +52,6 @@
     "cross-spawn": "^7.0.1",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-import-resolver-webpack": "^0.13.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.24.1",

--- a/packages/review/eslint-config-app/base.js
+++ b/packages/review/eslint-config-app/base.js
@@ -1271,7 +1271,6 @@ module.exports = {
     'node/prefer-promises/fs': 'off',
   },
   settings: {
-    'import/resolver': 'webpack',
     'import/extensions': jsExtensions,
     'import/ignore': ['\\.coffee$'],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -830,7 +830,6 @@ importers:
       cross-spawn: ^7.0.1
       eslint: ^7.32.0
       eslint-config-prettier: ^8.3.0
-      eslint-import-resolver-webpack: ^0.13.1
       eslint-plugin-eslint-comments: ^3.2.0
       eslint-plugin-filenames: ^1.3.2
       eslint-plugin-import: ^2.24.1
@@ -859,10 +858,9 @@ importers:
       cross-spawn: 7.0.3
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0_eslint@7.32.0
-      eslint-import-resolver-webpack: 0.13.2_eslint-plugin-import@2.25.4
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.32.0
       eslint-plugin-filenames: 1.3.2_eslint@7.32.0
-      eslint-plugin-import: 2.25.4_eslint@7.32.0
+      eslint-plugin-import: 2.25.4_4e45d3a7b9f8ef33842d7116d2543b58
       eslint-plugin-markdown: 2.2.1_eslint@7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
       eslint-plugin-prettier: 4.0.0_6e6a25a49a944db0fa38418c3ba4bc86
@@ -8551,7 +8549,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8660,7 +8657,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8701,7 +8697,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8741,7 +8736,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8775,7 +8769,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8806,7 +8799,6 @@ packages:
       - '@parcel/css'
       - '@swc/core'
       - '@types/react'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8835,7 +8827,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8863,7 +8854,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8895,7 +8885,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8933,7 +8922,6 @@ packages:
       - '@parcel/css'
       - '@swc/core'
       - '@types/react'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8989,7 +8977,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -9023,7 +9010,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -9065,7 +9051,6 @@ packages:
       - '@parcel/css'
       - '@swc/core'
       - '@types/react'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -11273,10 +11258,10 @@ packages:
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@storybook/addons': 6.4.20_react@17.0.2
       '@storybook/api': 6.4.20_react@17.0.2
-      '@storybook/builder-webpack4': 6.4.20_b43b76531763da8fcf690631ce26f490
+      '@storybook/builder-webpack4': 6.4.20_12edc9d24e0541c36a080f6bf6f285e8
       '@storybook/client-logger': 6.4.20
       '@storybook/components': 6.4.20_b08e3c15324cbe90a6ff8fcd416c932c
-      '@storybook/core': 6.4.20_765f8dfebdf49bc9567a04e02009dcf1
+      '@storybook/core': 6.4.20_350d06cf30b4367eed5fed94371c3a67
       '@storybook/core-events': 6.4.20
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.20
@@ -11697,7 +11682,7 @@ packages:
       esbuild: 0.13.15
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6
+      fork-ts-checker-webpack-plugin: 4.1.6_typescript@4.5.4+webpack@4.46.0
       glob: 7.2.0
       glob-promise: 3.4.0_glob@7.2.0
       global: 4.4.0
@@ -11722,99 +11707,6 @@ packages:
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
       - '@types/react'
-      - acorn
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: false
-
-  /@storybook/builder-webpack4/6.4.20_b43b76531763da8fcf690631ce26f490:
-    resolution: {integrity: sha512-Lekx2T0P5tLD0Xd2+6t2dicbZ2oTX/lW1bc+Uxz6QROLqh4/H84CTyofVLJYmZUtgnLQee/cqz5JVkpoA72ebA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/plugin-proposal-class-properties': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-proposal-decorators': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-proposal-export-default-from': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-proposal-object-rest-spread': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-proposal-optional-chaining': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-proposal-private-methods': 7.16.11_@babel+core@7.17.8
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.17.8
-      '@babel/plugin-transform-arrow-functions': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-block-scoping': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-classes': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-destructuring': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-for-of': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-parameters': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-shorthand-properties': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-spread': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.8
-      '@babel/preset-env': 7.16.11_@babel+core@7.17.8
-      '@babel/preset-react': 7.16.7_@babel+core@7.17.8
-      '@babel/preset-typescript': 7.16.7_@babel+core@7.17.8
-      '@storybook/addons': 6.4.20_react@17.0.2
-      '@storybook/api': 6.4.20_react@17.0.2
-      '@storybook/channel-postmessage': 6.4.20
-      '@storybook/channels': 6.4.20
-      '@storybook/client-api': 6.4.20_react@17.0.2
-      '@storybook/client-logger': 6.4.20
-      '@storybook/components': 6.4.20_b08e3c15324cbe90a6ff8fcd416c932c
-      '@storybook/core-common': 6.4.20_react@17.0.2+typescript@4.5.4
-      '@storybook/core-events': 6.4.20
-      '@storybook/node-logger': 6.4.20
-      '@storybook/preview-web': 6.4.20_react@17.0.2
-      '@storybook/router': 6.4.20_react@17.0.2
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.4.20_react@17.0.2
-      '@storybook/theming': 6.4.20_react@17.0.2
-      '@storybook/ui': 6.4.20_b08e3c15324cbe90a6ff8fcd416c932c
-      '@types/node': 14.18.4
-      '@types/webpack': 4.41.32
-      autoprefixer: 9.8.8
-      babel-loader: 8.2.3_b72fb7e629d39881e138edb6dcd0dfbe
-      babel-plugin-macros: 2.8.0
-      babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.17.8
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      core-js: 3.21.1
-      css-loader: 3.6.0_webpack@4.46.0
-      esbuild: 0.13.15
-      file-loader: 6.2.0_webpack@4.46.0
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6
-      glob: 7.2.0
-      glob-promise: 3.4.0_glob@7.2.0
-      global: 4.4.0
-      html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4_typescript@4.5.4
-      postcss: 7.0.39
-      postcss-flexbugs-fixes: 4.2.1
-      postcss-loader: 4.3.0_postcss@7.0.39+webpack@4.46.0
-      raw-loader: 4.0.2_webpack@4.46.0
-      react: 17.0.2
-      stable: 0.1.8
-      style-loader: 1.3.0_webpack@4.46.0
-      terser-webpack-plugin: 4.2.3_acorn@7.4.1+webpack@4.46.0
-      ts-dedent: 2.2.0
-      typescript: 4.5.4
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-      webpack-dev-middleware: 3.7.3_webpack@4.46.0
-      webpack-filter-warnings-plugin: 1.2.1_webpack@4.46.0
-      webpack-hot-middleware: 2.25.1
-      webpack-virtual-modules: 0.2.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - acorn
       - eslint
       - supports-color
       - vue-template-compiler
@@ -11895,7 +11787,6 @@ packages:
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/react'
-      - acorn
       - eslint
       - supports-color
       - uglify-js
@@ -12243,83 +12134,6 @@ packages:
       ws: 8.5.0
     transitivePeerDependencies:
       - '@types/react'
-      - acorn
-      - bufferutil
-      - encoding
-      - eslint
-      - supports-color
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: false
-
-  /@storybook/core-server/6.4.20_e9ff98c847b0d2281e7643040e9ef748:
-    resolution: {integrity: sha512-AqpTjZE3/23IdDN5i6Srky3zdapQKSnHqlibl1mppRscf1IZe6OJJWtCHACpJKJwnOpPV/WxL8oron4mUjvrbA==}
-    peerDependencies:
-      '@storybook/builder-webpack5': 6.4.20
-      '@storybook/manager-webpack5': 6.4.20
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      '@storybook/builder-webpack5':
-        optional: true
-      '@storybook/manager-webpack5':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.6
-      '@storybook/builder-webpack4': 6.4.20_b43b76531763da8fcf690631ce26f490
-      '@storybook/builder-webpack5': 6.4.20_12edc9d24e0541c36a080f6bf6f285e8
-      '@storybook/core-client': 6.4.20_be15b9759c72a6d6e973db0224a0f336
-      '@storybook/core-common': 6.4.20_react@17.0.2+typescript@4.5.4
-      '@storybook/core-events': 6.4.20
-      '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/csf-tools': 6.4.20
-      '@storybook/manager-webpack4': 6.4.20_b43b76531763da8fcf690631ce26f490
-      '@storybook/manager-webpack5': 6.4.20_12edc9d24e0541c36a080f6bf6f285e8
-      '@storybook/node-logger': 6.4.20
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.4.20_react@17.0.2
-      '@types/node': 14.18.4
-      '@types/node-fetch': 2.5.12
-      '@types/pretty-hrtime': 1.0.1
-      '@types/webpack': 4.41.32
-      better-opn: 2.1.1
-      boxen: 5.1.2
-      chalk: 4.1.2
-      cli-table3: 0.6.1
-      commander: 6.2.1
-      compression: 1.7.4
-      core-js: 3.21.1
-      cpy: 8.1.2
-      detect-port: 1.3.0
-      esbuild: 0.13.15
-      express: 4.17.2
-      file-system-cache: 1.0.5
-      fs-extra: 9.1.0
-      globby: 11.0.4
-      ip: 1.1.5
-      lodash: 4.17.21
-      node-fetch: 2.6.7
-      pretty-hrtime: 1.0.3
-      prompts: 2.4.2
-      react: 17.0.2
-      regenerator-runtime: 0.13.9
-      serve-favicon: 2.5.0
-      slash: 3.0.0
-      telejson: 5.3.3
-      ts-dedent: 2.2.0
-      typescript: 4.5.4
-      util-deprecate: 1.0.2
-      watchpack: 2.3.1
-      webpack: 4.46.0
-      ws: 8.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - acorn
       - bufferutil
       - encoding
       - eslint
@@ -12353,41 +12167,6 @@ packages:
     transitivePeerDependencies:
       - '@storybook/manager-webpack5'
       - '@types/react'
-      - acorn
-      - bufferutil
-      - encoding
-      - eslint
-      - supports-color
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: false
-
-  /@storybook/core/6.4.20_765f8dfebdf49bc9567a04e02009dcf1:
-    resolution: {integrity: sha512-CQ3aaTHoHVV9BRUjqdr33cKv+/q1DMWBrtvEuZpW6gKq/CUuDXLQrAUARD18H/I5BlIJGbP5ccwkZNiY34QWKg==}
-    peerDependencies:
-      '@storybook/builder-webpack5': 6.4.20
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      '@storybook/builder-webpack5':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@storybook/builder-webpack5': 6.4.20_12edc9d24e0541c36a080f6bf6f285e8
-      '@storybook/core-client': 6.4.20_65f43a8dda7a9e748791f44a5ec930b1
-      '@storybook/core-server': 6.4.20_e9ff98c847b0d2281e7643040e9ef748
-      react: 17.0.2
-      typescript: 4.5.4
-      webpack: 5.71.0_esbuild@0.13.15
-    transitivePeerDependencies:
-      - '@storybook/manager-webpack5'
-      - '@types/react'
-      - acorn
       - bufferutil
       - encoding
       - eslint
@@ -12421,7 +12200,6 @@ packages:
     transitivePeerDependencies:
       - '@storybook/manager-webpack5'
       - '@types/react'
-      - acorn
       - bufferutil
       - encoding
       - eslint
@@ -12512,67 +12290,6 @@ packages:
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
       - '@types/react'
-      - acorn
-      - encoding
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: false
-
-  /@storybook/manager-webpack4/6.4.20_b43b76531763da8fcf690631ce26f490:
-    resolution: {integrity: sha512-4Q9ZJNT64Omn0shD8JfXi1yccjQVWruBxKoELbn4zLOUtmb5/ETmBHkek/nBnLo7i5J6ZkyB66L9qokfC/WsxQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.8
-      '@babel/preset-react': 7.16.7_@babel+core@7.17.8
-      '@storybook/addons': 6.4.20_react@17.0.2
-      '@storybook/core-client': 6.4.20_be15b9759c72a6d6e973db0224a0f336
-      '@storybook/core-common': 6.4.20_react@17.0.2+typescript@4.5.4
-      '@storybook/node-logger': 6.4.20
-      '@storybook/theming': 6.4.20_react@17.0.2
-      '@storybook/ui': 6.4.20_b08e3c15324cbe90a6ff8fcd416c932c
-      '@types/node': 14.18.4
-      '@types/webpack': 4.41.32
-      babel-loader: 8.2.3_b72fb7e629d39881e138edb6dcd0dfbe
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      chalk: 4.1.2
-      core-js: 3.21.1
-      css-loader: 3.6.0_webpack@4.46.0
-      esbuild: 0.13.15
-      express: 4.17.2
-      file-loader: 6.2.0_webpack@4.46.0
-      file-system-cache: 1.0.5
-      find-up: 5.0.0
-      fs-extra: 9.1.0
-      html-webpack-plugin: 4.5.2_webpack@4.46.0
-      node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4_typescript@4.5.4
-      react: 17.0.2
-      read-pkg-up: 7.0.1
-      regenerator-runtime: 0.13.9
-      resolve-from: 5.0.0
-      style-loader: 1.3.0_webpack@4.46.0
-      telejson: 5.3.3
-      terser-webpack-plugin: 4.2.3_acorn@7.4.1+webpack@4.46.0
-      ts-dedent: 2.2.0
-      typescript: 4.5.4
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-      webpack-dev-middleware: 3.7.3_webpack@4.46.0
-      webpack-virtual-modules: 0.2.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - acorn
       - encoding
       - eslint
       - supports-color
@@ -12630,7 +12347,6 @@ packages:
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/react'
-      - acorn
       - encoding
       - eslint
       - supports-color
@@ -12748,7 +12464,6 @@ packages:
       - '@storybook/manager-webpack5'
       - '@types/react'
       - '@types/webpack'
-      - acorn
       - bufferutil
       - encoding
       - eslint
@@ -15410,10 +15125,6 @@ packages:
   /array-filter/1.0.0:
     resolution: {integrity: sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=}
     dev: true
-
-  /array-find/1.0.0:
-    resolution: {integrity: sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=}
-    dev: false
 
   /array-flatten/1.1.1:
     resolution: {integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=}
@@ -18944,17 +18655,32 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
 
   /debug/3.1.0:
     resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
 
@@ -19268,6 +18994,8 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /detect-port/1.3.0:
@@ -19277,6 +19005,8 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
 
   /detective/5.2.0:
     resolution: {integrity: sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==}
@@ -20222,6 +19952,7 @@ packages:
       yeast: 0.1.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
       - utf-8-validate
     dev: false
 
@@ -20233,15 +19964,6 @@ packages:
       base64-arraybuffer: 0.1.4
       blob: 0.0.5
       has-binary2: 1.0.3
-    dev: false
-
-  /enhanced-resolve/0.9.1:
-    resolution: {integrity: sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=}
-    engines: {node: '>=0.6'}
-    dependencies:
-      graceful-fs: 4.2.10
-      memory-fs: 0.2.0
-      tapable: 0.1.10
     dev: false
 
   /enhanced-resolve/4.5.0:
@@ -20878,28 +20600,6 @@ packages:
       resolve: 1.22.0
     dev: false
 
-  /eslint-import-resolver-webpack/0.13.2_eslint-plugin-import@2.25.4:
-    resolution: {integrity: sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      eslint-plugin-import: '>=1.4.0'
-      webpack: '>=1.11.0'
-    dependencies:
-      array-find: 1.0.0
-      debug: 3.2.7
-      enhanced-resolve: 0.9.1
-      esbuild: 0.13.15
-      eslint-plugin-import: 2.25.4_eslint@7.32.0
-      find-root: 1.1.0
-      has: 1.0.3
-      interpret: 1.4.0
-      is-core-module: 2.8.0
-      is-regex: 1.1.4
-      lodash: 4.17.21
-      resolve: 1.22.0
-      semver: 5.7.1
-    dev: false
-
   /eslint-index/1.5.0:
     resolution: {integrity: sha512-lIr1cGKFEW1M/7URdTX1r+pYWsxpSqv1p8u0SRPBVjUQvNt3r430VoOR006QzQX0eB8ngGe5fzZu8eW64TlkoA==}
     dependencies:
@@ -20910,12 +20610,26 @@ packages:
       yargs: 11.1.1
     dev: true
 
-  /eslint-module-utils/2.7.2:
+  /eslint-module-utils/2.7.2_0399891fd6df64bf98347649afe6640f:
     resolution: {integrity: sha512-zquepFnWCY2ISMFwD/DqzaM++H+7PDzOpUvotJWm/y1BAFt5R4oeULgdrTejKqLkz7MA/tgstsUMNYc7wNdTrg==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
-      debug: 3.2.7
-      find-up: 2.1.0
+      '@typescript-eslint/parser': 5.17.0_eslint@7.32.0+typescript@4.5.4
+      eslint-import-resolver-node: 0.3.6
     dev: false
 
   /eslint-plugin-es/3.0.1_eslint@7.32.0:
@@ -20952,19 +20666,24 @@ packages:
       lodash.upperfirst: 4.3.1
     dev: false
 
-  /eslint-plugin-import/2.25.4_eslint@7.32.0:
+  /eslint-plugin-import/2.25.4_4e45d3a7b9f8ef33842d7116d2543b58:
     resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.17.0_eslint@7.32.0+typescript@4.5.4
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.2
+      eslint-module-utils: 2.7.2_0399891fd6df64bf98347649afe6640f
       has: 1.0.3
       is-core-module: 2.8.0
       is-glob: 4.0.3
@@ -20972,6 +20691,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.0
       tsconfig-paths: 3.12.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: false
 
   /eslint-plugin-markdown/2.2.1_eslint@7.32.0:
@@ -22218,9 +21941,19 @@ packages:
     resolution: {integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=}
     dev: false
 
-  /fork-ts-checker-webpack-plugin/4.1.6:
+  /fork-ts-checker-webpack-plugin/4.1.6_typescript@4.5.4+webpack@4.46.0:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
+    peerDependencies:
+      eslint: '>= 6'
+      typescript: '>= 2.7'
+      vue-template-compiler: '*'
+      webpack: '>= 4'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      vue-template-compiler:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.16.7
       chalk: 2.4.2
@@ -22228,6 +21961,8 @@ packages:
       minimatch: 3.0.4
       semver: 5.7.1
       tapable: 1.1.3
+      typescript: 4.5.4
+      webpack: 4.46.0
       worker-rpc: 0.1.1
     dev: false
 
@@ -23446,8 +23181,6 @@ packages:
       html-minifier-terser: 6.1.0
       parse5: 6.0.1
       webpack: 5.71.0_esbuild@0.13.15
-    transitivePeerDependencies:
-      - acorn
     dev: false
 
   /html-minifier-terser/5.1.1:
@@ -23475,8 +23208,6 @@ packages:
       param-case: 3.0.4
       relateurl: 0.2.7
       terser: 5.10.0
-    transitivePeerDependencies:
-      - acorn
     dev: false
 
   /html-tags/3.1.0:
@@ -23518,8 +23249,6 @@ packages:
       pretty-error: 4.0.0
       tapable: 2.2.1
       webpack: 5.71.0_esbuild@0.13.15
-    transitivePeerDependencies:
-      - acorn
     dev: false
 
   /html5shiv/3.7.3:
@@ -27327,10 +27056,6 @@ packages:
     resolution: {integrity: sha1-fIekZGREwy11Q4VwkF8tvRsagFo=}
     dependencies:
       map-or-similar: 1.5.0
-
-  /memory-fs/0.2.0:
-    resolution: {integrity: sha1-8rslNovBIeORwlIN6Slpyu4KApA=}
-    dev: false
 
   /memory-fs/0.4.1:
     resolution: {integrity: sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=}
@@ -31533,6 +31258,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - eslint
+      - supports-color
       - typescript
       - vue-template-compiler
       - webpack
@@ -31717,6 +31443,9 @@ packages:
   /react-live/2.3.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-b+Nc7x/bLu2sPX/If1uncrmUvYtXTqxY8QpzBw/X76SA3QJ1ggU0Ld6X5phLXZ469+XWO5lOU7OpAt0JoTyZPQ==}
     engines: {node: '>= 0.12.0', npm: '>= 2.0.0'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@types/buble': 0.20.1
       buble: 0.19.6
@@ -31728,9 +31457,6 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       react-simple-code-editor: 0.11.0_react-dom@17.0.2+react@17.0.2
       unescape: 1.0.1
-    transitivePeerDependencies:
-      - react
-      - react-dom
     dev: false
 
   /react-loadable-ssr-addon-v5-slorber/1.0.1_fc8cb065053e04bf73bf05d6b2de63ea:
@@ -33593,6 +33319,7 @@ packages:
       to-array: 0.1.4
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
       - utf-8-validate
     dev: false
 
@@ -34637,11 +34364,6 @@ packages:
       - ts-node
     dev: false
 
-  /tapable/0.1.10:
-    resolution: {integrity: sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=}
-    engines: {node: '>=0.6'}
-    dev: false
-
   /tapable/1.1.3:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
     engines: {node: '>=6'}
@@ -34819,26 +34541,6 @@ packages:
       worker-farm: 1.7.0
     dev: false
 
-  /terser-webpack-plugin/4.2.3_acorn@7.4.1+webpack@4.46.0:
-    resolution: {integrity: sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      cacache: 15.3.0
-      find-cache-dir: 3.3.2
-      jest-worker: 26.6.2
-      p-limit: 3.1.0
-      schema-utils: 3.1.1
-      serialize-javascript: 5.0.1
-      source-map: 0.6.1
-      terser: 5.10.0_acorn@7.4.1
-      webpack: 4.46.0
-      webpack-sources: 1.4.3
-    transitivePeerDependencies:
-      - acorn
-    dev: false
-
   /terser-webpack-plugin/4.2.3_webpack@4.46.0:
     resolution: {integrity: sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==}
     engines: {node: '>= 10.13.0'}
@@ -34856,8 +34558,6 @@ packages:
       terser: 5.10.0
       webpack: 4.46.0
       webpack-sources: 1.4.3
-    transitivePeerDependencies:
-      - acorn
     dev: false
 
   /terser-webpack-plugin/5.3.0_esbuild@0.13.15+webpack@5.71.0:
@@ -34883,35 +34583,7 @@ packages:
       source-map: 0.6.1
       terser: 5.10.0
       webpack: 5.71.0_esbuild@0.13.15
-    transitivePeerDependencies:
-      - acorn
     dev: false
-
-  /terser-webpack-plugin/5.3.1_d9886b7c8c9b007697305832fcdd6aa3:
-    resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      esbuild: 0.13.15
-      jest-worker: 27.5.1
-      schema-utils: 3.1.1
-      serialize-javascript: 6.0.0
-      source-map: 0.6.1
-      terser: 5.10.0_acorn@8.7.0
-      webpack: 5.71.0_esbuild@0.13.15
-    transitivePeerDependencies:
-      - acorn
 
   /terser-webpack-plugin/5.3.1_esbuild@0.13.15+webpack@5.71.0:
     resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
@@ -34936,8 +34608,6 @@ packages:
       source-map: 0.6.1
       terser: 5.10.0
       webpack: 5.71.0_esbuild@0.13.15
-    transitivePeerDependencies:
-      - acorn
 
   /terser/4.8.0:
     resolution: {integrity: sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==}
@@ -34954,39 +34624,6 @@ packages:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
     engines: {node: '>=10'}
     hasBin: true
-    peerDependencies:
-      acorn: ^8.5.0
-    peerDependenciesMeta:
-      acorn:
-        optional: true
-    dependencies:
-      acorn: 8.7.0
-      commander: 2.20.3
-      source-map: 0.7.3
-      source-map-support: 0.5.21
-
-  /terser/5.10.0_acorn@7.4.1:
-    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    peerDependencies:
-      acorn: ^8.5.0
-    peerDependenciesMeta:
-      acorn:
-        optional: true
-    dependencies:
-      acorn: 7.4.1
-      commander: 2.20.3
-      source-map: 0.7.3
-      source-map-support: 0.5.21
-    dev: false
-
-  /terser/5.10.0_acorn@8.7.0:
-    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    peerDependencies:
-      acorn: ^8.5.0
     peerDependenciesMeta:
       acorn:
         optional: true
@@ -36850,7 +36487,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.1_d9886b7c8c9b007697305832fcdd6aa3
+      terser-webpack-plugin: 5.3.1_esbuild@0.13.15+webpack@5.71.0
       watchpack: 2.3.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
# PR Details

## Description

Remove `eslint-import-resolver-webpack`.

This resolver is used to resolve `webpack.config.js` and get the alias config, it is useless in modern.js projects, we did not  expose the `webpack.config.js` file.

![image](https://user-images.githubusercontent.com/7237365/168265446-eaebe9b9-ddc8-4bc8-a9ac-c1de19f32b6d.png)

## Motivation

Reduce dependencies, and fix the peer deps warning:

![image](https://user-images.githubusercontent.com/7237365/168267032-e5ff4ea5-8078-4423-a000-7c881e8408cb.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
