### PR TITLE
chore: fix integration test missing @babel/runtime dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4482,12 +4482,14 @@ importers:
 
   tests/integration/alias-set:
     specifiers:
+      '@babel/runtime': ^7
       '@modern-js/app-tools': workspace:*
       '@modern-js/runtime': workspace:*
       axios: ^0.24.0
       react: ^17.0.1
       react-dom: ^17.0.1
     dependencies:
+      '@babel/runtime': 7.17.9
       '@modern-js/runtime': link:../../../packages/cli/plugin-runtime
       axios: 0.24.0
       react: 17.0.2
@@ -4497,6 +4499,7 @@ importers:
 
   tests/integration/api-service-koa:
     specifiers:
+      '@babel/runtime': ^7
       '@modern-js/app-tools': workspace:*
       '@modern-js/plugin-bff': workspace:*
       '@modern-js/plugin-jarvis': workspace:*
@@ -4515,6 +4518,7 @@ importers:
       react-dom: ^17.0.1
       typescript: ^4
     dependencies:
+      '@babel/runtime': 7.17.9
       '@modern-js/plugin-bff': link:../../../packages/cli/plugin-bff
       '@modern-js/plugin-koa': link:../../../packages/server/plugin-koa
       '@modern-js/runtime': link:../../../packages/cli/plugin-runtime
@@ -4536,6 +4540,7 @@ importers:
 
   tests/integration/bff-express:
     specifiers:
+      '@babel/runtime': ^7
       '@modern-js/app-tools': workspace:*
       '@modern-js/plugin-bff': workspace:*
       '@modern-js/plugin-express': workspace:*
@@ -4552,6 +4557,7 @@ importers:
       react-dom: ^17.0.1
       typescript: ^4
     dependencies:
+      '@babel/runtime': 7.17.9
       '@modern-js/plugin-bff': link:../../../packages/cli/plugin-bff
       '@modern-js/plugin-express': link:../../../packages/server/plugin-express
       '@modern-js/runtime': link:../../../packages/cli/plugin-runtime
@@ -4991,12 +4997,14 @@ importers:
 
   tests/integration/esbuild/fixtures/minify-js:
     specifiers:
+      '@babel/runtime': ^7
       '@modern-js/app-tools': workspace:*
       '@modern-js/plugin-esbuild': workspace:*
       '@modern-js/runtime': workspace:*
       react: ^17.0.1
       react-dom: ^17.0.1
     dependencies:
+      '@babel/runtime': 7.17.9
       '@modern-js/runtime': link:../../../../../packages/cli/plugin-runtime
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -5006,6 +5014,7 @@ importers:
 
   tests/integration/new-mwa-app:
     specifiers:
+      '@babel/runtime': ^7
       '@modern-js/app-tools': workspace:*
       '@modern-js/plugin-jarvis': workspace:*
       '@modern-js/runtime': workspace:*
@@ -5016,6 +5025,7 @@ importers:
       react-dom: ^17.0.1
       typescript: ^4
     dependencies:
+      '@babel/runtime': 7.17.9
       '@modern-js/runtime': link:../../../packages/cli/plugin-runtime
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -5032,12 +5042,14 @@ importers:
 
   tests/integration/runtime/fixtures/use-loader:
     specifiers:
+      '@babel/runtime': ^7
       '@modern-js/app-tools': workspace:*
       '@modern-js/plugin-ssr': workspace:*
       '@modern-js/runtime': workspace:*
       react: ^17.0.1
       react-dom: ^17.0.1
     dependencies:
+      '@babel/runtime': 7.17.9
       '@modern-js/app-tools': link:../../../../../packages/solutions/app-tools
       '@modern-js/plugin-ssr': link:../../../../../packages/cli/plugin-ssr
       '@modern-js/runtime': link:../../../../../packages/cli/plugin-runtime
@@ -5046,6 +5058,7 @@ importers:
 
   tests/integration/server-config:
     specifiers:
+      '@babel/runtime': ^7
       '@modern-js/app-tools': workspace:*
       '@modern-js/plugin-jarvis': workspace:*
       '@modern-js/runtime': workspace:*
@@ -5060,6 +5073,7 @@ importers:
       react-dom: ^17.0.1
       typescript: ^4
     dependencies:
+      '@babel/runtime': 7.17.9
       '@modern-js/runtime': link:../../../packages/cli/plugin-runtime
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -5077,6 +5091,7 @@ importers:
 
   tests/integration/server-prod:
     specifiers:
+      '@babel/runtime': ^7
       '@modern-js/app-tools': workspace:*
       '@modern-js/plugin-jarvis': workspace:*
       '@modern-js/runtime': workspace:*
@@ -5085,6 +5100,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
     dependencies:
+      '@babel/runtime': 7.17.9
       '@modern-js/runtime': link:../../../packages/cli/plugin-runtime
       axios: 0.24.0
       express: 4.17.2
@@ -5096,6 +5112,7 @@ importers:
 
   tests/integration/testing-app:
     specifiers:
+      '@babel/runtime': ^7
       '@modern-js/app-tools': workspace:*
       '@modern-js/plugin-jarvis': workspace:*
       '@modern-js/plugin-testing': workspace:*
@@ -5108,6 +5125,7 @@ importers:
       react-dom: ^17.0.1
       typescript: ^4
     dependencies:
+      '@babel/runtime': 7.17.9
       '@modern-js/runtime': link:../../../packages/cli/plugin-runtime
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2

--- a/tests/integration/alias-set/package.json
+++ b/tests/integration/alias-set/package.json
@@ -7,6 +7,7 @@
     "build": "modern build"
   },
   "dependencies": {
+    "@babel/runtime": "^7",
     "@modern-js/runtime": "workspace:*",
     "axios": "^0.24.0",
     "react": "^17.0.1",

--- a/tests/integration/api-service-koa/package.json
+++ b/tests/integration/api-service-koa/package.json
@@ -35,6 +35,7 @@
     "dist/"
   ],
   "dependencies": {
+    "@babel/runtime": "^7",
     "@modern-js/plugin-bff": "workspace:*",
     "@modern-js/plugin-koa": "workspace:*",
     "@modern-js/runtime": "workspace:*",

--- a/tests/integration/bff-express/package.json
+++ b/tests/integration/bff-express/package.json
@@ -36,6 +36,7 @@
     "dist/"
   ],
   "dependencies": {
+    "@babel/runtime": "^7",
     "@modern-js/plugin-bff": "workspace:*",
     "@modern-js/plugin-express": "workspace:*",
     "@modern-js/runtime": "workspace:*",

--- a/tests/integration/esbuild/fixtures/minify-js/package.json
+++ b/tests/integration/esbuild/fixtures/minify-js/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "@babel/runtime": "^7",
     "@modern-js/runtime": "workspace:*"
   },
   "devDependencies": {

--- a/tests/integration/new-mwa-app/package.json
+++ b/tests/integration/new-mwa-app/package.json
@@ -34,6 +34,7 @@
     "dist/"
   ],
   "dependencies": {
+    "@babel/runtime": "^7",
     "@modern-js/runtime": "workspace:*",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/tests/integration/runtime/fixtures/use-loader/package.json
+++ b/tests/integration/runtime/fixtures/use-loader/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "@babel/runtime": "^7",
     "@modern-js/runtime": "workspace:*",
     "@modern-js/plugin-ssr": "workspace:*",
     "@modern-js/app-tools": "workspace:*"

--- a/tests/integration/server-config/package.json
+++ b/tests/integration/server-config/package.json
@@ -31,6 +31,7 @@
     "dist/"
   ],
   "dependencies": {
+    "@babel/runtime": "^7",
     "@modern-js/runtime": "workspace:*",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/tests/integration/server-prod/package.json
+++ b/tests/integration/server-prod/package.json
@@ -39,6 +39,7 @@
     ".rpt2_cache/"
   ],
   "dependencies": {
+    "@babel/runtime": "^7",
     "@modern-js/runtime": "workspace:*",
     "axios": "^0.24.0",
     "express": "^4.17.1",

--- a/tests/integration/testing-app/package.json
+++ b/tests/integration/testing-app/package.json
@@ -10,6 +10,7 @@
     "test": "modern test"
   },
   "dependencies": {
+    "@babel/runtime": "^7",
     "@modern-js/runtime": "workspace:*",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"


### PR DESCRIPTION
# PR Details

## Description

Fix integration test missing `@babel/runtime` dependency.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
