### PR TITLE
feat: support tools.webpackChain config

### DIFF
--- a/.changeset/clean-clocks-punch.md
+++ b/.changeset/clean-clocks-punch.md
@@ -1,0 +1,13 @@
+---
+'@modern-js/core': minor
+'@modern-js/plugin-bff': minor
+'@modern-js/plugin-esbuild': minor
+'@modern-js/plugin-fast-refresh': minor
+'@modern-js/plugin-garfish': minor
+'@modern-js/plugin-less': minor
+'@modern-js/plugin-sass': minor
+'@modern-js/plugin-ssr': minor
+'@modern-js/webpack': minor
+---
+
+feat: support tools.webpackChain config

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@jest/types": "^27.0.6",
     "@modern-js/types": "workspace:*",
+    "@modern-js/webpack": "workspace:*",
     "@scripts/build": "workspace:*",
     "@scripts/jest-config": "workspace:*",
     "@types/babel__code-frame": "^7.0.3",

--- a/packages/cli/core/src/config/mergeConfig.ts
+++ b/packages/cli/core/src/config/mergeConfig.ts
@@ -14,6 +14,7 @@ export interface NormalizedToolsConfig
   extends Omit<
     ToolsConfig,
     | 'webpack'
+    | 'webpackChain'
     | 'babel'
     | 'postcss'
     | 'autoprefixer'
@@ -25,6 +26,9 @@ export interface NormalizedToolsConfig
     | 'styledComponents'
   > {
   webpack: ToolsConfig['webpack'] | Array<NonNullable<ToolsConfig['webpack']>>;
+  webpackChain:
+    | ToolsConfig['webpackChain']
+    | Array<NonNullable<ToolsConfig['webpackChain']>>;
   babel: ToolsConfig['babel'] | Array<NonNullable<ToolsConfig['babel']>>;
   postcss: ToolsConfig['postcss'] | Array<NonNullable<ToolsConfig['postcss']>>;
   styledComponents:

--- a/packages/cli/core/src/config/schema/tools.ts
+++ b/packages/cli/core/src/config/schema/tools.ts
@@ -3,6 +3,7 @@ export const tools = {
   additionalProperties: false,
   properties: {
     webpack: { typeof: ['object', 'function'] },
+    webpackChain: { typeof: ['function'] },
     babel: { typeof: ['object', 'function'] },
     postcss: { typeof: ['object', 'function'] },
     lodash: { typeof: ['object', 'function'] },

--- a/packages/cli/core/src/config/types/index.ts
+++ b/packages/cli/core/src/config/types/index.ts
@@ -4,6 +4,7 @@ import type { MetaOptions } from '@modern-js/utils';
 import type { TransformOptions } from '@babel/core';
 import type webpack from 'webpack';
 import type { Configuration as WebpackConfiguration } from 'webpack';
+import type { WebpackChain } from '@modern-js/webpack';
 import type autoprefixer from 'autoprefixer';
 import type {
   BasePluginOptions,
@@ -216,10 +217,20 @@ export type WebpackConfig =
       // FIXME: utils type
       utils: {
         env: string;
+        name: string;
         webpack: typeof webpack;
         [key: string]: any;
       },
     ) => WebpackConfiguration | void);
+
+export type WebpackChainConfig = (
+  chain: WebpackChain,
+  utils: {
+    env: string;
+    name: string;
+    webpack: typeof webpack;
+  },
+) => void;
 
 export type BabelConfig =
   | TransformOptions
@@ -236,6 +247,7 @@ export type TerserConfig =
 
 export interface ToolsConfig {
   webpack?: WebpackConfig;
+  webpackChain?: WebpackChainConfig;
   babel?: BabelConfig;
   autoprefixer?: AutoprefixerConfig;
   postcss?: ConfigFunction;

--- a/packages/cli/core/src/config/types/index.ts
+++ b/packages/cli/core/src/config/types/index.ts
@@ -219,6 +219,10 @@ export type WebpackConfig =
         env: string;
         name: string;
         webpack: typeof webpack;
+        /**
+         * @deprecated please use `tools.webpackChain` instead.
+         */
+        chain: WebpackChain;
         [key: string]: any;
       },
     ) => WebpackConfiguration | void);

--- a/packages/cli/plugin-bff/src/cli.ts
+++ b/packages/cli/plugin-bff/src/cli.ts
@@ -24,7 +24,7 @@ export default (): CliPlugin => ({
     config() {
       return {
         tools: {
-          webpack: (_config, { chain }) => {
+          webpackChain: (chain, { name }) => {
             const { appDirectory, port } = api.useAppContext();
             const modernConfig = api.useResolvedConfigContext() as UserConfig;
             const { bff } = modernConfig || {};
@@ -52,7 +52,7 @@ export default (): CliPlugin => ({
                 apiDir: rootDir,
                 port,
                 fetcher,
-                target: _config.name,
+                target: name,
                 requestCreator: bff?.requestCreator,
               });
           },

--- a/packages/cli/plugin-bff/tests/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/plugin-bff/tests/__snapshots__/cli.test.ts.snap
@@ -10,7 +10,7 @@ Array [
       ],
     },
     "tools": Object {
-      "webpack": [Function],
+      "webpackChain": [Function],
     },
   },
 ]

--- a/packages/cli/plugin-bff/tests/cli.test.ts
+++ b/packages/cli/plugin-bff/tests/cli.test.ts
@@ -51,7 +51,7 @@ describe('bff cli plugin', () => {
         port: 3000,
       } as any);
     });
-    manager.run(() => tools.webpack({}, { chain }));
+    manager.run(() => tools.webpackChain(chain, {}));
 
     expect(chain.toConfig()).toMatchObject({
       module: {

--- a/packages/cli/plugin-esbuild/src/index.ts
+++ b/packages/cli/plugin-esbuild/src/index.ts
@@ -12,11 +12,13 @@ export default (): CliPlugin => ({
     config() {
       return {
         tools: {
-          webpack: (config, { chain }) => {
+          webpackChain: chain => {
             const resolvedConfig = api.useResolvedConfigContext();
 
             const { esbuild = {} } = resolvedConfig.tools;
 
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error webpack-chain missing minimizers type
             chain.optimization.minimizers
               .delete('js')
               .delete('css')

--- a/packages/cli/plugin-fast-refresh/src/cli.ts
+++ b/packages/cli/plugin-fast-refresh/src/cli.ts
@@ -8,7 +8,7 @@ export default (): CliPlugin => ({
     config() {
       return {
         tools: {
-          webpack: (config, { chain, name }) => {
+          webpackChain: (chain, { name }) => {
             if (name === 'client' && isFastRefresh()) {
               const ReactFastRefreshPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
               chain.plugin('react-fast-refresh').use(ReactFastRefreshPlugin, [

--- a/packages/cli/plugin-garfish/src/cli/index.ts
+++ b/packages/cli/plugin-garfish/src/cli/index.ts
@@ -126,19 +126,17 @@ export default ({
                 'Access-Control-Allow-Origin': '*',
               },
             },
-            webpack: (
-              webpackConfig: any,
-              { chain, webpack, env = process.env.NODE_ENV || 'development' },
+            webpackChain: (
+              chain,
+              { webpack, env = process.env.NODE_ENV || 'development' },
             ) => {
               // eslint-disable-next-line react-hooks/rules-of-hooks
               const resolveOptions = useResolvedConfigContext();
               if (resolveOptions?.deploy?.microFrontend) {
                 chain.output.libraryTarget('umd');
-                if (resolveOptions?.server?.port) {
+                if (resolveOptions?.server?.port && env === 'development') {
                   chain.output.publicPath(
-                    env === 'development'
-                      ? `//localhost:${resolveOptions.server.port}/`
-                      : webpackConfig.output.publicPath,
+                    `//localhost:${resolveOptions.server.port}/`,
                   );
                 }
                 // add comments avoid sourcemap abnormal

--- a/packages/cli/plugin-garfish/tests/cli.test.tsx
+++ b/packages/cli/plugin-garfish/tests/cli.test.tsx
@@ -153,8 +153,7 @@ describe('plugin-garfish cli', () => {
     webpackConfig.plugin('html-main').use(HTMLWebpackPlugin);
 
 
-    config[0].tools.webpack({}, {
-      chain: webpackConfig,
+    config[0].tools.webpackChain(webpackConfig, {
       webpack: jest.fn(),
       env: 'development'
     });
@@ -192,8 +191,7 @@ describe('plugin-garfish cli', () => {
     function HTMLWebpackPlugin() {};
     webpackConfig.plugin('html-main').use(HTMLWebpackPlugin);
 
-    config[0].tools.webpack({}, {
-      chain: webpackConfig,
+    config[0].tools.webpackChain(webpackConfig, {
       webpack: jest.fn(),
       env: 'development'
     });

--- a/packages/cli/plugin-less/src/cli.ts
+++ b/packages/cli/plugin-less/src/cli.ts
@@ -26,7 +26,7 @@ export default (): CliPlugin => ({
     config() {
       return {
         tools: {
-          webpack: (config, { chain }) => {
+          webpackChain: chain => {
             const options = api.useResolvedConfigContext();
 
             const {
@@ -48,6 +48,8 @@ export default (): CliPlugin => ({
                   : LESS_REGEX,
                 exclude: LESS_MODULE_REGEX,
                 use: [
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-expect-error webpack-chain missing type
                   ...loaders.oneOf('css').toConfig().use,
                   {
                     loader: require.resolve('less-loader'),
@@ -65,6 +67,8 @@ export default (): CliPlugin => ({
                   : LESS_MODULE_REGEX,
                 exclude: [/node_modules/, GLOBAL_LESS_REGEX],
                 use: [
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-expect-error webpack-chain missing type
                   ...loaders.oneOf('css-modules').toConfig().use,
                   {
                     loader: require.resolve('less-loader'),

--- a/packages/cli/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/cli/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -4,7 +4,7 @@ exports[`plugin less test config 1`] = `
 Array [
   Object {
     "tools": Object {
-      "webpack": [Function],
+      "webpackChain": [Function],
     },
   },
 ]

--- a/packages/cli/plugin-sass/src/cli.ts
+++ b/packages/cli/plugin-sass/src/cli.ts
@@ -25,7 +25,7 @@ export default (): CliPlugin => ({
       config() {
         return {
           tools: {
-            webpack: (config, { chain }) => {
+            webpackChain: chain => {
               const options = api.useResolvedConfigContext();
 
               const {
@@ -47,6 +47,8 @@ export default (): CliPlugin => ({
                     : SASS_REGEX,
                   exclude: SASS_MODULE_REGEX,
                   use: [
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-expect-error webpack-chain missing minimizers type
                     ...loaders.oneOf('css').toConfig().use,
                     {
                       loader: require.resolve('sass-loader'),
@@ -64,6 +66,8 @@ export default (): CliPlugin => ({
                     : SASS_MODULE_REGEX,
                   exclude: [/node_modules/, GLOBAL_SASS_REGEX],
                   use: [
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-expect-error webpack-chain missing minimizers type
                     ...loaders.oneOf('css-modules').toConfig().use,
                     {
                       loader: require.resolve('sass-loader'),

--- a/packages/cli/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/cli/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -4,7 +4,7 @@ exports[`plugin sass test config 1`] = `
 Array [
   Object {
     "tools": Object {
-      "webpack": [Function],
+      "webpackChain": [Function],
     },
   },
 ]

--- a/packages/cli/plugin-ssr/src/cli/index.ts
+++ b/packages/cli/plugin-ssr/src/cli/index.ts
@@ -36,9 +36,9 @@ export default (): CliPlugin => ({
             },
           },
           tools: {
-            webpack: (config, { chain }) => {
+            webpackChain: (chain, { name }) => {
               const userConfig = api.useResolvedConfigContext();
-              if (isUseSSRBundle(userConfig) && config.name !== 'server') {
+              if (isUseSSRBundle(userConfig) && name !== 'server') {
                 chain
                   .plugin('loadable')
                   .use(LoadableWebpackPlugin, [

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -670,6 +670,26 @@ class BaseWebpackConfig {
     }
   }
 
+  applyToolsWebpackChain() {
+    if (!this.options.tools) {
+      return;
+    }
+
+    const { webpackChain } = this.options.tools;
+    if (webpackChain) {
+      const toArray = <T>(item: T | T[]): T[] =>
+        Array.isArray(item) ? item : [item];
+
+      toArray(webpackChain).forEach(item => {
+        item(this.chain, {
+          env: process.env.NODE_ENV!,
+          name: this.chain.get('name'),
+          webpack,
+        });
+      });
+    }
+  }
+
   getChain() {
     this.chain.context(this.appDirectory);
 
@@ -688,6 +708,7 @@ class BaseWebpackConfig {
     this.optimization();
     this.stats();
     this.watchOptions();
+    this.applyToolsWebpackChain();
 
     const config = this.chain.toConfig();
 

--- a/packages/cli/webpack/src/utils/getWebpackLogging.ts
+++ b/packages/cli/webpack/src/utils/getWebpackLogging.ts
@@ -10,20 +10,17 @@ export const getWebpackLogging = () => ({
   level: 'info',
   console: {
     ...webpackLogger,
-    info: (...args: any[]) => {
-      const messages = args.filter(arg => !/\[webpack-dev-server\]/.test(arg));
+    info: (...messages: string[]) => {
       if (messages.length) {
         webpackLogger.info(...messages);
       }
     },
-    warn: (...args: any[]) => {
-      const messages = args.filter(
-        arg =>
-          !/\[webpack.cache.PackFileCacheStrategy/.test(arg) &&
-          !/\[webpack-dev-server\]/.test(arg),
+    warn: (...messages: string[]) => {
+      const filtered = messages.filter(
+        message => !/\[webpack.cache.PackFileCacheStrategy/.test(message),
       );
-      if (messages.length) {
-        webpackLogger.warn(...messages);
+      if (filtered.length) {
+        webpackLogger.warn(...filtered);
       }
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,7 @@ importers:
       '@modern-js/plugin': workspace:^1.3.4
       '@modern-js/types': workspace:*
       '@modern-js/utils': workspace:^1.7.4
+      '@modern-js/webpack': workspace:*
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@types/babel__code-frame': ^7.0.3
@@ -261,6 +262,7 @@ importers:
     devDependencies:
       '@jest/types': 27.5.1
       '@modern-js/types': link:../../toolkit/types
+      '@modern-js/webpack': link:../webpack
       '@scripts/build': link:../../../scripts/build
       '@scripts/jest-config': link:../../../scripts/jest-config
       '@types/babel__code-frame': 7.0.3
@@ -856,7 +858,7 @@ importers:
       eslint-config-prettier: 8.3.0_eslint@7.32.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.32.0
       eslint-plugin-filenames: 1.3.2_eslint@7.32.0
-      eslint-plugin-import: 2.25.4_eslint@7.32.0
+      eslint-plugin-import: 2.25.4_4e45d3a7b9f8ef33842d7116d2543b58
       eslint-plugin-markdown: 2.2.1_eslint@7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
       eslint-plugin-prettier: 4.0.0_6e6a25a49a944db0fa38418c3ba4bc86
@@ -5952,8 +5954,8 @@ packages:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-environment-visitor': 7.16.7
-      '@babel/helper-function-name': 7.16.7
-      '@babel/helper-member-expression-to-functions': 7.16.7
+      '@babel/helper-function-name': 7.17.9
+      '@babel/helper-member-expression-to-functions': 7.17.7
       '@babel/helper-optimise-call-expression': 7.16.7
       '@babel/helper-replace-supers': 7.16.7
       '@babel/helper-split-export-declaration': 7.16.7
@@ -6083,6 +6085,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.10
+    dev: false
 
   /@babel/helper-member-expression-to-functions/7.17.7:
     resolution: {integrity: sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==}
@@ -8589,7 +8592,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8698,7 +8700,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8739,7 +8740,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8779,7 +8779,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8813,7 +8812,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8844,7 +8842,6 @@ packages:
       - '@parcel/css'
       - '@swc/core'
       - '@types/react'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8873,7 +8870,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8901,7 +8897,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8933,7 +8928,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -8971,7 +8965,6 @@ packages:
       - '@parcel/css'
       - '@swc/core'
       - '@types/react'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -9027,7 +9020,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -9061,7 +9053,6 @@ packages:
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -9103,7 +9094,6 @@ packages:
       - '@parcel/css'
       - '@swc/core'
       - '@types/react'
-      - acorn
       - bufferutil
       - csso
       - debug
@@ -11342,10 +11332,10 @@ packages:
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@storybook/addons': 6.4.20_react@17.0.2
       '@storybook/api': 6.4.20_react@17.0.2
-      '@storybook/builder-webpack4': 6.4.20_b43b76531763da8fcf690631ce26f490
+      '@storybook/builder-webpack4': 6.4.20_12edc9d24e0541c36a080f6bf6f285e8
       '@storybook/client-logger': 6.4.20
       '@storybook/components': 6.4.20_b08e3c15324cbe90a6ff8fcd416c932c
-      '@storybook/core': 6.4.20_765f8dfebdf49bc9567a04e02009dcf1
+      '@storybook/core': 6.4.20_350d06cf30b4367eed5fed94371c3a67
       '@storybook/core-events': 6.4.20
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.20
@@ -11766,7 +11756,7 @@ packages:
       esbuild: 0.13.15
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6
+      fork-ts-checker-webpack-plugin: 4.1.6_typescript@4.5.4+webpack@4.46.0
       glob: 7.2.0
       glob-promise: 3.4.0_glob@7.2.0
       global: 4.4.0
@@ -11791,99 +11781,6 @@ packages:
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
       - '@types/react'
-      - acorn
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: false
-
-  /@storybook/builder-webpack4/6.4.20_b43b76531763da8fcf690631ce26f490:
-    resolution: {integrity: sha512-Lekx2T0P5tLD0Xd2+6t2dicbZ2oTX/lW1bc+Uxz6QROLqh4/H84CTyofVLJYmZUtgnLQee/cqz5JVkpoA72ebA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/plugin-proposal-class-properties': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-proposal-decorators': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-proposal-export-default-from': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-proposal-object-rest-spread': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-proposal-optional-chaining': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-proposal-private-methods': 7.16.11_@babel+core@7.17.8
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.17.8
-      '@babel/plugin-transform-arrow-functions': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-block-scoping': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-classes': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-destructuring': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-for-of': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-parameters': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-shorthand-properties': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-spread': 7.16.7_@babel+core@7.17.8
-      '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.8
-      '@babel/preset-env': 7.16.11_@babel+core@7.17.8
-      '@babel/preset-react': 7.16.7_@babel+core@7.17.8
-      '@babel/preset-typescript': 7.16.7_@babel+core@7.17.8
-      '@storybook/addons': 6.4.20_react@17.0.2
-      '@storybook/api': 6.4.20_react@17.0.2
-      '@storybook/channel-postmessage': 6.4.20
-      '@storybook/channels': 6.4.20
-      '@storybook/client-api': 6.4.20_react@17.0.2
-      '@storybook/client-logger': 6.4.20
-      '@storybook/components': 6.4.20_b08e3c15324cbe90a6ff8fcd416c932c
-      '@storybook/core-common': 6.4.20_react@17.0.2+typescript@4.5.4
-      '@storybook/core-events': 6.4.20
-      '@storybook/node-logger': 6.4.20
-      '@storybook/preview-web': 6.4.20_react@17.0.2
-      '@storybook/router': 6.4.20_react@17.0.2
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.4.20_react@17.0.2
-      '@storybook/theming': 6.4.20_react@17.0.2
-      '@storybook/ui': 6.4.20_b08e3c15324cbe90a6ff8fcd416c932c
-      '@types/node': 14.18.4
-      '@types/webpack': 4.41.32
-      autoprefixer: 9.8.8
-      babel-loader: 8.2.3_b72fb7e629d39881e138edb6dcd0dfbe
-      babel-plugin-macros: 2.8.0
-      babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.17.8
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      core-js: 3.21.1
-      css-loader: 3.6.0_webpack@4.46.0
-      esbuild: 0.13.15
-      file-loader: 6.2.0_webpack@4.46.0
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6
-      glob: 7.2.0
-      glob-promise: 3.4.0_glob@7.2.0
-      global: 4.4.0
-      html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4_typescript@4.5.4
-      postcss: 7.0.39
-      postcss-flexbugs-fixes: 4.2.1
-      postcss-loader: 4.3.0_postcss@7.0.39+webpack@4.46.0
-      raw-loader: 4.0.2_webpack@4.46.0
-      react: 17.0.2
-      stable: 0.1.8
-      style-loader: 1.3.0_webpack@4.46.0
-      terser-webpack-plugin: 4.2.3_acorn@7.4.1+webpack@4.46.0
-      ts-dedent: 2.2.0
-      typescript: 4.5.4
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-      webpack-dev-middleware: 3.7.3_webpack@4.46.0
-      webpack-filter-warnings-plugin: 1.2.1_webpack@4.46.0
-      webpack-hot-middleware: 2.25.1
-      webpack-virtual-modules: 0.2.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - acorn
       - eslint
       - supports-color
       - vue-template-compiler
@@ -11964,7 +11861,6 @@ packages:
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/react'
-      - acorn
       - eslint
       - supports-color
       - uglify-js
@@ -12312,83 +12208,6 @@ packages:
       ws: 8.5.0
     transitivePeerDependencies:
       - '@types/react'
-      - acorn
-      - bufferutil
-      - encoding
-      - eslint
-      - supports-color
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: false
-
-  /@storybook/core-server/6.4.20_e9ff98c847b0d2281e7643040e9ef748:
-    resolution: {integrity: sha512-AqpTjZE3/23IdDN5i6Srky3zdapQKSnHqlibl1mppRscf1IZe6OJJWtCHACpJKJwnOpPV/WxL8oron4mUjvrbA==}
-    peerDependencies:
-      '@storybook/builder-webpack5': 6.4.20
-      '@storybook/manager-webpack5': 6.4.20
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      '@storybook/builder-webpack5':
-        optional: true
-      '@storybook/manager-webpack5':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.6
-      '@storybook/builder-webpack4': 6.4.20_b43b76531763da8fcf690631ce26f490
-      '@storybook/builder-webpack5': 6.4.20_12edc9d24e0541c36a080f6bf6f285e8
-      '@storybook/core-client': 6.4.20_be15b9759c72a6d6e973db0224a0f336
-      '@storybook/core-common': 6.4.20_react@17.0.2+typescript@4.5.4
-      '@storybook/core-events': 6.4.20
-      '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/csf-tools': 6.4.20
-      '@storybook/manager-webpack4': 6.4.20_b43b76531763da8fcf690631ce26f490
-      '@storybook/manager-webpack5': 6.4.20_12edc9d24e0541c36a080f6bf6f285e8
-      '@storybook/node-logger': 6.4.20
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.4.20_react@17.0.2
-      '@types/node': 14.18.4
-      '@types/node-fetch': 2.5.12
-      '@types/pretty-hrtime': 1.0.1
-      '@types/webpack': 4.41.32
-      better-opn: 2.1.1
-      boxen: 5.1.2
-      chalk: 4.1.2
-      cli-table3: 0.6.1
-      commander: 6.2.1
-      compression: 1.7.4
-      core-js: 3.21.1
-      cpy: 8.1.2
-      detect-port: 1.3.0
-      esbuild: 0.13.15
-      express: 4.17.2
-      file-system-cache: 1.0.5
-      fs-extra: 9.1.0
-      globby: 11.0.4
-      ip: 1.1.5
-      lodash: 4.17.21
-      node-fetch: 2.6.7
-      pretty-hrtime: 1.0.3
-      prompts: 2.4.2
-      react: 17.0.2
-      regenerator-runtime: 0.13.9
-      serve-favicon: 2.5.0
-      slash: 3.0.0
-      telejson: 5.3.3
-      ts-dedent: 2.2.0
-      typescript: 4.5.4
-      util-deprecate: 1.0.2
-      watchpack: 2.3.1
-      webpack: 4.46.0
-      ws: 8.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - acorn
       - bufferutil
       - encoding
       - eslint
@@ -12422,41 +12241,6 @@ packages:
     transitivePeerDependencies:
       - '@storybook/manager-webpack5'
       - '@types/react'
-      - acorn
-      - bufferutil
-      - encoding
-      - eslint
-      - supports-color
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: false
-
-  /@storybook/core/6.4.20_765f8dfebdf49bc9567a04e02009dcf1:
-    resolution: {integrity: sha512-CQ3aaTHoHVV9BRUjqdr33cKv+/q1DMWBrtvEuZpW6gKq/CUuDXLQrAUARD18H/I5BlIJGbP5ccwkZNiY34QWKg==}
-    peerDependencies:
-      '@storybook/builder-webpack5': 6.4.20
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      '@storybook/builder-webpack5':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@storybook/builder-webpack5': 6.4.20_12edc9d24e0541c36a080f6bf6f285e8
-      '@storybook/core-client': 6.4.20_65f43a8dda7a9e748791f44a5ec930b1
-      '@storybook/core-server': 6.4.20_e9ff98c847b0d2281e7643040e9ef748
-      react: 17.0.2
-      typescript: 4.5.4
-      webpack: 5.71.0_esbuild@0.13.15
-    transitivePeerDependencies:
-      - '@storybook/manager-webpack5'
-      - '@types/react'
-      - acorn
       - bufferutil
       - encoding
       - eslint
@@ -12490,7 +12274,6 @@ packages:
     transitivePeerDependencies:
       - '@storybook/manager-webpack5'
       - '@types/react'
-      - acorn
       - bufferutil
       - encoding
       - eslint
@@ -12581,67 +12364,6 @@ packages:
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
       - '@types/react'
-      - acorn
-      - encoding
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: false
-
-  /@storybook/manager-webpack4/6.4.20_b43b76531763da8fcf690631ce26f490:
-    resolution: {integrity: sha512-4Q9ZJNT64Omn0shD8JfXi1yccjQVWruBxKoELbn4zLOUtmb5/ETmBHkek/nBnLo7i5J6ZkyB66L9qokfC/WsxQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.8
-      '@babel/preset-react': 7.16.7_@babel+core@7.17.8
-      '@storybook/addons': 6.4.20_react@17.0.2
-      '@storybook/core-client': 6.4.20_be15b9759c72a6d6e973db0224a0f336
-      '@storybook/core-common': 6.4.20_react@17.0.2+typescript@4.5.4
-      '@storybook/node-logger': 6.4.20
-      '@storybook/theming': 6.4.20_react@17.0.2
-      '@storybook/ui': 6.4.20_b08e3c15324cbe90a6ff8fcd416c932c
-      '@types/node': 14.18.4
-      '@types/webpack': 4.41.32
-      babel-loader: 8.2.3_b72fb7e629d39881e138edb6dcd0dfbe
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      chalk: 4.1.2
-      core-js: 3.21.1
-      css-loader: 3.6.0_webpack@4.46.0
-      esbuild: 0.13.15
-      express: 4.17.2
-      file-loader: 6.2.0_webpack@4.46.0
-      file-system-cache: 1.0.5
-      find-up: 5.0.0
-      fs-extra: 9.1.0
-      html-webpack-plugin: 4.5.2_webpack@4.46.0
-      node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4_typescript@4.5.4
-      react: 17.0.2
-      read-pkg-up: 7.0.1
-      regenerator-runtime: 0.13.9
-      resolve-from: 5.0.0
-      style-loader: 1.3.0_webpack@4.46.0
-      telejson: 5.3.3
-      terser-webpack-plugin: 4.2.3_acorn@7.4.1+webpack@4.46.0
-      ts-dedent: 2.2.0
-      typescript: 4.5.4
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-      webpack-dev-middleware: 3.7.3_webpack@4.46.0
-      webpack-virtual-modules: 0.2.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - acorn
       - encoding
       - eslint
       - supports-color
@@ -12699,7 +12421,6 @@ packages:
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/react'
-      - acorn
       - encoding
       - eslint
       - supports-color
@@ -12817,7 +12538,6 @@ packages:
       - '@storybook/manager-webpack5'
       - '@types/react'
       - '@types/webpack'
-      - acorn
       - bufferutil
       - encoding
       - eslint
@@ -19007,17 +18727,32 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
 
   /debug/3.1.0:
     resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
 
@@ -19331,6 +19066,8 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /detect-port/1.3.0:
@@ -19340,6 +19077,8 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
 
   /detective/5.2.0:
     resolution: {integrity: sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==}
@@ -20285,6 +20024,7 @@ packages:
       yeast: 0.1.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
       - utf-8-validate
     dev: false
 
@@ -20946,12 +20686,26 @@ packages:
       yargs: 11.1.1
     dev: true
 
-  /eslint-module-utils/2.7.2:
+  /eslint-module-utils/2.7.2_0399891fd6df64bf98347649afe6640f:
     resolution: {integrity: sha512-zquepFnWCY2ISMFwD/DqzaM++H+7PDzOpUvotJWm/y1BAFt5R4oeULgdrTejKqLkz7MA/tgstsUMNYc7wNdTrg==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
-      debug: 3.2.7
-      find-up: 2.1.0
+      '@typescript-eslint/parser': 5.17.0_eslint@7.32.0+typescript@4.5.4
+      eslint-import-resolver-node: 0.3.6
     dev: false
 
   /eslint-plugin-es/3.0.1_eslint@7.32.0:
@@ -20988,19 +20742,24 @@ packages:
       lodash.upperfirst: 4.3.1
     dev: false
 
-  /eslint-plugin-import/2.25.4_eslint@7.32.0:
+  /eslint-plugin-import/2.25.4_4e45d3a7b9f8ef33842d7116d2543b58:
     resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.17.0_eslint@7.32.0+typescript@4.5.4
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.2
+      eslint-module-utils: 2.7.2_0399891fd6df64bf98347649afe6640f
       has: 1.0.3
       is-core-module: 2.8.0
       is-glob: 4.0.3
@@ -21008,6 +20767,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.0
       tsconfig-paths: 3.12.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: false
 
   /eslint-plugin-markdown/2.2.1_eslint@7.32.0:
@@ -22261,9 +22024,19 @@ packages:
     resolution: {integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=}
     dev: false
 
-  /fork-ts-checker-webpack-plugin/4.1.6:
+  /fork-ts-checker-webpack-plugin/4.1.6_typescript@4.5.4+webpack@4.46.0:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
+    peerDependencies:
+      eslint: '>= 6'
+      typescript: '>= 2.7'
+      vue-template-compiler: '*'
+      webpack: '>= 4'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      vue-template-compiler:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.16.7
       chalk: 2.4.2
@@ -22271,6 +22044,8 @@ packages:
       minimatch: 3.0.4
       semver: 5.7.1
       tapable: 1.1.3
+      typescript: 4.5.4
+      webpack: 4.46.0
       worker-rpc: 0.1.1
     dev: false
 
@@ -23494,8 +23269,6 @@ packages:
       html-minifier-terser: 6.1.0
       parse5: 6.0.1
       webpack: 5.71.0_esbuild@0.13.15
-    transitivePeerDependencies:
-      - acorn
     dev: false
 
   /html-minifier-terser/5.1.1:
@@ -23523,8 +23296,6 @@ packages:
       param-case: 3.0.4
       relateurl: 0.2.7
       terser: 5.10.0
-    transitivePeerDependencies:
-      - acorn
     dev: false
 
   /html-tags/3.1.0:
@@ -23566,8 +23337,6 @@ packages:
       pretty-error: 4.0.0
       tapable: 2.2.1
       webpack: 5.71.0_esbuild@0.13.15
-    transitivePeerDependencies:
-      - acorn
     dev: false
 
   /html5shiv/3.7.3:
@@ -31578,6 +31347,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - eslint
+      - supports-color
       - typescript
       - vue-template-compiler
       - webpack
@@ -31762,6 +31532,9 @@ packages:
   /react-live/2.3.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-b+Nc7x/bLu2sPX/If1uncrmUvYtXTqxY8QpzBw/X76SA3QJ1ggU0Ld6X5phLXZ469+XWO5lOU7OpAt0JoTyZPQ==}
     engines: {node: '>= 0.12.0', npm: '>= 2.0.0'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@types/buble': 0.20.1
       buble: 0.19.6
@@ -31773,9 +31546,6 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       react-simple-code-editor: 0.11.0_react-dom@17.0.2+react@17.0.2
       unescape: 1.0.1
-    transitivePeerDependencies:
-      - react
-      - react-dom
     dev: false
 
   /react-loadable-ssr-addon-v5-slorber/1.0.1_fc8cb065053e04bf73bf05d6b2de63ea:
@@ -33638,6 +33408,7 @@ packages:
       to-array: 0.1.4
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
       - utf-8-validate
     dev: false
 
@@ -34859,26 +34630,6 @@ packages:
       worker-farm: 1.7.0
     dev: false
 
-  /terser-webpack-plugin/4.2.3_acorn@7.4.1+webpack@4.46.0:
-    resolution: {integrity: sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      cacache: 15.3.0
-      find-cache-dir: 3.3.2
-      jest-worker: 26.6.2
-      p-limit: 3.1.0
-      schema-utils: 3.1.1
-      serialize-javascript: 5.0.1
-      source-map: 0.6.1
-      terser: 5.10.0_acorn@7.4.1
-      webpack: 4.46.0
-      webpack-sources: 1.4.3
-    transitivePeerDependencies:
-      - acorn
-    dev: false
-
   /terser-webpack-plugin/4.2.3_webpack@4.46.0:
     resolution: {integrity: sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==}
     engines: {node: '>= 10.13.0'}
@@ -34896,8 +34647,6 @@ packages:
       terser: 5.10.0
       webpack: 4.46.0
       webpack-sources: 1.4.3
-    transitivePeerDependencies:
-      - acorn
     dev: false
 
   /terser-webpack-plugin/5.3.0_esbuild@0.13.15+webpack@5.71.0:
@@ -34923,35 +34672,7 @@ packages:
       source-map: 0.6.1
       terser: 5.10.0
       webpack: 5.71.0_esbuild@0.13.15
-    transitivePeerDependencies:
-      - acorn
     dev: false
-
-  /terser-webpack-plugin/5.3.1_d9886b7c8c9b007697305832fcdd6aa3:
-    resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      esbuild: 0.13.15
-      jest-worker: 27.5.1
-      schema-utils: 3.1.1
-      serialize-javascript: 6.0.0
-      source-map: 0.6.1
-      terser: 5.10.0_acorn@8.7.0
-      webpack: 5.71.0_esbuild@0.13.15
-    transitivePeerDependencies:
-      - acorn
 
   /terser-webpack-plugin/5.3.1_esbuild@0.13.15+webpack@5.71.0:
     resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
@@ -34976,8 +34697,6 @@ packages:
       source-map: 0.6.1
       terser: 5.10.0
       webpack: 5.71.0_esbuild@0.13.15
-    transitivePeerDependencies:
-      - acorn
 
   /terser/4.8.0:
     resolution: {integrity: sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==}
@@ -34994,39 +34713,6 @@ packages:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
     engines: {node: '>=10'}
     hasBin: true
-    peerDependencies:
-      acorn: ^8.5.0
-    peerDependenciesMeta:
-      acorn:
-        optional: true
-    dependencies:
-      acorn: 8.7.0
-      commander: 2.20.3
-      source-map: 0.7.3
-      source-map-support: 0.5.21
-
-  /terser/5.10.0_acorn@7.4.1:
-    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    peerDependencies:
-      acorn: ^8.5.0
-    peerDependenciesMeta:
-      acorn:
-        optional: true
-    dependencies:
-      acorn: 7.4.1
-      commander: 2.20.3
-      source-map: 0.7.3
-      source-map-support: 0.5.21
-    dev: false
-
-  /terser/5.10.0_acorn@8.7.0:
-    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    peerDependencies:
-      acorn: ^8.5.0
     peerDependenciesMeta:
       acorn:
         optional: true
@@ -36909,7 +36595,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.1_d9886b7c8c9b007697305832fcdd6aa3
+      terser-webpack-plugin: 5.3.1_esbuild@0.13.15+webpack@5.71.0
       watchpack: 2.3.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/website/docs/apis/config/tools/autoprefixer.md
+++ b/website/docs/apis/config/tools/autoprefixer.md
@@ -1,6 +1,5 @@
 ---
 sidebar_label: autoprefixer
-sidebar_position: 2
 ---
 
 # tools.autoprefixer

--- a/website/docs/apis/config/tools/babel.md
+++ b/website/docs/apis/config/tools/babel.md
@@ -1,6 +1,5 @@
 ---
 sidebar_label: babel
-sidebar_position: 1
 ---
 
 # tools.babel

--- a/website/docs/apis/config/tools/dev-server.md
+++ b/website/docs/apis/config/tools/dev-server.md
@@ -1,6 +1,5 @@
 ---
 sidebar_label: devServer
-sidebar_position: 12
 ---
 
 # tools.devServer

--- a/website/docs/apis/config/tools/jest.md
+++ b/website/docs/apis/config/tools/jest.md
@@ -1,6 +1,5 @@
 ---
 sidebar_label: jest
-sidebar_position: 10
 ---
 
 # tools.jest

--- a/website/docs/apis/config/tools/less.md
+++ b/website/docs/apis/config/tools/less.md
@@ -1,6 +1,5 @@
 ---
 sidebar_label: less
-sidebar_position: 7
 ---
 
 # tools.less

--- a/website/docs/apis/config/tools/postcss.md
+++ b/website/docs/apis/config/tools/postcss.md
@@ -1,6 +1,5 @@
 ---
 sidebar_label: postcss
-sidebar_position: 3
 ---
 
 # tools.postcss

--- a/website/docs/apis/config/tools/sass.md
+++ b/website/docs/apis/config/tools/sass.md
@@ -1,6 +1,5 @@
 ---
 sidebar_label: sass
-sidebar_position: 6
 ---
 
 # tools.sass

--- a/website/docs/apis/config/tools/styled-components.md
+++ b/website/docs/apis/config/tools/styled-components.md
@@ -1,6 +1,5 @@
 ---
 sidebar_label: styledComponents
-sidebar_position: 4
 ---
 
 # tools.styledComponents

--- a/website/docs/apis/config/tools/tailwindcss.md
+++ b/website/docs/apis/config/tools/tailwindcss.md
@@ -1,6 +1,5 @@
 ---
 sidebar_label: tailwindcss
-sidebar_position: 5
 ---
 
 # tools.tailwindcss

--- a/website/docs/apis/config/tools/webpack-chain.md
+++ b/website/docs/apis/config/tools/webpack-chain.md
@@ -1,0 +1,105 @@
+---
+sidebar_label: webpackChain
+---
+
+# tools.webpackChain
+
+:::info 适用的工程方案
+MWA。
+:::
+
+- 类型： `(chain, { env, name, webpack }) => void`
+- 默认值： `undefined`
+
+通过 [webpack-chain](https://github.com/neutrinojs/webpack-chain) 来修改默认的 webpack 配置，值为 `Function` 类型。
+
+- 函数的第一个参数为 `webpack-chain` 对象。
+- 函数的第二个参数为一些工具集合，包括 `env`、`name`、`webpack` 等。
+
+相比于 `tools.webpack`，**webpack-chain 不仅支持链式调用，而且能够基于别名来定位到内置的 Rule 或 Plugin，从而实现精准的配置修改。**我们推荐使用 `tools.webpackChain` 来代替 `tools.webpack`。
+
+## 示例
+
+以下是一些常见用法的示例，完整 API 请参考 [webpack-chain 文档](https://github.com/neutrinojs/webpack-chain)。
+
+### 新增 loader
+
+```js title="modern.config.js"
+export default defineConfig({
+  tools: {
+    webpackChain: chain => {
+      chain.module
+        .rule('compile-svg')
+        .test(/\.svg$/)
+        .use('svg-inline')
+        .loader('svg-inline-loader');
+    },
+  },
+});
+```
+
+### 新增 plugin
+
+```js title="modern.config.js"
+import CleanPlugin from 'clean-webpack-plugin';
+
+export default defineConfig({
+  tools: {
+    webpackChain: chain => {
+      chain.plugin('clean').use(CleanPlugin, [['dist'], { root: '/dir' }]);
+    },
+  },
+});
+```
+
+### 获取环境
+
+通过 `env` 参数可以判断当前环境为 `development` 还是 `production`：
+
+```js title="modern.config.js"
+export default defineConfig({
+  tools: {
+    webpackChain: (chain, { env }) => {
+      console.log(env); // => development
+    },
+  },
+});
+```
+
+### webpack
+
+通过 `webpack` 参数可以获取 Modern.js 内部使用的 webpack 对象。
+
+```js title="modern.config.js"
+export default defineConfig({
+  tools: {
+    webpackChain: (chain, { webpack }) => {
+      console.log(
+        new webpack.BannerPlugin({
+          banner: 'hello world!',
+        }),
+      );
+    },
+  },
+});
+```
+
+建议优先使用该参数来访问 webpack 对象，而不是通过 import 来引入 `webpack`。
+
+如果需要通过 import 引入，则项目里需要单独安装 webpack 依赖，这样可能会导致 webpack 被重复安装，因此不推荐该做法。
+
+```js title="modern.config.js"
+import webpack from 'webpack';
+
+export default defineConfig({
+  tools: {
+    webpackChain: (chain) => {
+      console.log(
+        new webpack.BannerPlugin({
+          banner: 'hello world!',
+        }),
+      );
+    },
+  },
+});
+```

--- a/website/docs/apis/config/tools/webpack.md
+++ b/website/docs/apis/config/tools/webpack.md
@@ -1,6 +1,5 @@
 ---
 sidebar_label: webpack
-sidebar_position: 11
 ---
 
 # tools.webpack


### PR DESCRIPTION
# PR Details

## Description

This is part of the RFC-001 implementation

Changes:

- support `tools.webpackChain` config.
- migrate plugins from `tools.webpack` to `tools.webpackChain`
- add document of tools.webpackChain` 
- webpack logger no need to filter webpack-dev-server (webpack-dev-server is no longer used)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
