### PR TITLE
fix(webpack): ts checker runs twice when ssr is enabled

### DIFF
--- a/.changeset/perfect-mirrors-grab.md
+++ b/.changeset/perfect-mirrors-grab.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): ts checker runs twice when ssr is enabled

--- a/packages/cli/webpack/src/config/node.ts
+++ b/packages/cli/webpack/src/config/node.ts
@@ -121,6 +121,9 @@ class NodeWebpackConfig extends BaseWebpackConfig {
 
     this.useDefinePlugin();
 
+    // Avoid repeated execution of ts checker
+    this.chain.plugins.delete(CHAIN_ID.PLUGIN.TS_CHECKER);
+
     if (this.options.cliOptions?.analyze) {
       enableBundleAnalyzer(this.chain, 'report-ssr.html');
     }
@@ -141,9 +144,6 @@ class NodeWebpackConfig extends BaseWebpackConfig {
 
   config() {
     const config = super.config();
-
-    // disable sourcemap
-    config.devtool = false;
 
     // prod bundle all dependencies
     if (isProd()) {


### PR DESCRIPTION
# PR Details

## Description

- remove `config.devtool = false`, the `devtool` is already defined by `this.chain.devtool(false)`

https://github.com/modern-js-dev/modern.js/blob/a7e8b0610a1130139643125872d1a3fad778cca9/packages/cli/webpack/src/config/node.ts#L20-L22

- fix ts checker runs twice when ssr is enabled

![middle_img_v2_5f7b6ae6-6d43-4fbf-9738-8c219467953g](https://user-images.githubusercontent.com/7237365/169812601-ea5ae69e-ebf5-417c-86c0-0ce47d66e8f0.jpg)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
