### PR TITLE
perf(webpack): make module-scope-plugin 10x faster

### DIFF
--- a/.changeset/twenty-vans-double.md
+++ b/.changeset/twenty-vans-double.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+feat(webpack): make module-scope-plugin 10x faster

--- a/packages/cli/webpack/src/plugins/module-scope-plugin.ts
+++ b/packages/cli/webpack/src/plugins/module-scope-plugin.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  * modified from https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/ModuleScopePlugin.js
  */
-import path from 'path';
+import { dirname, relative, resolve } from 'path';
 import { chalk } from '@modern-js/utils';
 
 export class ModuleScopePlugin {
@@ -18,6 +18,9 @@ export class ModuleScopePlugin {
   allowedPatterns: RegExp[];
 
   relativeAllowedDirs: string[];
+
+  // cache validated paths for performance
+  cache: Map<string, boolean>;
 
   constructor({
     appSrc,
@@ -35,8 +38,9 @@ export class ModuleScopePlugin {
       src => Object.prototype.toString.call(src) === '[object RegExp]',
     ) as RegExp[];
     this.relativeAllowedDirs = this.allowedDirs.map(
-      allowedDir => `${path.relative(path.dirname(allowedDir), allowedDir)}/`,
+      allowedDir => `${relative(dirname(allowedDir), allowedDir)}/`,
     );
+    this.cache = new Map();
   }
 
   apply(resolver: any) {
@@ -45,10 +49,14 @@ export class ModuleScopePlugin {
     resolver.hooks.file.tapAsync(
       'ModuleScopePlugin',
       (request: any, contextResolver: any, callback: any) => {
+        const { issuer } = request.context;
+
         // Unknown issuer, probably webpack internals
-        if (!request.context.issuer) {
+        if (!issuer || this.cache.get(issuer)) {
           return callback();
         }
+
+        this.cache.set(issuer, true);
 
         if (
           // If this resolves to a node_module, we don't care what happens next
@@ -63,16 +71,16 @@ export class ModuleScopePlugin {
         // Maybe an indexOf === 0 would be better?
         if (
           allowedDirs.every(allowedDir => {
-            const relative = path.relative(allowedDir, request.context.issuer);
+            const result = relative(allowedDir, issuer);
             // If it's not in one of our app src or a subdirectory, not our request!
-            return relative.startsWith('../') || relative.startsWith('..\\');
+            return result.startsWith('../') || result.startsWith('..\\');
           })
         ) {
           return callback();
         }
 
-        const requestFullPath = path.resolve(
-          path.dirname(request.context.issuer),
+        const requestFullPath = resolve(
+          dirname(issuer),
           request.__innerRequest_request,
         );
 
@@ -92,7 +100,7 @@ export class ModuleScopePlugin {
         // Error if in a parent directory of all given appSrcs
         if (
           allowedDirs.every(allowedDir => {
-            const requestRelative = path.relative(allowedDir, requestFullPath);
+            const requestRelative = relative(allowedDir, requestFullPath);
             return (
               requestRelative.startsWith('../') ||
               requestRelative.startsWith('..\\')
@@ -119,6 +127,8 @@ export class ModuleScopePlugin {
             writable: false,
             enumerable: false,
           });
+          // remove invalid path from cache
+          this.cache.set(issuer, false);
           return callback(scopeError, request);
         } else {
           return callback();


### PR DESCRIPTION
# PR Details

## Description

Currently `module-scope-plugin` repeats the calculation for each path, we can add cache to make the `module-scope-plugin` 10x faster.

## Benchmark

Tested in `arco-pro` project.

Before this PR:

![origin_img_v2_ef9e8827-5b53-4828-8def-fd2b541e912g](https://user-images.githubusercontent.com/7237365/168968956-d35d0368-6647-4a0a-a83c-c5c1b8cf2aa3.jpg)

After this PR:

![origin_img_v2_ab5873cb-7ab9-4711-962d-9ac4e8c3922g](https://user-images.githubusercontent.com/7237365/168968977-de224ada-f19b-437f-82d2-6ec63a557fcd.jpg)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
