### PR TITLE
fix(webpack): webpack watch mode rebuild twice on file change

### DIFF
--- a/.changeset/serious-rice-pretend.md
+++ b/.changeset/serious-rice-pretend.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): webpack watch mode rebuild twice on file change

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -660,6 +660,14 @@ class BaseWebpackConfig {
     return chainConfig;
   }
 
+  watchOptions() {
+    this.chain.watchOptions({
+      // fix webpack watch mode rebuild twice on file change
+      // https://github.com/webpack/webpack/issues/15431
+      aggregateTimeout: 100,
+    });
+  }
+
   getChain() {
     this.chain.context(this.appDirectory);
 
@@ -677,6 +685,7 @@ class BaseWebpackConfig {
     this.cache();
     this.optimization();
     this.stats();
+    this.watchOptions();
 
     const config = this.chain.toConfig();
 

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -661,11 +661,13 @@ class BaseWebpackConfig {
   }
 
   watchOptions() {
-    this.chain.watchOptions({
-      // fix webpack watch mode rebuild twice on file change
-      // https://github.com/webpack/webpack/issues/15431
-      aggregateTimeout: 100,
-    });
+    if (isDev()) {
+      this.chain.watchOptions({
+        // fix webpack watch mode rebuild twice on file change
+        // https://github.com/webpack/webpack/issues/15431
+        aggregateTimeout: 100,
+      });
+    }
   }
 
   getChain() {


### PR DESCRIPTION
# PR Details

## Description

webpack [v5.66.0](https://github.com/webpack/webpack/releases/tag/v5.66.0) reduce default `watchOptions.aggregateTimeout` from `200ms` to `20ms`, which caused watch mode rebuild twice on file change.

![image](https://user-images.githubusercontent.com/7237365/168538597-c33eb840-5fd2-40aa-8c5f-b2107529ea0e.png)

To fix this issue, we can increase  `watchOptions.aggregateTimeout` to `100ms` util webpack fix this issue.

![image](https://user-images.githubusercontent.com/7237365/168538661-3e6c9b02-408e-43a5-8de4-d574c1703358.png)

## Related Issue

- https://github.com/webpack/webpack/issues/15431
- https://github.com/webpack/webpack/pull/15041

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
