### PR TITLE
fix(core): should not register a `core` command

### DIFF
--- a/.changeset/early-camels-lie.md
+++ b/.changeset/early-camels-lie.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/core': patch
+---
+
+fix(core): should not register the `core` command

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "new": "modern new",
     "setup": "npm run reset && pnpm install",
-    "reset": "pnpm dlx rimraf ./**/node_modules",
+    "reset": "npx rimraf ./**/node_modules",
     "test": "npm run test:ut",
     "test:ut": "node --conditions=jsnext:source -r btsm node_modules/jest/bin/jest.js -c jest.config.js --maxWorkers=2",
     "test:e2e": "cd tests && npm run test",

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -38,7 +38,6 @@
       ]
     }
   },
-  "bin": "./dist/bin.js",
   "scripts": {
     "prepare": "pnpm build",
     "prepublishOnly": "only-allow-pnpm",


### PR DESCRIPTION
# PR Details

## Description

The `modern` command is provided by `xxx-tools`, and `@modern-js/core` should not register a `core` command.

Fix the following error:

![origin_img_v2_f3ff35e7-ebc5-4765-92ee-7048fd5e07ag](https://user-images.githubusercontent.com/7237365/169624421-cf206cdf-2d7a-46b7-9051-2166e11837e1.jpg)

Remove:

![image](https://user-images.githubusercontent.com/7237365/169624500-c7a264d8-df5d-45e5-987f-e42b3dd0f66e.png)

Also change `pnpm dlx rimraf` to `npx rimraf` because `pnpm dlx` will modify the lock file.

## Related Issue

https://github.com/modern-js-dev/modern.js/issues/438#issuecomment-1004526723

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
