### PR TITLE
fix(plugin-garfish): use resolved context in config hook

### DIFF
--- a/packages/cli/plugin-garfish/src/cli/index.ts
+++ b/packages/cli/plugin-garfish/src/cli/index.ts
@@ -57,8 +57,6 @@ export default ({
       config() {
         // eslint-disable-next-line react-hooks/rules-of-hooks
         const config = useAppContext();
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const resolveOptions = useResolvedConfigContext();
         pluginsExportsUtils = createRuntimeExportsUtils(
           config.internalDirectory,
           'plugins',
@@ -83,6 +81,8 @@ export default ({
               webpackConfig: any,
               { chain, webpack, env = process.env.NODE_ENV || 'development' },
             ) => {
+              // eslint-disable-next-line react-hooks/rules-of-hooks
+              const resolveOptions = useResolvedConfigContext();
               if (resolveOptions?.deploy?.microFrontend) {
                 chain.output.libraryTarget('umd');
                 if (resolveOptions?.server?.port) {


### PR DESCRIPTION
# PR Details

Plugin Garfish invoke `useResolvedContextConfig` in config hook which can only get `{}` as a result.

## Description

move `useResolvedContextConfig` to webpack callback.

## Related Issue

nil

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
