### PR TITLE
docs: remove `postcss-preset-env`

### DIFF
--- a/website/docs/guides/tutorials/c05-component/5.2-use-standalone-component.md
+++ b/website/docs/guides/tutorials/c05-component/5.2-use-standalone-component.md
@@ -82,9 +82,9 @@ declare module 'react-ladda' {
 ![result1](https://lf3-static.bytednsdoc.com/obj/eden-cn/aphqeh7uhohpquloj/modern-js/docs/05/result1.png)
 
 :::info 注
-CSS 文件会自动经过 [postcss-preset-env](https://preset-env.cssdb.org/features)、[autoprefixer](https://github.com/postcss/autoprefixer) 等主流 PostCSS 项目的处理，不用担心平台兼容性问题（如果有特殊兼容需求可以调整 [browserslist](/docs/guides/tutorials/c04-es6-plus-and-ts/4.3-compatibility) 配置）
+CSS 文件会自动经过 Modern.js 内置的 [PostCSS](docs/guides/usages/css/postcss) 的处理，能够满足大多数项目的样式开发需求。
 
-也支持导入 SCSS、Less 文件。有的组件使用 CSS in JS，不需要额外导入样式文件，下一节会有相关介绍。
+Modern.js 也支持导入 SCSS、Less 文件。此外，有的组件使用 CSS in JS，不需要额外导入样式文件，下一节会有相关介绍。
 :::
 
 ---

--- a/website/docs/guides/tutorials/c06-css-and-component/6.3-postcss.md
+++ b/website/docs/guides/tutorials/c06-css-and-component/6.3-postcss.md
@@ -51,7 +51,7 @@ import './styles/utils.css';
 ```
 
 :::info 注
-上一节提到过，Modern.js 集成了 [postcss-preset-env](https://preset-env.cssdb.org/features)、[autoprefixer](https://github.com/postcss/autoprefixer) 等主流 PostCSS 项目，因此不但会自动处理平台兼容性，也支持现代 CSS 语法特性，比如 [custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)。
+Modern.js 集成了 [PostCSS](docs/guides/usages/css/postcss)，支持现代 CSS 语法特性，比如 [custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*)。
 :::
 
 在 `src/components/Item/index.tsx` 里使用，把：


### PR DESCRIPTION
# PR Details

Remove `postcss-preset-env`.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
