### PR TITLE
refactor: adjust lint related package's deps

### DIFF
--- a/packages/cli/plugin-analyze/src/constants.ts
+++ b/packages/cli/plugin-analyze/src/constants.ts
@@ -1,6 +1,7 @@
 export const JS_EXTENSIONS = ['.js', '.ts', '.jsx', '.tsx'];
 
 export const INDEX_FILE_NAME = 'index';
+const aa = 11;
 
 export const APP_FILE_NAME = 'App';
 

--- a/packages/cli/plugin-analyze/src/constants.ts
+++ b/packages/cli/plugin-analyze/src/constants.ts
@@ -1,7 +1,6 @@
 export const JS_EXTENSIONS = ['.js', '.ts', '.jsx', '.tsx'];
 
 export const INDEX_FILE_NAME = 'index';
-const aa = 11;
 
 export const APP_FILE_NAME = 'App';
 

--- a/packages/cli/plugin-jarvis/package.json
+++ b/packages/cli/plugin-jarvis/package.json
@@ -39,31 +39,15 @@
     "test": "wireit"
   },
   "dependencies": {
-    "@babel/core": "^7.17.0",
-    "@babel/eslint-parser": "^7.15.0",
-    "@babel/eslint-plugin": "^7.14.5",
     "@babel/runtime": "^7.15.3",
     "@modern-js-app/eslint-config": "workspace:^1.2.10",
     "@modern-js/eslint-config": "workspace:^1.2.5",
     "@modern-js/tsconfig": "workspace:^1.2.0",
     "@modern-js/utils": "workspace:^1.7.4",
-    "@typescript-eslint/eslint-plugin": "^5.17.0",
-    "@typescript-eslint/parser": "^5.17.0",
     "cross-spawn": "^7.0.1",
     "eslint": "^7.32.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-eslint-comments": "^3.2.0",
-    "eslint-plugin-filenames": "^1.3.2",
-    "eslint-plugin-import": "^2.24.1",
-    "eslint-plugin-markdown": "^2.2.0",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-promise": "^5.1.0",
-    "eslint-plugin-react": "^7.24.0",
-    "eslint-plugin-react-hooks": "^4.2.0",
     "husky": "4.3.8",
-    "lint-staged": "^11.2.3",
-    "prettier": "^2.3.2"
+    "lint-staged": "^11.2.3"
   },
   "devDependencies": {
     "@modern-js/core": "workspace:*",

--- a/packages/cli/plugin-jarvis/package.json
+++ b/packages/cli/plugin-jarvis/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.2.11",
+  "version": "1.2.12",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -40,8 +40,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.15.3",
-    "@modern-js-app/eslint-config": "workspace:^1.2.10",
-    "@modern-js/eslint-config": "workspace:^1.2.5",
+    "@modern-js-app/eslint-config": "workspace:^1.2.12",
+    "@modern-js/eslint-config": "workspace:^1.2.6",
     "@modern-js/tsconfig": "workspace:^1.2.0",
     "@modern-js/utils": "workspace:^1.7.4",
     "cross-spawn": "^7.0.1",

--- a/packages/review/eslint-config-app/package.json
+++ b/packages/review/eslint-config-app/package.json
@@ -17,15 +17,29 @@
     "check": "eslint-find-rules --unused index.js",
     "stat": "eslint-index index.js --format table"
   },
-  "peerDependencies": {
-    "@modern-js/plugin-jarvis": "workspace:^1.2.11"
-  },
   "dependencies": {
-    "@modern-js/babel-preset-app": "workspace:^1.3.3"
+    "@babel/core": "^7.17.0",
+    "@babel/eslint-parser": "^7.17.0",
+    "@babel/eslint-plugin": "^7.17.0",
+    "@modern-js/babel-preset-app": "workspace:^1.3.3",
+    "@typescript-eslint/eslint-plugin": "^5.17.0",
+    "@typescript-eslint/parser": "^5.17.0",
+    "eslint": "^7.32.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-filenames": "^1.3.2",
+    "eslint-plugin-import": "^2.24.1",
+    "eslint-plugin-markdown": "^2.2.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-promise": "^5.1.0",
+    "eslint-plugin-react": "^7.24.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "prettier": "^2.3.2",
+    "typescript": "^4"
   },
   "devDependencies": {
     "@scripts/build": "workspace:*",
-    "eslint": "^7.32.0",
     "eslint-find-rules": "^3.4.0",
     "eslint-index": "^1.5.0"
   },

--- a/packages/review/eslint-config-app/package.json
+++ b/packages/review/eslint-config-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js-app/eslint-config",
-  "version": "1.2.10",
+  "version": "1.2.12",
   "description": "The meta-framework suite designed from scratch for frontend-focused modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/review/eslint-config/package.json
+++ b/packages/review/eslint-config/package.json
@@ -17,9 +17,6 @@
     "check": "eslint-find-rules --unused index.js",
     "stat": "eslint-index index.js --format table"
   },
-  "peerDependencies": {
-    "@modern-js/plugin-jarvis": "workspace:^1.2.8"
-  },
   "dependencies": {
     "@modern-js-app/eslint-config": "workspace:^1.2.9"
   },

--- a/packages/review/eslint-config/package.json
+++ b/packages/review/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/eslint-config",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "The meta-framework suite designed from scratch for frontend-focused modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",
@@ -18,7 +18,7 @@
     "stat": "eslint-index index.js --format table"
   },
   "dependencies": {
-    "@modern-js-app/eslint-config": "workspace:^1.2.9"
+    "@modern-js-app/eslint-config": "workspace:^1.2.12"
   },
   "devDependencies": {
     "@scripts/build": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,9 +810,9 @@ importers:
   packages/cli/plugin-jarvis:
     specifiers:
       '@babel/runtime': ^7.15.3
-      '@modern-js-app/eslint-config': workspace:^1.2.10
+      '@modern-js-app/eslint-config': workspace:^1.2.12
       '@modern-js/core': workspace:*
-      '@modern-js/eslint-config': workspace:^1.2.5
+      '@modern-js/eslint-config': workspace:^1.2.6
       '@modern-js/tsconfig': workspace:^1.2.0
       '@modern-js/utils': workspace:^1.7.4
       '@scripts/build': workspace:*
@@ -836,16 +836,6 @@ importers:
       '@modern-js/utils': link:../../toolkit/utils
       cross-spawn: 7.0.3
       eslint: 7.32.0
-      eslint-config-prettier: 8.3.0_eslint@7.32.0
-      eslint-plugin-eslint-comments: 3.2.0_eslint@7.32.0
-      eslint-plugin-filenames: 1.3.2_eslint@7.32.0
-      eslint-plugin-import: 2.25.4_4e45d3a7b9f8ef33842d7116d2543b58
-      eslint-plugin-markdown: 2.2.1_eslint@7.32.0
-      eslint-plugin-node: 11.1.0_eslint@7.32.0
-      eslint-plugin-prettier: 4.0.0_6e6a25a49a944db0fa38418c3ba4bc86
-      eslint-plugin-promise: 5.2.0_eslint@7.32.0
-      eslint-plugin-react: 7.28.0_eslint@7.32.0
-      eslint-plugin-react-hooks: 4.3.0_eslint@7.32.0
       husky: 4.3.8
       lint-staged: 11.2.6
     devDependencies:
@@ -2726,7 +2716,7 @@ importers:
 
   packages/review/eslint-config:
     specifiers:
-      '@modern-js-app/eslint-config': workspace:^1.2.9
+      '@modern-js-app/eslint-config': workspace:^1.2.12
       '@scripts/build': workspace:*
       eslint: ^7.32.0
       eslint-find-rules: ^3.4.0
@@ -8606,6 +8596,7 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -8714,6 +8705,7 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -8754,6 +8746,7 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -8793,6 +8786,7 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -8826,6 +8820,7 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -8856,6 +8851,7 @@ packages:
       - '@parcel/css'
       - '@swc/core'
       - '@types/react'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -8884,6 +8880,7 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -8911,6 +8908,7 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -8942,6 +8940,7 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -8979,6 +8978,7 @@ packages:
       - '@parcel/css'
       - '@swc/core'
       - '@types/react'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -9034,6 +9034,7 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -9067,6 +9068,7 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -9108,6 +9110,7 @@ packages:
       - '@parcel/css'
       - '@swc/core'
       - '@types/react'
+      - acorn
       - bufferutil
       - csso
       - debug
@@ -9411,7 +9414,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.3
+      debug: 4.3.4
       espree: 7.3.1
       globals: 12.4.0
       ignore: 4.0.6
@@ -9429,7 +9432,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.3
+      debug: 4.3.4
       espree: 7.3.1
       globals: 13.12.0
       ignore: 4.0.6
@@ -9601,7 +9604,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.3
+      debug: 4.3.4
       minimatch: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -11346,10 +11349,10 @@ packages:
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@storybook/addons': 6.4.20_react@17.0.2
       '@storybook/api': 6.4.20_react@17.0.2
-      '@storybook/builder-webpack4': 6.4.20_12edc9d24e0541c36a080f6bf6f285e8
+      '@storybook/builder-webpack4': 6.4.20_b43b76531763da8fcf690631ce26f490
       '@storybook/client-logger': 6.4.20
       '@storybook/components': 6.4.20_b08e3c15324cbe90a6ff8fcd416c932c
-      '@storybook/core': 6.4.20_350d06cf30b4367eed5fed94371c3a67
+      '@storybook/core': 6.4.20_765f8dfebdf49bc9567a04e02009dcf1
       '@storybook/core-events': 6.4.20
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.20
@@ -11770,7 +11773,7 @@ packages:
       esbuild: 0.13.15
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_typescript@4.5.4+webpack@4.46.0
+      fork-ts-checker-webpack-plugin: 4.1.6
       glob: 7.2.0
       glob-promise: 3.4.0_glob@7.2.0
       global: 4.4.0
@@ -11795,6 +11798,99 @@ packages:
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
       - '@types/react'
+      - acorn
+      - eslint
+      - supports-color
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+    dev: false
+
+  /@storybook/builder-webpack4/6.4.20_b43b76531763da8fcf690631ce26f490:
+    resolution: {integrity: sha512-Lekx2T0P5tLD0Xd2+6t2dicbZ2oTX/lW1bc+Uxz6QROLqh4/H84CTyofVLJYmZUtgnLQee/cqz5JVkpoA72ebA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/core': 7.17.8
+      '@babel/plugin-proposal-class-properties': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-proposal-decorators': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-proposal-export-default-from': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-proposal-object-rest-spread': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-proposal-optional-chaining': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-proposal-private-methods': 7.16.11_@babel+core@7.17.8
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.17.8
+      '@babel/plugin-transform-arrow-functions': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-transform-block-scoping': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-transform-classes': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-transform-destructuring': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-transform-for-of': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-transform-parameters': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-transform-shorthand-properties': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-transform-spread': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.8
+      '@babel/preset-env': 7.16.11_@babel+core@7.17.8
+      '@babel/preset-react': 7.16.7_@babel+core@7.17.8
+      '@babel/preset-typescript': 7.16.7_@babel+core@7.17.8
+      '@storybook/addons': 6.4.20_react@17.0.2
+      '@storybook/api': 6.4.20_react@17.0.2
+      '@storybook/channel-postmessage': 6.4.20
+      '@storybook/channels': 6.4.20
+      '@storybook/client-api': 6.4.20_react@17.0.2
+      '@storybook/client-logger': 6.4.20
+      '@storybook/components': 6.4.20_b08e3c15324cbe90a6ff8fcd416c932c
+      '@storybook/core-common': 6.4.20_react@17.0.2+typescript@4.5.4
+      '@storybook/core-events': 6.4.20
+      '@storybook/node-logger': 6.4.20
+      '@storybook/preview-web': 6.4.20_react@17.0.2
+      '@storybook/router': 6.4.20_react@17.0.2
+      '@storybook/semver': 7.3.2
+      '@storybook/store': 6.4.20_react@17.0.2
+      '@storybook/theming': 6.4.20_react@17.0.2
+      '@storybook/ui': 6.4.20_b08e3c15324cbe90a6ff8fcd416c932c
+      '@types/node': 14.18.4
+      '@types/webpack': 4.41.32
+      autoprefixer: 9.8.8
+      babel-loader: 8.2.3_b72fb7e629d39881e138edb6dcd0dfbe
+      babel-plugin-macros: 2.8.0
+      babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.17.8
+      case-sensitive-paths-webpack-plugin: 2.4.0
+      core-js: 3.21.1
+      css-loader: 3.6.0_webpack@4.46.0
+      esbuild: 0.13.15
+      file-loader: 6.2.0_webpack@4.46.0
+      find-up: 5.0.0
+      fork-ts-checker-webpack-plugin: 4.1.6
+      glob: 7.2.0
+      glob-promise: 3.4.0_glob@7.2.0
+      global: 4.4.0
+      html-webpack-plugin: 4.5.2_webpack@4.46.0
+      pnp-webpack-plugin: 1.6.4_typescript@4.5.4
+      postcss: 7.0.39
+      postcss-flexbugs-fixes: 4.2.1
+      postcss-loader: 4.3.0_postcss@7.0.39+webpack@4.46.0
+      raw-loader: 4.0.2_webpack@4.46.0
+      react: 17.0.2
+      stable: 0.1.8
+      style-loader: 1.3.0_webpack@4.46.0
+      terser-webpack-plugin: 4.2.3_acorn@7.4.1+webpack@4.46.0
+      ts-dedent: 2.2.0
+      typescript: 4.5.4
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
+      util-deprecate: 1.0.2
+      webpack: 4.46.0
+      webpack-dev-middleware: 3.7.3_webpack@4.46.0
+      webpack-filter-warnings-plugin: 1.2.1_webpack@4.46.0
+      webpack-hot-middleware: 2.25.1
+      webpack-virtual-modules: 0.2.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - acorn
       - eslint
       - supports-color
       - vue-template-compiler
@@ -11875,6 +11971,7 @@ packages:
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/react'
+      - acorn
       - eslint
       - supports-color
       - uglify-js
@@ -12222,6 +12319,83 @@ packages:
       ws: 8.5.0
     transitivePeerDependencies:
       - '@types/react'
+      - acorn
+      - bufferutil
+      - encoding
+      - eslint
+      - supports-color
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+    dev: false
+
+  /@storybook/core-server/6.4.20_e9ff98c847b0d2281e7643040e9ef748:
+    resolution: {integrity: sha512-AqpTjZE3/23IdDN5i6Srky3zdapQKSnHqlibl1mppRscf1IZe6OJJWtCHACpJKJwnOpPV/WxL8oron4mUjvrbA==}
+    peerDependencies:
+      '@storybook/builder-webpack5': 6.4.20
+      '@storybook/manager-webpack5': 6.4.20
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      '@storybook/builder-webpack5':
+        optional: true
+      '@storybook/manager-webpack5':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.6
+      '@storybook/builder-webpack4': 6.4.20_b43b76531763da8fcf690631ce26f490
+      '@storybook/builder-webpack5': 6.4.20_12edc9d24e0541c36a080f6bf6f285e8
+      '@storybook/core-client': 6.4.20_be15b9759c72a6d6e973db0224a0f336
+      '@storybook/core-common': 6.4.20_react@17.0.2+typescript@4.5.4
+      '@storybook/core-events': 6.4.20
+      '@storybook/csf': 0.0.2--canary.87bc651.0
+      '@storybook/csf-tools': 6.4.20
+      '@storybook/manager-webpack4': 6.4.20_b43b76531763da8fcf690631ce26f490
+      '@storybook/manager-webpack5': 6.4.20_12edc9d24e0541c36a080f6bf6f285e8
+      '@storybook/node-logger': 6.4.20
+      '@storybook/semver': 7.3.2
+      '@storybook/store': 6.4.20_react@17.0.2
+      '@types/node': 14.18.4
+      '@types/node-fetch': 2.5.12
+      '@types/pretty-hrtime': 1.0.1
+      '@types/webpack': 4.41.32
+      better-opn: 2.1.1
+      boxen: 5.1.2
+      chalk: 4.1.2
+      cli-table3: 0.6.1
+      commander: 6.2.1
+      compression: 1.7.4
+      core-js: 3.21.1
+      cpy: 8.1.2
+      detect-port: 1.3.0
+      esbuild: 0.13.15
+      express: 4.17.2
+      file-system-cache: 1.0.5
+      fs-extra: 9.1.0
+      globby: 11.0.4
+      ip: 1.1.5
+      lodash: 4.17.21
+      node-fetch: 2.6.7
+      pretty-hrtime: 1.0.3
+      prompts: 2.4.2
+      react: 17.0.2
+      regenerator-runtime: 0.13.9
+      serve-favicon: 2.5.0
+      slash: 3.0.0
+      telejson: 5.3.3
+      ts-dedent: 2.2.0
+      typescript: 4.5.4
+      util-deprecate: 1.0.2
+      watchpack: 2.3.1
+      webpack: 4.46.0
+      ws: 8.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - acorn
       - bufferutil
       - encoding
       - eslint
@@ -12255,6 +12429,41 @@ packages:
     transitivePeerDependencies:
       - '@storybook/manager-webpack5'
       - '@types/react'
+      - acorn
+      - bufferutil
+      - encoding
+      - eslint
+      - supports-color
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+    dev: false
+
+  /@storybook/core/6.4.20_765f8dfebdf49bc9567a04e02009dcf1:
+    resolution: {integrity: sha512-CQ3aaTHoHVV9BRUjqdr33cKv+/q1DMWBrtvEuZpW6gKq/CUuDXLQrAUARD18H/I5BlIJGbP5ccwkZNiY34QWKg==}
+    peerDependencies:
+      '@storybook/builder-webpack5': 6.4.20
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+      typescript: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@storybook/builder-webpack5':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@storybook/builder-webpack5': 6.4.20_12edc9d24e0541c36a080f6bf6f285e8
+      '@storybook/core-client': 6.4.20_65f43a8dda7a9e748791f44a5ec930b1
+      '@storybook/core-server': 6.4.20_e9ff98c847b0d2281e7643040e9ef748
+      react: 17.0.2
+      typescript: 4.5.4
+      webpack: 5.71.0_esbuild@0.13.15
+    transitivePeerDependencies:
+      - '@storybook/manager-webpack5'
+      - '@types/react'
+      - acorn
       - bufferutil
       - encoding
       - eslint
@@ -12288,6 +12497,7 @@ packages:
     transitivePeerDependencies:
       - '@storybook/manager-webpack5'
       - '@types/react'
+      - acorn
       - bufferutil
       - encoding
       - eslint
@@ -12378,6 +12588,67 @@ packages:
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
       - '@types/react'
+      - acorn
+      - encoding
+      - eslint
+      - supports-color
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+    dev: false
+
+  /@storybook/manager-webpack4/6.4.20_b43b76531763da8fcf690631ce26f490:
+    resolution: {integrity: sha512-4Q9ZJNT64Omn0shD8JfXi1yccjQVWruBxKoELbn4zLOUtmb5/ETmBHkek/nBnLo7i5J6ZkyB66L9qokfC/WsxQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/core': 7.17.8
+      '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.8
+      '@babel/preset-react': 7.16.7_@babel+core@7.17.8
+      '@storybook/addons': 6.4.20_react@17.0.2
+      '@storybook/core-client': 6.4.20_be15b9759c72a6d6e973db0224a0f336
+      '@storybook/core-common': 6.4.20_react@17.0.2+typescript@4.5.4
+      '@storybook/node-logger': 6.4.20
+      '@storybook/theming': 6.4.20_react@17.0.2
+      '@storybook/ui': 6.4.20_b08e3c15324cbe90a6ff8fcd416c932c
+      '@types/node': 14.18.4
+      '@types/webpack': 4.41.32
+      babel-loader: 8.2.3_b72fb7e629d39881e138edb6dcd0dfbe
+      case-sensitive-paths-webpack-plugin: 2.4.0
+      chalk: 4.1.2
+      core-js: 3.21.1
+      css-loader: 3.6.0_webpack@4.46.0
+      esbuild: 0.13.15
+      express: 4.17.2
+      file-loader: 6.2.0_webpack@4.46.0
+      file-system-cache: 1.0.5
+      find-up: 5.0.0
+      fs-extra: 9.1.0
+      html-webpack-plugin: 4.5.2_webpack@4.46.0
+      node-fetch: 2.6.7
+      pnp-webpack-plugin: 1.6.4_typescript@4.5.4
+      react: 17.0.2
+      read-pkg-up: 7.0.1
+      regenerator-runtime: 0.13.9
+      resolve-from: 5.0.0
+      style-loader: 1.3.0_webpack@4.46.0
+      telejson: 5.3.3
+      terser-webpack-plugin: 4.2.3_acorn@7.4.1+webpack@4.46.0
+      ts-dedent: 2.2.0
+      typescript: 4.5.4
+      url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
+      util-deprecate: 1.0.2
+      webpack: 4.46.0
+      webpack-dev-middleware: 3.7.3_webpack@4.46.0
+      webpack-virtual-modules: 0.2.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - acorn
       - encoding
       - eslint
       - supports-color
@@ -12435,6 +12706,7 @@ packages:
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/react'
+      - acorn
       - encoding
       - eslint
       - supports-color
@@ -12552,6 +12824,7 @@ packages:
       - '@storybook/manager-webpack5'
       - '@types/react'
       - '@types/webpack'
+      - acorn
       - bufferutil
       - encoding
       - eslint
@@ -18741,32 +19014,17 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
 
   /debug/3.1.0:
     resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.1.3
 
@@ -19080,8 +19338,6 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /detect-port/1.3.0:
@@ -19091,8 +19347,6 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
-    transitivePeerDependencies:
-      - supports-color
 
   /detective/5.2.0:
     resolution: {integrity: sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==}
@@ -20038,7 +20292,6 @@ packages:
       yeast: 0.1.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
     dev: false
 
@@ -20700,26 +20953,12 @@ packages:
       yargs: 11.1.1
     dev: true
 
-  /eslint-module-utils/2.7.2_0399891fd6df64bf98347649afe6640f:
+  /eslint-module-utils/2.7.2:
     resolution: {integrity: sha512-zquepFnWCY2ISMFwD/DqzaM++H+7PDzOpUvotJWm/y1BAFt5R4oeULgdrTejKqLkz7MA/tgstsUMNYc7wNdTrg==}
     engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.17.0_eslint@7.32.0+typescript@4.5.4
-      eslint-import-resolver-node: 0.3.6
+      debug: 3.2.7
+      find-up: 2.1.0
     dev: false
 
   /eslint-plugin-es/3.0.1_eslint@7.32.0:
@@ -20756,35 +20995,26 @@ packages:
       lodash.upperfirst: 4.3.1
     dev: false
 
-  /eslint-plugin-import/2.25.4_4e45d3a7b9f8ef33842d7116d2543b58:
+  /eslint-plugin-import/2.25.4_eslint@7.32.0:
     resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
     engines: {node: '>=4'}
     peerDependencies:
-      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.17.0_eslint@7.32.0+typescript@4.5.4
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.2_0399891fd6df64bf98347649afe6640f
+      eslint-module-utils: 2.7.2
       has: 1.0.3
       is-core-module: 2.8.1
       is-glob: 4.0.3
       minimatch: 3.0.4
       object.values: 1.1.5
       resolve: 1.22.0
-      tsconfig-paths: 3.12.0
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
+      tsconfig-paths: 3.14.1
     dev: false
 
   /eslint-plugin-markdown/2.2.1_eslint@7.32.0:
@@ -22038,19 +22268,9 @@ packages:
     resolution: {integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=}
     dev: false
 
-  /fork-ts-checker-webpack-plugin/4.1.6_typescript@4.5.4+webpack@4.46.0:
+  /fork-ts-checker-webpack-plugin/4.1.6:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
-    peerDependencies:
-      eslint: '>= 6'
-      typescript: '>= 2.7'
-      vue-template-compiler: '*'
-      webpack: '>= 4'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      vue-template-compiler:
-        optional: true
     dependencies:
       '@babel/code-frame': 7.16.7
       chalk: 2.4.2
@@ -22058,8 +22278,6 @@ packages:
       minimatch: 3.0.4
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 4.5.4
-      webpack: 4.46.0
       worker-rpc: 0.1.1
     dev: false
 
@@ -23282,6 +23500,8 @@ packages:
       html-minifier-terser: 6.1.0
       parse5: 6.0.1
       webpack: 5.71.0_esbuild@0.13.15
+    transitivePeerDependencies:
+      - acorn
     dev: false
 
   /html-minifier-terser/5.1.1:
@@ -23309,6 +23529,8 @@ packages:
       param-case: 3.0.4
       relateurl: 0.2.7
       terser: 5.10.0
+    transitivePeerDependencies:
+      - acorn
     dev: false
 
   /html-tags/3.1.0:
@@ -23350,6 +23572,8 @@ packages:
       pretty-error: 4.0.0
       tapable: 2.2.1
       webpack: 5.71.0_esbuild@0.13.15
+    transitivePeerDependencies:
+      - acorn
     dev: false
 
   /html5shiv/3.7.3:
@@ -31367,7 +31591,6 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - eslint
-      - supports-color
       - typescript
       - vue-template-compiler
       - webpack
@@ -31552,9 +31775,6 @@ packages:
   /react-live/2.3.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-b+Nc7x/bLu2sPX/If1uncrmUvYtXTqxY8QpzBw/X76SA3QJ1ggU0Ld6X5phLXZ469+XWO5lOU7OpAt0JoTyZPQ==}
     engines: {node: '>= 0.12.0', npm: '>= 2.0.0'}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
     dependencies:
       '@types/buble': 0.20.1
       buble: 0.19.6
@@ -31566,6 +31786,9 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       react-simple-code-editor: 0.11.0_react-dom@17.0.2+react@17.0.2
       unescape: 1.0.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
     dev: false
 
   /react-loadable-ssr-addon-v5-slorber/1.0.1_fc8cb065053e04bf73bf05d6b2de63ea:
@@ -33428,7 +33651,6 @@ packages:
       to-array: 0.1.4
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
       - utf-8-validate
     dev: false
 
@@ -34650,6 +34872,26 @@ packages:
       worker-farm: 1.7.0
     dev: false
 
+  /terser-webpack-plugin/4.2.3_acorn@7.4.1+webpack@4.46.0:
+    resolution: {integrity: sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      cacache: 15.3.0
+      find-cache-dir: 3.3.2
+      jest-worker: 26.6.2
+      p-limit: 3.1.0
+      schema-utils: 3.1.1
+      serialize-javascript: 5.0.1
+      source-map: 0.6.1
+      terser: 5.10.0_acorn@7.4.1
+      webpack: 4.46.0
+      webpack-sources: 1.4.3
+    transitivePeerDependencies:
+      - acorn
+    dev: false
+
   /terser-webpack-plugin/4.2.3_webpack@4.46.0:
     resolution: {integrity: sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==}
     engines: {node: '>= 10.13.0'}
@@ -34667,6 +34909,8 @@ packages:
       terser: 5.10.0
       webpack: 4.46.0
       webpack-sources: 1.4.3
+    transitivePeerDependencies:
+      - acorn
     dev: false
 
   /terser-webpack-plugin/5.3.0_esbuild@0.13.15+webpack@5.71.0:
@@ -34692,7 +34936,35 @@ packages:
       source-map: 0.6.1
       terser: 5.10.0
       webpack: 5.71.0_esbuild@0.13.15
+    transitivePeerDependencies:
+      - acorn
     dev: false
+
+  /terser-webpack-plugin/5.3.1_d9886b7c8c9b007697305832fcdd6aa3:
+    resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      esbuild: 0.13.15
+      jest-worker: 27.5.1
+      schema-utils: 3.1.1
+      serialize-javascript: 6.0.0
+      source-map: 0.6.1
+      terser: 5.10.0_acorn@8.7.0
+      webpack: 5.71.0_esbuild@0.13.15
+    transitivePeerDependencies:
+      - acorn
 
   /terser-webpack-plugin/5.3.1_esbuild@0.13.15+webpack@5.71.0:
     resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
@@ -34717,6 +34989,8 @@ packages:
       source-map: 0.6.1
       terser: 5.10.0
       webpack: 5.71.0_esbuild@0.13.15
+    transitivePeerDependencies:
+      - acorn
 
   /terser/4.8.0:
     resolution: {integrity: sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==}
@@ -34733,6 +35007,39 @@ packages:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
     engines: {node: '>=10'}
     hasBin: true
+    peerDependencies:
+      acorn: ^8.5.0
+    peerDependenciesMeta:
+      acorn:
+        optional: true
+    dependencies:
+      acorn: 8.7.0
+      commander: 2.20.3
+      source-map: 0.7.3
+      source-map-support: 0.5.21
+
+  /terser/5.10.0_acorn@7.4.1:
+    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    peerDependencies:
+      acorn: ^8.5.0
+    peerDependenciesMeta:
+      acorn:
+        optional: true
+    dependencies:
+      acorn: 7.4.1
+      commander: 2.20.3
+      source-map: 0.7.3
+      source-map-support: 0.5.21
+    dev: false
+
+  /terser/5.10.0_acorn@8.7.0:
+    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    peerDependencies:
+      acorn: ^8.5.0
     peerDependenciesMeta:
       acorn:
         optional: true
@@ -36605,7 +36912,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.1_esbuild@0.13.15+webpack@5.71.0
+      terser-webpack-plugin: 5.3.1_d9886b7c8c9b007697305832fcdd6aa3
       watchpack: 2.3.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -809,9 +809,6 @@ importers:
 
   packages/cli/plugin-jarvis:
     specifiers:
-      '@babel/core': ^7.17.0
-      '@babel/eslint-parser': ^7.15.0
-      '@babel/eslint-plugin': ^7.14.5
       '@babel/runtime': ^7.15.3
       '@modern-js-app/eslint-config': workspace:^1.2.10
       '@modern-js/core': workspace:*
@@ -825,36 +822,18 @@ importers:
       '@types/node': ^14
       '@types/react': ^17
       '@types/react-dom': ^17
-      '@typescript-eslint/eslint-plugin': ^5.17.0
-      '@typescript-eslint/parser': ^5.17.0
       cross-spawn: ^7.0.1
       eslint: ^7.32.0
-      eslint-config-prettier: ^8.3.0
-      eslint-plugin-eslint-comments: ^3.2.0
-      eslint-plugin-filenames: ^1.3.2
-      eslint-plugin-import: ^2.24.1
-      eslint-plugin-markdown: ^2.2.0
-      eslint-plugin-node: ^11.1.0
-      eslint-plugin-prettier: ^4.0.0
-      eslint-plugin-promise: ^5.1.0
-      eslint-plugin-react: ^7.24.0
-      eslint-plugin-react-hooks: ^4.2.0
       husky: 4.3.8
       jest: ^27
       lint-staged: ^11.2.3
-      prettier: ^2.3.2
       typescript: ^4
     dependencies:
-      '@babel/core': 7.17.8
-      '@babel/eslint-parser': 7.16.5_@babel+core@7.17.8+eslint@7.32.0
-      '@babel/eslint-plugin': 7.16.5_bd6d92c29f43bb8c4e96480c43aa3a3b
       '@babel/runtime': 7.16.7
       '@modern-js-app/eslint-config': link:../../review/eslint-config-app
       '@modern-js/eslint-config': link:../../review/eslint-config
       '@modern-js/tsconfig': link:../../review/tsconfig
       '@modern-js/utils': link:../../toolkit/utils
-      '@typescript-eslint/eslint-plugin': 5.17.0_2de05dc4f6e006e27551942a75536f07
-      '@typescript-eslint/parser': 5.17.0_eslint@7.32.0+typescript@4.5.4
       cross-spawn: 7.0.3
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0_eslint@7.32.0
@@ -869,7 +848,6 @@ importers:
       eslint-plugin-react-hooks: 4.3.0_eslint@7.32.0
       husky: 4.3.8
       lint-staged: 11.2.6
-      prettier: 2.5.1
     devDependencies:
       '@modern-js/core': link:../core
       '@scripts/build': link:../../../scripts/build
@@ -2763,16 +2741,50 @@ importers:
 
   packages/review/eslint-config-app:
     specifiers:
+      '@babel/core': ^7.17.0
+      '@babel/eslint-parser': ^7.17.0
+      '@babel/eslint-plugin': ^7.17.0
       '@modern-js/babel-preset-app': workspace:^1.3.3
       '@scripts/build': workspace:*
+      '@typescript-eslint/eslint-plugin': ^5.17.0
+      '@typescript-eslint/parser': ^5.17.0
       eslint: ^7.32.0
+      eslint-config-prettier: ^8.3.0
       eslint-find-rules: ^3.4.0
       eslint-index: ^1.5.0
+      eslint-plugin-eslint-comments: ^3.2.0
+      eslint-plugin-filenames: ^1.3.2
+      eslint-plugin-import: ^2.24.1
+      eslint-plugin-markdown: ^2.2.0
+      eslint-plugin-node: ^11.1.0
+      eslint-plugin-prettier: ^4.0.0
+      eslint-plugin-promise: ^5.1.0
+      eslint-plugin-react: ^7.24.0
+      eslint-plugin-react-hooks: ^4.2.0
+      prettier: ^2.3.2
+      typescript: ^4
     dependencies:
+      '@babel/core': 7.17.8
+      '@babel/eslint-parser': 7.17.0_@babel+core@7.17.8+eslint@7.32.0
+      '@babel/eslint-plugin': 7.17.7_515d8656fcd46b03c06d80c44514b8c3
       '@modern-js/babel-preset-app': link:../../cli/babel-preset-app
+      '@typescript-eslint/eslint-plugin': 5.17.0_2de05dc4f6e006e27551942a75536f07
+      '@typescript-eslint/parser': 5.17.0_eslint@7.32.0+typescript@4.5.4
+      eslint: 7.32.0
+      eslint-config-prettier: 8.3.0_eslint@7.32.0
+      eslint-plugin-eslint-comments: 3.2.0_eslint@7.32.0
+      eslint-plugin-filenames: 1.3.2_eslint@7.32.0
+      eslint-plugin-import: 2.25.4_eslint@7.32.0
+      eslint-plugin-markdown: 2.2.1_eslint@7.32.0
+      eslint-plugin-node: 11.1.0_eslint@7.32.0
+      eslint-plugin-prettier: 4.0.0_6e6a25a49a944db0fa38418c3ba4bc86
+      eslint-plugin-promise: 5.2.0_eslint@7.32.0
+      eslint-plugin-react: 7.28.0_eslint@7.32.0
+      eslint-plugin-react-hooks: 4.3.0_eslint@7.32.0
+      prettier: 2.5.1
+      typescript: 4.5.4
     devDependencies:
       '@scripts/build': link:../../../scripts/build
-      eslint: 7.32.0
       eslint-find-rules: 3.6.1_eslint@7.32.0
       eslint-index: 1.5.0
 
@@ -5816,8 +5828,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/eslint-parser/7.16.5_@babel+core@7.17.8+eslint@7.32.0:
-    resolution: {integrity: sha512-mUqYa46lgWqHKQ33Q6LNCGp/wPR3eqOYTUixHFsfrSQqRxH0+WOzca75iEjFr5RDGH1dDz622LaHhLOzOuQRUA==}
+  /@babel/eslint-parser/7.17.0_@babel+core@7.17.8+eslint@7.32.0:
+    resolution: {integrity: sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': '>=7.11.0'
@@ -5830,14 +5842,14 @@ packages:
       semver: 6.3.0
     dev: false
 
-  /@babel/eslint-plugin/7.16.5_bd6d92c29f43bb8c4e96480c43aa3a3b:
-    resolution: {integrity: sha512-R1p6RMyU1Xl1U/NNr+D4+HjkQzN5dQOX0MpjW9WLWhHDjhzN9gso96MxxOFvPh0fKF/mMH8TGW2kuqQ2eK2s9A==}
+  /@babel/eslint-plugin/7.17.7_515d8656fcd46b03c06d80c44514b8c3:
+    resolution: {integrity: sha512-JATUoJJXSgwI0T8juxWYtK1JSgoLpIGUsCHIv+NMXcUDA2vIe6nvAHR9vnuJgs/P1hOFw7vPwibixzfqBBLIVw==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/eslint-parser': '>=7.11.0'
       eslint: '>=7.5.0'
     dependencies:
-      '@babel/eslint-parser': 7.16.5_@babel+core@7.17.8+eslint@7.32.0
+      '@babel/eslint-parser': 7.17.0_@babel+core@7.17.8+eslint@7.32.0
       eslint: 7.32.0
       eslint-rule-composer: 0.3.0
     dev: false
@@ -14145,12 +14157,12 @@ packages:
       '@typescript-eslint/scope-manager': 5.17.0
       '@typescript-eslint/type-utils': 5.17.0_eslint@7.32.0+typescript@4.5.4
       '@typescript-eslint/utils': 5.17.0_eslint@7.32.0+typescript@4.5.4
-      debug: 4.3.3
+      debug: 4.3.4
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
-      semver: 7.3.5
+      semver: 7.3.7
       tsutils: 3.21.0_typescript@4.5.4
       typescript: 4.5.4
     transitivePeerDependencies:
@@ -14170,7 +14182,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.17.0
       '@typescript-eslint/types': 5.17.0
       '@typescript-eslint/typescript-estree': 5.17.0_typescript@4.5.4
-      debug: 4.3.3
+      debug: 4.3.4
       eslint: 7.32.0
       typescript: 4.5.4
     transitivePeerDependencies:
@@ -14196,7 +14208,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/utils': 5.17.0_eslint@7.32.0+typescript@4.5.4
-      debug: 4.3.3
+      debug: 4.3.4
       eslint: 7.32.0
       tsutils: 3.21.0_typescript@4.5.4
       typescript: 4.5.4
@@ -14220,10 +14232,10 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.17.0
       '@typescript-eslint/visitor-keys': 5.17.0
-      debug: 4.3.3
-      globby: 11.0.4
+      debug: 4.3.4
+      globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.5
+      semver: 7.3.7
       tsutils: 3.21.0_typescript@4.5.4
       typescript: 4.5.4
     transitivePeerDependencies:
@@ -20711,7 +20723,7 @@ packages:
     dev: false
 
   /eslint-plugin-es/3.0.1_eslint@7.32.0:
-    resolution: {integrity: sha1-dafN/czdwFiZNK7rOEF18iHFeJM=}
+    resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
@@ -20722,7 +20734,7 @@ packages:
     dev: false
 
   /eslint-plugin-eslint-comments/3.2.0_eslint@7.32.0:
-    resolution: {integrity: sha1-nhzXtEE1JquzE5MwcderoFyhL/o=}
+    resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
     peerDependencies:
       eslint: '>=4.19.1'
@@ -20733,7 +20745,7 @@ packages:
     dev: false
 
   /eslint-plugin-filenames/1.3.2_eslint@7.32.0:
-    resolution: {integrity: sha1-cJTwDXrv3WmZ46wZ9yzqBY5ZDPc=}
+    resolution: {integrity: sha512-tqxJTiEM5a0JmRCUYQmxw23vtTxrb2+a3Q2mMOPhFxvt7ZQQJmdiuMby9B/vUAuVMghyP7oET+nIf6EO6CBd/w==}
     peerDependencies:
       eslint: '*'
     dependencies:
@@ -20763,7 +20775,7 @@ packages:
       eslint-import-resolver-node: 0.3.6
       eslint-module-utils: 2.7.2_0399891fd6df64bf98347649afe6640f
       has: 1.0.3
-      is-core-module: 2.8.0
+      is-core-module: 2.8.1
       is-glob: 4.0.3
       minimatch: 3.0.4
       object.values: 1.1.5
@@ -20854,14 +20866,14 @@ packages:
       object.fromentries: 2.0.5
       object.hasown: 1.1.0
       object.values: 1.1.5
-      prop-types: 15.8.0
+      prop-types: 15.8.1
       resolve: 2.0.0-next.3
       semver: 6.3.0
       string.prototype.matchall: 4.0.6
     dev: false
 
   /eslint-rule-composer/0.3.0:
-    resolution: {integrity: sha1-eTIMknsMXA09PSt2yLSkiPJbuvk=}
+    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
     engines: {node: '>=4.0.0'}
     dev: false
 
@@ -22775,7 +22787,6 @@ packages:
       ignore: 5.2.0
       merge2: 1.4.1
       slash: 3.0.0
-    dev: true
 
   /globby/12.2.0:
     resolution: {integrity: sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==}
@@ -30282,6 +30293,7 @@ packages:
   /prettier/2.5.1:
     resolution: {integrity: sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
     dev: false
 
   /pretty-error/2.1.2:
@@ -35273,15 +35285,6 @@ packages:
       typescript: 4.5.4
     dev: false
 
-  /tsconfig-paths/3.12.0:
-    resolution: {integrity: sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==}
-    dependencies:
-      '@types/json5': 0.0.29
-      json5: 1.0.1
-      minimist: 1.2.5
-      strip-bom: 3.0.0
-    dev: false
-
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
@@ -35289,7 +35292,6 @@ packages:
       json5: 1.0.1
       minimist: 1.2.6
       strip-bom: 3.0.0
-    dev: true
 
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}


### PR DESCRIPTION
# PR Details

1.  Move eslint related deps to `@modern-js/eslint-config-app`.
2. Add `typecripts` in `@modern-js/eslint-config-app` since `@typescript-eslint/*` depend on it,  otherwise the lint may fail in a JS project.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
