### PR TITLE
feat: add buildPreset config, support bundle

### DIFF
--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -75,7 +75,13 @@
     "@modern-js/utils": "workspace:^1.7.5",
     "normalize-path": "^3.0.0",
     "p-map": "^4",
-    "process.argv": "^0.6.0"
+    "process.argv": "^0.6.0",
+    "@rollup/plugin-json": "~4.1.0",
+    "@speedy-js/speedy-core": "^0.12.1-alpha.4",
+    "@speedy-js/speedy-types": "^0.12.1-alpha.4",
+    "rollup": "^2.70.2",
+    "rollup-plugin-dts": "^4.2.1",
+    "rollup-plugin-hashbang": "^3.0.0"
   },
   "devDependencies": {
     "@scripts/build": "workspace:*",

--- a/packages/solutions/module-tools/src/commands/build.ts
+++ b/packages/solutions/module-tools/src/commands/build.ts
@@ -40,6 +40,7 @@ export const build = async (
   const modernConfig = api.useResolvedConfigContext();
   const tsconfigPath = path.join(appDirectory, tsconfigName);
   dotenv.config();
+  const outputPath = modernConfig.output.path ?? 'dist';
   const isTsProject = tsConfigutils.existTsConfigFile(tsconfigPath);
   const enableTscCompiler =
     isTsProject && tsc && !modernConfig.output.disableTsChecker;
@@ -58,6 +59,7 @@ export const build = async (
       tsconfigName,
       enableTscCompiler,
       clear,
+      outputPath,
     },
     modernConfig,
   );

--- a/packages/solutions/module-tools/src/features/build/bundle/index.ts
+++ b/packages/solutions/module-tools/src/features/build/bundle/index.ts
@@ -1,0 +1,10 @@
+import { runSpeedy } from './runSpeedy';
+import { startRollup } from './runRollup';
+import type { TaskBuildConfig } from '../../../types';
+
+
+export const buildInBundleMode = async (config: TaskBuildConfig) => {
+  Promise.all([startRollup(config), runSpeedy(config)]);
+};
+
+

--- a/packages/solutions/module-tools/src/features/build/bundle/runRollup.ts
+++ b/packages/solutions/module-tools/src/features/build/bundle/runRollup.ts
@@ -1,0 +1,147 @@
+import path from 'path';
+import { InputOptions, OutputOptions, Plugin } from 'rollup';
+import ts from 'typescript';
+import hashbangPlugin from 'rollup-plugin-hashbang';
+import jsonPlugin from '@rollup/plugin-json';
+import { Import } from '@modern-js/utils';
+import { TaskBuildConfig } from '../../../types';
+
+const logger: typeof import('../../../features/build/logger') = Import.lazy(
+  '../../../features/build/logger',
+  require,
+);
+
+// Copied from https://github.com/egoist/tsup/blob/dev/src/rollup.ts
+
+const loadCompilerOptions = (tsconfig?: string) => {
+  if (!tsconfig) {
+    return {};
+  }
+  const configFile = ts.readConfigFile(tsconfig, ts.sys.readFile);
+  const { options } = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    './',
+  );
+  return options;
+};
+
+const dtsPlugin: typeof import('rollup-plugin-dts') = require('rollup-plugin-dts');
+
+type RollupConfig = {
+  inputConfig: InputOptions;
+  outputConfig: OutputOptions;
+};
+
+const getRollupConfig = async (options: TaskBuildConfig): Promise<RollupConfig> => {
+  const { appDirectory, outputPath, bundleOption, tsconfig } = options;
+  const distDir = path.join(appDirectory, `./${outputPath}/types`)
+  const compilerOptions = loadCompilerOptions(tsconfig);
+  const dtsOptions = { entry: bundleOption.entry };
+
+  const ignoreFiles: Plugin = {
+    name: 'ignore-files',
+    load(id) {
+      if (!/\.(js|cjs|mjs|jsx|ts|tsx|mts|json)$/.test(id)) {
+        return '';
+      }
+    },
+  };
+
+  return {
+    inputConfig: {
+      input: dtsOptions.entry,
+      onwarn(warning, handler) {
+        if (
+          warning.code === 'UNRESOLVED_IMPORT' ||
+          warning.code === 'CIRCULAR_DEPENDENCY' ||
+          warning.code === 'EMPTY_BUNDLE'
+        ) {
+          return;
+        }
+        handler(warning);
+      },
+      plugins: [
+        hashbangPlugin(),
+        jsonPlugin(),
+        ignoreFiles,
+        dtsPlugin.default({
+          compilerOptions: {
+            ...compilerOptions,
+            baseUrl: path.resolve(compilerOptions.baseUrl || '.'),
+            // Ensure ".d.ts" modules are generated
+            declaration: true,
+            // Skip ".js" generation
+            noEmit: false,
+            emitDeclarationOnly: true,
+            // Skip code generation when error occurs
+            noEmitOnError: true,
+            // Avoid extra work
+            checkJs: false,
+            declarationMap: false,
+            skipLibCheck: true,
+            preserveSymlinks: false,
+            // Ensure we can parse the latest code
+            target: ts.ScriptTarget.ESNext,
+          },
+        }),
+      ].filter(Boolean),
+    },
+    outputConfig: {
+      dir: distDir || 'dist',
+      format: 'esm',
+      exports: 'named',
+    },
+  };
+};
+
+async function runRollup(options: RollupConfig) {
+  const { rollup } = await import('rollup');
+  try {
+    const start = Date.now();
+    const getDuration = () => {
+      return `${Math.floor(Date.now() - start)}ms`;
+    };
+    console.info('dts', 'Build start');
+    const bundle = await rollup(options.inputConfig);
+    await bundle.write(options.outputConfig);
+    console.info('dts', `Build success in ${getDuration()}`);
+  } catch (error) {
+    console.error('dts', 'Build error');
+    console.error(error);
+  }
+}
+
+async function watchRollup(options: {
+  inputConfig: InputOptions;
+  outputConfig: OutputOptions;
+}) {
+  const { watch } = await import('rollup');
+  watch({
+    ...options.inputConfig,
+    plugins: options.inputConfig.plugins,
+    output: options.outputConfig,
+  }).on('event', event => {
+    if (event.code === 'START') {
+      console.info(logger.clearFlag);
+      console.info('dts', 'Build start');
+    } else if (event.code === 'BUNDLE_END') {
+      console.info('dts', `Build success in ${event.duration}ms`);
+    } else if (event.code === 'ERROR') {
+      console.error(logger.clearFlag, 'dts', 'Build failed');
+      console.error(event.error);
+    }
+  });
+}
+
+export const startRollup = async (options: TaskBuildConfig) => {
+  if(options.dts) {
+    const config = await getRollupConfig(options);
+    if (options.enableWatchMode) {
+      watchRollup(config);
+    } else {
+      await runRollup(config);
+    }
+  }
+};
+

--- a/packages/solutions/module-tools/src/features/build/bundle/runSpeedy.ts
+++ b/packages/solutions/module-tools/src/features/build/bundle/runSpeedy.ts
@@ -1,0 +1,40 @@
+import { SpeedyBundler } from '@speedy-js/speedy-core';
+import { CLIConfig, SpeedyPlugin } from '@speedy-js/speedy-types';
+import path from 'path';
+import { TaskBuildConfig } from '../../../types';
+
+
+export const runSpeedy = async (config: TaskBuildConfig) => {
+  const { target, watch, bundleOption, appDirectory, outputPath } = config;
+  const plugins: SpeedyPlugin[] = [];
+  Promise.all([...config.format.map(async format => {
+    const distDir = path.join(appDirectory, `./${outputPath}/${format}`);
+    const cliConfig: CLIConfig = {
+      command: 'build',
+      mode: 'production',
+      preset: 'webapp',
+      platform: 'node',
+      watch,
+      input: {
+        index: bundleOption.entry ?? 'src/index.ts',
+      },
+      target,
+      output: {
+        path: distDir,
+        format,
+        filename: '[dir]/[name]',
+      },
+      html: false,
+      plugins,
+      ...bundleOption.speedyOption,
+    };
+    console.info('speedy', 'Build start');
+    const startTime = new Date().getTime();
+    const compiler = await SpeedyBundler.create(cliConfig);
+    await compiler.build();
+    const duration = new Date().getTime() - startTime;
+    console.info('speedy', `Build success in ${duration}ms`);
+  })])
+};
+
+

--- a/packages/solutions/module-tools/src/features/build/constants.ts
+++ b/packages/solutions/module-tools/src/features/build/constants.ts
@@ -1,4 +1,4 @@
-import type { IPackageModeValue } from '../../types';
+import type { NormalizedBuildConfig, IPackageModeValue } from '../../types';
 
 // Universal JS 的默认选择，三份构建产物，支持 Node.js，对现代浏览器有优化
 const universalJs: IPackageModeValue[] = [
@@ -50,3 +50,28 @@ export const runTscWatchTitle = 'Run `tsc -w` log';
 export const runTscTitle = 'Run `tsc` log';
 export const runStyleCompilerTitle = 'Run style compiler code log';
 export const clearFlag = '\x1Bc';
+
+export const defaultLibraryPreset: NormalizedBuildConfig[] = [{
+  format: ['esm', 'cjs'],
+  target: 'esnext',
+  bundle: false,
+  bundleOption: {
+    entry: 'src/index.ts',
+    speedyOption: {},
+  },
+  tsconfig: 'tsconfig.json',
+  watch: false,
+  dts: true
+}];
+export const defaultComponentPreset: NormalizedBuildConfig[] = [{
+  format: ['esm', 'cjs', 'iife'],
+  target: 'esnext',
+  bundle: false,
+  bundleOption: {
+    entry: 'src/index.ts',
+    speedyOption: {},
+  },
+  tsconfig: 'tsconfig.json',
+  watch: false,
+  dts: true
+}];

--- a/packages/solutions/module-tools/src/features/build/index.ts
+++ b/packages/solutions/module-tools/src/features/build/index.ts
@@ -2,16 +2,41 @@ import path from 'path';
 import { Import, fs } from '@modern-js/utils';
 import type { NormalizedConfig, PluginAPI } from '@modern-js/core';
 import type { IBuildConfig } from '../../types';
+import { normalizeModuleConfig } from './utils';
 
 const buildFeature: typeof import('./build') = Import.lazy('./build', require);
 const buildWatchFeature: typeof import('./build-watch') = Import.lazy(
   './build-watch',
   require,
 );
+const buildBundleFeature: typeof import('./bundle') = Import.lazy(
+  './bundle',
+  require,
+);
+
 const bp: typeof import('./build-platform') = Import.lazy(
   './build-platform',
   require,
 );
+
+const checkPlatformAndRunBuild = async (platform: IBuildConfig['platform'], options: { api: PluginAPI, isTsProject: boolean }) => {
+  const { api, isTsProject } = options;
+  if (typeof platform === 'boolean' && platform) {
+    if (process.env.RUN_PLATFORM) {
+      await bp.buildPlatform(api, { platform: 'all', isTsProject });
+    }
+    return { exit: true };
+  }
+
+  if (typeof platform === 'string') {
+    if (process.env.RUN_PLATFORM) {
+      await bp.buildPlatform(api, { platform, isTsProject });
+    }
+    return { exit: true };
+  }
+
+  return { exit: false };
+}
 
 export const build = async (
   api: PluginAPI,
@@ -28,18 +53,9 @@ export const build = async (
   const {
     output: { path: outputPath = 'dist' },
   } = modernConfig;
-  // TODO: maybe need watch mode in build platform
-  if (typeof platform === 'boolean' && platform) {
-    if (process.env.RUN_PLATFORM) {
-      await bp.buildPlatform(api, { platform: 'all', isTsProject });
-    }
-    return;
-  }
 
-  if (typeof platform === 'string') {
-    if (process.env.RUN_PLATFORM) {
-      await bp.buildPlatform(api, { platform, isTsProject });
-    }
+  const platformBuildRet = await checkPlatformAndRunBuild(platform, { api, isTsProject });
+  if (platformBuildRet.exit) {
     return;
   }
 
@@ -47,9 +63,19 @@ export const build = async (
     fs.removeSync(path.join(appDirectory, outputPath));
   }
 
-  if (enableWatchMode) {
-    await buildWatchFeature.buildInWatchMode(api, config, modernConfig);
-  } else {
-    await buildFeature.buildSourceCode(api, config, modernConfig);
-  }
+  // should normalize module tool config here, ensure the same config for build
+  //TODO: merge cli and module config
+  const normalizedModuleConfig = normalizeModuleConfig(modernConfig.buildPreset);
+  Promise.all(normalizedModuleConfig.map(moduleConfig => {
+    if (moduleConfig.bundle) {
+      return buildBundleFeature.buildInBundleMode({
+        ...config,
+        ...moduleConfig,
+      });
+    } else if (enableWatchMode) {
+      return buildWatchFeature.buildInWatchMode(api, config, modernConfig);
+    } else {
+      return buildFeature.buildSourceCode(api, config, modernConfig);
+    }
+  }));
 };

--- a/packages/solutions/module-tools/src/features/build/type.ts
+++ b/packages/solutions/module-tools/src/features/build/type.ts
@@ -1,0 +1,28 @@
+import { UserConfig } from "@speedy-js/speedy-types";
+
+export type Format = 'esm' | 'cjs' | 'iife';
+
+export type Target =
+  | 'es6'
+  | 'es5'
+  | 'es2015'
+  | 'es2016'
+  | 'es2017'
+  | 'es2018'
+  | 'es2019'
+  | 'es2020'
+  | 'esnext';
+
+export type BuildConfig = {
+    tsconfig?: string;
+    watch?: boolean;
+    dts?: boolean;
+    bundle?: boolean;
+    format?: Format[];
+    target?: Target;
+    bundleOption?: {
+        entry?: string;
+    } & UserConfig;
+};
+
+export type BuildPreset = BuildConfig[] | BuildConfig | 'library' | 'component'

--- a/packages/solutions/module-tools/src/features/build/utils.ts
+++ b/packages/solutions/module-tools/src/features/build/utils.ts
@@ -8,6 +8,8 @@ import type {
   JsSyntaxType,
   ITaskMapper,
   ModuleToolsConfig,
+  BuildPreset,
+  NormalizedBuildConfig,
 } from '../../types';
 import type { LoggerText } from './logger';
 
@@ -237,3 +239,35 @@ export class TimeCounter {
     return span < 1000 ? `${span}ms` : `${(span / 1000).toFixed(2)}s`;
   }
 }
+export const normalizeModuleConfig = (preset?: BuildPreset): NormalizedBuildConfig[] => {
+  if (preset === 'library' || !preset) {
+    return constants.defaultLibraryPreset;
+  } else if (preset === 'component') {
+    return constants.defaultComponentPreset;
+  }
+  //FIXME:throw error when preset is empty array
+  const presetArray = Array.isArray(preset) ? preset : [preset];
+  const normalizedModule = presetArray.map(config => {
+    const format = config.format ?? ['esm', 'cjs'];
+    const target = config.target ?? 'esnext';
+    const bundle = config.bundle ?? false;
+    const bundleOption = config.bundleOption;
+    const normalizedBundleOption = {
+      entry: bundleOption?.entry ?? 'src/index.ts',
+      speedyOption: bundleOption?.speedyOption ?? {},
+    }
+    const watch = config.watch ?? false;
+    const tsconfig = config.tsconfig ?? 'tsconfig.json';
+    const dts = config.dts ?? true;
+    return {
+      format,
+      target,
+      bundle,
+      bundleOption: normalizedBundleOption,
+      watch,
+      tsconfig,
+      dts
+    };
+  });
+  return normalizedModule;
+};

--- a/packages/solutions/module-tools/src/schema/index.ts
+++ b/packages/solutions/module-tools/src/schema/index.ts
@@ -1,4 +1,5 @@
 import { sourceSchema } from './source';
 import { outputSchema } from './output';
+import { moduleSchema } from './module';
 
-export const addSchema = () => [...sourceSchema, ...outputSchema];
+export const addSchema = () => [...sourceSchema, ...outputSchema, ...moduleSchema];

--- a/packages/solutions/module-tools/src/schema/module.ts
+++ b/packages/solutions/module-tools/src/schema/module.ts
@@ -1,0 +1,58 @@
+const properties = {
+  'target': {
+    enum: [
+      'es6',
+      'es5',
+      'es2015',
+      'es2016',
+      'es2017',
+      'es2018',
+      'es2019',
+      'es2020',
+      'esnext',
+    ],
+  },
+  'format': {
+    type: 'array',
+    items: [
+      { enum: ['cjs', 'esm', 'iife'] }
+    ]
+  },
+  'watch': {
+    type: 'boolean',
+  },
+  'tsconfig': {
+    type: 'string',
+  },
+  'dts': {
+    type: 'boolean',
+  },
+  'bundle': {
+    type: 'boolean',
+  },
+  'bundleOption': {
+    type: 'object',
+    properties: {
+      'entry': {
+        type: 'string',
+      },
+      'speedyOption': {
+        type: 'object',
+      },
+    }
+  },
+};
+
+export const moduleSchema = [
+  {
+    target: 'buildPreset',
+    schema: {
+      if: {
+        type: 'array',
+        items: [{ type: 'object', properties }]
+      },
+      elseIf:  { type: 'object', properties },
+      else: { enum: ['library', 'component'] },
+    }
+  },
+];

--- a/packages/solutions/module-tools/src/types.ts
+++ b/packages/solutions/module-tools/src/types.ts
@@ -3,6 +3,7 @@ import type { ImportStyleType } from '@modern-js/babel-preset-module';
 import type { NormalizedConfig } from '@modern-js/core';
 import type { LoggerText } from './features/build/logger/logText';
 import type { Platform } from './features/build/build-platform';
+import type { UserConfig } from '@speedy-js/speedy-core';
 
 export type { Platform } from './features/build/build-platform';
 export type { ITsconfig } from './utils/tsconfig';
@@ -37,6 +38,7 @@ export interface IBuildConfig {
   sourceDir: string;
   tsconfigName?: string;
   clear?: boolean;
+  outputPath: string;
 }
 
 export interface IPackageModeValue {
@@ -63,3 +65,56 @@ export type ModuleToolsConfig = NormalizedConfig & {
   output: OutputConfig & ModuleToolsOutput;
   source: NormalizedConfig['source'] & ModuleToolsSource;
 };
+
+
+export type TaskBuildConfig = IBuildConfig & NormalizedBuildConfig;
+export type Format = 'esm' | 'cjs' | 'iife';
+export type Target =
+  | 'es6'
+  | 'es5'
+  | 'es2015'
+  | 'es2016'
+  | 'es2017'
+  | 'es2018'
+  | 'es2019'
+  | 'es2020'
+  | 'esnext';
+
+
+export type BundleOption = {
+  entry?: string;
+  speedyOption?: UserConfig;
+};
+
+export type BuildConfig = {
+  format?: Format[];
+  target?: Target;
+  bundle?: boolean;
+  bundleOption?: BundleOption;
+  tsconfig?: string;
+  watch?: boolean;
+  dts?: boolean;
+};
+
+export type NormalizedBuildConfig = (Required<BuildConfig> & {
+  bundleOption: Required<BundleOption>
+});
+
+export type BuildPreset = BuildConfig[] | BuildConfig | 'library' | 'component'
+
+declare module '@modern-js/core' {
+  // interface OutputConfig {
+  //   assetsPath: string;
+  //   enableSourceMap: boolean;
+  //   importStyle: ImportStyleType;
+  //   packageMode: PackageModeType;
+  //   packageFields: IPackageFields;
+  // }
+  // interface SourceConfig {
+  //   jsxTransformRuntime: 'automatic' | 'classic';
+  // }
+
+  interface NormalizedConfig {
+    buildPreset?: BuildPreset;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3637,8 +3637,11 @@ importers:
       '@modern-js/plugin-i18n': workspace:^1.2.6
       '@modern-js/style-compiler': workspace:^1.2.7
       '@modern-js/utils': workspace:^1.7.5
+      '@rollup/plugin-json': ~4.1.0
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
+      '@speedy-js/speedy-core': ^0.12.1-alpha.4
+      '@speedy-js/speedy-types': ^0.12.1-alpha.4
       '@types/babel__core': ^7.1.15
       '@types/babel__generator': ^7.6.3
       '@types/babel__traverse': ^7.14.2
@@ -3652,6 +3655,9 @@ importers:
       normalize-path: ^3.0.0
       p-map: ^4
       process.argv: ^0.6.0
+      rollup: ^2.70.2
+      rollup-plugin-dts: ^4.2.1
+      rollup-plugin-hashbang: ^3.0.0
       typescript: ^4
     dependencies:
       '@babel/generator': 7.16.8
@@ -3671,9 +3677,15 @@ importers:
       '@modern-js/plugin-i18n': link:../../cli/plugin-i18n
       '@modern-js/style-compiler': link:../../toolkit/compiler/style
       '@modern-js/utils': link:../../toolkit/utils
+      '@rollup/plugin-json': 4.1.0_rollup@2.70.2
+      '@speedy-js/speedy-core': 0.12.1-alpha.4
+      '@speedy-js/speedy-types': 0.12.1-alpha.4
       normalize-path: 3.0.0
       p-map: 4.0.0
       process.argv: 0.6.0
+      rollup: 2.70.2
+      rollup-plugin-dts: 4.2.1_rollup@2.70.2+typescript@4.5.4
+      rollup-plugin-hashbang: 3.0.0_rollup@2.70.2
     devDependencies:
       '@scripts/build': link:../../../scripts/build
       '@scripts/jest-config': link:../../../scripts/jest-config
@@ -7979,7 +7991,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.16.7
       '@babel/parser': 7.16.8
       '@babel/types': 7.17.0
-      debug: 4.3.3
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7996,7 +8008,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.16.7
       '@babel/parser': 7.16.8
       '@babel/types': 7.17.0
-      debug: 4.3.3_supports-color@5.5.0
+      debug: 4.3.4_supports-color@5.5.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -10758,6 +10770,10 @@ packages:
     resolution: {integrity: sha512-zrsUxjLOKAzdewIDRWy9nsV1GQsKBCWaGwsZQlCgr6/q+vjyZhFgqedLfFBuI9anTPEUT4APq9Mu0SZBTzIcGQ==}
     dev: false
 
+  /@prebundle/detect-port/1.3.1:
+    resolution: {integrity: sha512-z8sg6hMTKj+ZrbYtn10cXqSLpR9tMa6jwKE9ObbI94wy+QKRR4/hHwIP9QEwk81NivMKvSc9wxvKfLEOtaMxQA==}
+    dev: false
+
   /@protobufjs/aspromise/1.1.2:
     resolution: {integrity: sha1-m4sMxmPWaafY9vXQiToU00jzD78=}
     dev: false
@@ -10874,6 +10890,15 @@ packages:
       rollup: 2.50.6
     dev: false
 
+  /@rollup/plugin-json/4.1.0_rollup@2.70.2:
+    resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.2
+      rollup: 2.70.2
+    dev: false
+
   /@rollup/plugin-node-resolve/10.0.0_rollup@2.50.6:
     resolution: {integrity: sha512-sNijGta8fqzwA1VwUEtTvWCx2E7qC70NMsDh4ZG13byAXYigBNZMxALhKUSycBks5gupJdq0lFrKumFrRZ8H3A==}
     engines: {node: '>= 10.0.0'}
@@ -10930,6 +10955,18 @@ packages:
       estree-walker: 1.0.1
       picomatch: 2.3.1
       rollup: 2.50.6
+    dev: false
+
+  /@rollup/pluginutils/3.1.0_rollup@2.70.2:
+    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.3.1
+      rollup: 2.70.2
     dev: false
 
   /@rushstack/node-core-library/3.44.3:
@@ -11130,6 +11167,381 @@ packages:
       webpack-sources: 1.4.3
     dev: false
 
+  /@speedy-js/esbuild-android-64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-cHpg+EuaaPCXFx7hCumxxPTHLbxDuGSc0nEju6eGFV9j1KglqY8TRRstcPhZCZVS9nM/vBQu5LBjsa5HPmi1iA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-android-arm64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-w9hZYFgfznIg1olZuXKJij8Q2MjCCajKKo5YXNT99OZpbQqdDmbC1v+Y/6a+bFiYV/p9t1pK4Pb5cp98OuzBlg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-darwin-64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-NYga2G7OuJmra/eXkbjr845DP66D5jS9n/VL7dlCvMfgJllxxJV2rwduyVB/CliBoHDq/jngVDYEstpsZ7ozHg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-darwin-arm64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-R1LZR+m1qC07R5TCl5IUmBng/bqUTHEAqw+DDqn2MbpIfL3zqjOVyx2noQqlJqG1Y7Had0rtB2og4NNG9T2NpQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-freebsd-64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-2f32AjLlDnh3fQO5+EFUyADtTqSdNoRlDEkI6+vJd1TV262MKwfbPJDZuDsY+/IuXEHIRWRrp7DNP/oibFmlKA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-freebsd-arm64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-Hf4Juvd6bOOVb1eHO7EyjUY6aRLUdH3+sVbJxMi+9pZMKnAMmp2Y9H2ONcZp7wFwdp6bp5slk2me0duZcZNl0g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-linux-32/0.14.28-speedy-1:
+    resolution: {integrity: sha512-qb+hoyu+ZWy4CDrhcczrWWuo7xOh6ck1s0QhN3rg1+A0hrsk+2QEJdorY8UId/xNwXuxxYGehsKd+eD63e6QOA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-linux-64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-5OHR2uigqZXwsAtfkp+V6/WNVa1niw3m7jphrnk9S+tL2uQIPWQaewylSXm+jqGjFtGZorUtAxSFyRsto77MWA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-linux-arm/0.14.28-speedy-1:
+    resolution: {integrity: sha512-Zg94wzkUEAJQy+wQAKb5wZxE9xBgeiKLvW/gjT6a7O9upzP0jeeFfnFN+siH5vohuISzqNbKkAGCorCVfqOuDg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-linux-arm64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-G8XCwmkMZ3OBe3qM4jdOJOag3Mdu7xcC8m39gPD6Z+Jb6nh5w+CGV3jYSE4MaGUmUNXKFeMoCzYJ2EFeH/T6CQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-linux-mips64le/0.14.28-speedy-1:
+    resolution: {integrity: sha512-0yHn2roEbqy4nAOa1cgGYP0SAaZFO+QG0AyIB8CDg9kIlq83pnXKV9jyP999Cw2cZv+QzW02yJpGg+0JKy2+nQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-linux-ppc64le/0.14.28-speedy-1:
+    resolution: {integrity: sha512-OcSrnosGIyhWHBwu0CI3E4fCsYsK8iQTvA0MK/FL+U03SUFvCYTVCVLTYx6fd0AbIYdvj7R1BwQsdFrDYPJA8w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-linux-riscv64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-u0be4rRJyqAiVstTvCFw0XNS1bMZW5wwZDwan7K1mXv1J+IfkQCF09D9fPiFOfwlRJ4MfNkn0cRdv1aPtY+gcQ==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-linux-s390x/0.14.28-speedy-1:
+    resolution: {integrity: sha512-QGDXRuF/cIJa12C2mhVnitYcuT8N/uEDbPrEUrKvzEODpgUAmMET9eOHRnnbo5UpIHRtExgx+6FVod0qr4VEJg==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-netbsd-64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-7S3/racKQInHA9WNhZfP/aps4csYusOpekxt9A1adL7Wb+T11UjZ/BEp4ArnOMeebuAfQtTZtchzTjDndn2WeQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-openbsd-64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-YKdIMat5ydTlX+DVAvumUSqV5NOzSzbRnqV+OZqpiXKSBHzxWEbGpXSnKgpy1xkWW7V2KdVeCax1Ig3L8eC0Aw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-sunos-64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-pua0qUbfWu294Z/z5tyOkhJCaomdenUS2Fe32P2sCu+lGKFxdT/aTPFlGkcCvCtM8yNEY5hNKJW+fypgJcZ+cw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-windows-32/0.14.28-speedy-1:
+    resolution: {integrity: sha512-asjtzX47nrBd1qkI5hCuri1yHy5ioK2dZfSbJ48OZP/bQ4EX1CmvifVHyvpoCELDoru/OchYNoBXKwDb6Pc89A==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-windows-64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-4fMiSBGDx+snYxQJO3Ia6F3hK/ZUGxAs+sh940B08Ud3mhDcRLguy9Dt8VLLLrVc1alUCezEYiYV6U8mzapSeA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild-windows-arm64/0.14.28-speedy-1:
+    resolution: {integrity: sha512-slwOWnMaEiw7RZ9WgbxqLMp/bIBRVFg+G63st64l5EwRRj8m3ILR0ATvlY2LPSOC5ip6LW2XKxAYH5iLG0fQUg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/esbuild/0.14.28-speedy-1:
+    resolution: {integrity: sha512-KMXUsz+ohnEFi8REmIE5RL32A4U2STqmsdoiuPLtWGWpurZeMZ0uVqNt9YtB8QiwQPx3sB/XHsstsH2X/DEkWA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@speedy-js/esbuild-android-64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-android-arm64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-darwin-64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-darwin-arm64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-freebsd-64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-freebsd-arm64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-linux-32': 0.14.28-speedy-1
+      '@speedy-js/esbuild-linux-64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-linux-arm': 0.14.28-speedy-1
+      '@speedy-js/esbuild-linux-arm64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-linux-mips64le': 0.14.28-speedy-1
+      '@speedy-js/esbuild-linux-ppc64le': 0.14.28-speedy-1
+      '@speedy-js/esbuild-linux-riscv64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-linux-s390x': 0.14.28-speedy-1
+      '@speedy-js/esbuild-netbsd-64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-openbsd-64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-sunos-64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-windows-32': 0.14.28-speedy-1
+      '@speedy-js/esbuild-windows-64': 0.14.28-speedy-1
+      '@speedy-js/esbuild-windows-arm64': 0.14.28-speedy-1
+    dev: false
+
+  /@speedy-js/source-map-android-arm-eabi/0.1.3:
+    resolution: {integrity: sha512-up6h+Lv0Sh3ZVG5vfmeaNrVEhZU+Q3XbimZYCkkp2LEAS/e/UOpyz3qelxf2OAWJET0rEYFgvRZUWr3fEvE7vw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map-android-arm64/0.1.3:
+    resolution: {integrity: sha512-afByHjzaqzRSco9FR3/sDJiFcYsKlHT1YYiwdo+RXtYFd6mhCFlhpqrcKlNi7STQohP79458iV82ooV7AlKAhA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map-darwin-arm64/0.1.3:
+    resolution: {integrity: sha512-uu2bauwS8/WfTd6wG9bRuNTOLMxGHUzlJGvTaIBSR0E6JmiyR8xkVcRHNeh3MbhdcJxKcPbTA64kmmearkdTxA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map-darwin-x64/0.1.3:
+    resolution: {integrity: sha512-cFO8mNncbI7v0ZT0EKMr5NoqRM2tGJ4IZoRrIeREY4+c1vcJcekrMKHD/q8CvaLlXIeTR6Do73gLjmcUIcyzzg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map-freebsd-x64/0.1.3:
+    resolution: {integrity: sha512-6HyJv2rbEsXZxi+mfZtVBBFlj2Gn6neZejYpC6fXEqBO5SYs0JmkXqf2gs3Sx509RqsNOunFC/EaSIG66/eN5g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map-linux-arm-gnueabihf/0.1.3:
+    resolution: {integrity: sha512-oMp8s2qyKSZMhIsWBR4aZlmIJhEHW8PvCDmt0z2aIt1whdlcCZ8Qul1Lxb66MFg+wPKHsZKK/2GUpE3eACYc+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map-linux-arm64-gnu/0.1.3:
+    resolution: {integrity: sha512-zPovamZqFrDsLoOTwa5vWRqWhLoS/gDptMoUx52pCU/1USShbCboeFyuXAkoe4YbFSPvr7hzfiMvxeTjzPk/Nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map-linux-arm64-musl/0.1.3:
+    resolution: {integrity: sha512-IQYK0p4fAJnn8h/+WgAC1gIrhJ4ySa1ajMqVNpk9i4MVQ2dUe6QVms4Jfrl5Qd9DU0QXYrLV7FLX+27ZCNEitg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map-linux-x64-gnu/0.1.3:
+    resolution: {integrity: sha512-QLkW+OA4S0h6fM5AZpJzcANE7J9rq5ZgyG5HF5etBu343Ybzl/hgFsAjkTD+CQr09+5PYYvzW5bsiHspePftJw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map-linux-x64-musl/0.1.3:
+    resolution: {integrity: sha512-J11Hskc7gCOx/D/CognBoiAXdKHKV9Z6BLFX5nEL7B0co2veL4ligs3VYrL/Uoy2+UiLv12Mx9x+smkvMyZnRQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map-win32-arm64-msvc/0.1.3:
+    resolution: {integrity: sha512-aVFB1MAb+JgwMDwWmRoPTklqM+q/boVqyVVZQjge1h/lCKZgWgl54/JtZTKCOL/yd+aURaV0UxcytqVRMWPubA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map-win32-ia32-msvc/0.1.3:
+    resolution: {integrity: sha512-DwHAdnypIKOqoqMvA+qf9YBcfknc6+P7keV3nWThS8YmYg1EcxVju312GCcp3I1SWoLXYMi8j5pDD+3EnSZl2w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map-win32-x64-msvc/0.1.3:
+    resolution: {integrity: sha512-bfSrS/C+kMbOlSxaGbTBBXljEsTz8/dEqRWw2sz3W8r1e6VWnkl+N0Xd/dAWu9SpN3G/tt8hLA4xsdq0aujNHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@speedy-js/source-map/0.1.3:
+    resolution: {integrity: sha512-kFebUqtFwVRDy6m5VbEN9i/ket7p7Cc38wy1Sfb8LTA/jiwhaKrhZ8ir2+lAO3nctymvxobvOI6t2kC9LlaxVA==}
+    engines: {node: '>= 10'}
+    optionalDependencies:
+      '@speedy-js/source-map-android-arm-eabi': 0.1.3
+      '@speedy-js/source-map-android-arm64': 0.1.3
+      '@speedy-js/source-map-darwin-arm64': 0.1.3
+      '@speedy-js/source-map-darwin-x64': 0.1.3
+      '@speedy-js/source-map-freebsd-x64': 0.1.3
+      '@speedy-js/source-map-linux-arm-gnueabihf': 0.1.3
+      '@speedy-js/source-map-linux-arm64-gnu': 0.1.3
+      '@speedy-js/source-map-linux-arm64-musl': 0.1.3
+      '@speedy-js/source-map-linux-x64-gnu': 0.1.3
+      '@speedy-js/source-map-linux-x64-musl': 0.1.3
+      '@speedy-js/source-map-win32-arm64-msvc': 0.1.3
+      '@speedy-js/source-map-win32-ia32-msvc': 0.1.3
+      '@speedy-js/source-map-win32-x64-msvc': 0.1.3
+    dev: false
+
+  /@speedy-js/speedy-config-loader/0.12.1-alpha.4:
+    resolution: {integrity: sha512-fStJxZBYr62lHqfd9U1hoIRitCdir0Dc28jh1Erl8ZbR/7hbrBhHGVtkAaid3KfHIc9uygIZkBsCtwcU0dl5rA==}
+    dev: false
+
+  /@speedy-js/speedy-core/0.12.1-alpha.4:
+    resolution: {integrity: sha512-iNggwsGVy2L0jJNO59iFl274AynwL1xcbzA1xPhFo28rdcCQYj4KEaQB1M9jEnO6mQr+qjalL+5KzsVk3pm9bQ==}
+    hasBin: true
+    dependencies:
+      '@prebundle/detect-port': 1.3.1
+      '@speedy-js/esbuild': 0.14.28-speedy-1
+      '@speedy-js/source-map': 0.1.3
+      '@speedy-js/speedy-config-loader': 0.12.1-alpha.4
+      '@speedy-js/speedy-diagnostic': 0.12.1-alpha.4
+      '@speedy-js/speedy-utils': 0.12.1-alpha.4
+      esbuild: 0.14.28
+    dev: false
+
+  /@speedy-js/speedy-diagnostic/0.12.1-alpha.4:
+    resolution: {integrity: sha512-KBguRBWzn1m4TUnI35SRxfcr0IZeKYMotKbCGXOyICvY/ezf8nQF+rMSmbTmGgy8tQkIkuk9x2kj1BsefLuHIg==}
+    dependencies:
+      '@speedy-js/speedy-types': 0.12.1-alpha.4
+    dev: false
+
+  /@speedy-js/speedy-types/0.12.1-alpha.4:
+    resolution: {integrity: sha512-geKF9yJXX9kcK+11NzXGLxaVUhz/K7/orrYW04xPoK1+6DkxEQaqNqp0gjsucTTlcPuUHXFzg5tAX8wE3pyezQ==}
+    dev: false
+
+  /@speedy-js/speedy-utils/0.12.1-alpha.4:
+    resolution: {integrity: sha512-Y43iYUBMmJWXZrBSQWzYA8FQhF3JxUbGszOBrKOuZqoONP19Tk2fDjFTROwW25mFe0j+mvwSJJQR8EdpkXBARQ==}
+    dev: false
+
   /@storybook/addon-actions/6.4.20_b08e3c15324cbe90a6ff8fcd416c932c:
     resolution: {integrity: sha512-5kW4orA6rOHzrDSvGwGL+uevsK9OzJRXq36eje3hCj+E5TGE8hApi+PIIBXI8bIkeJ3zkAS5kjMFdOk+8moT0g==}
     peerDependencies:
@@ -11304,7 +11716,6 @@ packages:
       acorn-walk: 7.2.0
       core-js: 3.21.1
       doctrine: 3.0.0
-      esbuild: 0.13.15
       escodegen: 2.0.0
       fast-deep-equal: 3.1.3
       global: 4.4.0
@@ -12701,7 +13112,6 @@ packages:
     dependencies:
       debug: 4.3.3
       endent: 2.1.0
-      esbuild: 0.13.15
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.4
@@ -12930,7 +13340,6 @@ packages:
       core-js-pure: 3.20.2
       downshift: 6.1.7_react@17.0.2
       emotion-theming: 10.3.0_316248eb6686a2fd4fbadcfd00de37f3
-      esbuild: 0.13.15
       fuse.js: 3.6.1
       global: 4.4.0
       lodash: 4.17.21
@@ -13372,7 +13781,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 14.18.4
+      '@types/node': 17.0.21
 
   /@types/bonjour/3.5.10:
     resolution: {integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==}
@@ -13708,7 +14117,7 @@ packages:
     resolution: {integrity: sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==}
 
   /@types/json5/0.0.29:
-    resolution: {integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=}
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
   /@types/keygrip/1.0.2:
     resolution: {integrity: sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==}
@@ -13876,6 +14285,7 @@ packages:
 
   /@types/node/14.14.45:
     resolution: {integrity: sha512-DssMqTV9UnnoxDWu959sDLZzfvqCF0qDNRjaWeYSui9xkFe61kKo4l1TWNTQONpuXEm+gLMRvdlzvNHBamzmEw==}
+    dev: true
 
   /@types/node/14.18.4:
     resolution: {integrity: sha512-swe3lD4izOJWHuxvsZdDFRq6S9i6koJsXOnQKYekhSO5JTizMVirUFgY/bUsaOJQj8oSD4oxmRYPBM/0b6jpdw==}
@@ -14070,7 +14480,7 @@ packages:
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 14.14.45
+      '@types/node': 17.0.21
 
   /@types/responselike/1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
@@ -14124,7 +14534,7 @@ packages:
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 16.11.18
+      '@types/node': 17.0.21
 
   /@types/signale/1.4.4:
     resolution: {integrity: sha512-VYy4VL64gA4uyUIYVj4tiGFF0VpdnRbJeqNENKGX42toNiTvt83rRzxdr0XK4DR3V01zPM0JQNIsL+IwWWfhsQ==}
@@ -15567,7 +15977,7 @@ packages:
     dev: false
 
   /astral-regex/2.0.0:
-    resolution: {integrity: sha1-SDFDxWeu7UeFdZwIZXhtx319LjE=}
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
 
   /async-each/1.0.3:
@@ -18972,19 +19382,6 @@ packages:
     dependencies:
       ms: 2.1.2
 
-  /debug/4.3.3_supports-color@5.5.0:
-    resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-      supports-color: 5.5.0
-    dev: false
-
   /debug/4.3.3_supports-color@8.1.1:
     resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
     engines: {node: '>=6.0'}
@@ -19008,6 +19405,19 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+
+  /debug/4.3.4_supports-color@5.5.0:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+      supports-color: 5.5.0
+    dev: false
 
   /decamelize-keys/1.1.0:
     resolution: {integrity: sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=}
@@ -20436,6 +20846,15 @@ packages:
       es6-symbol: 3.1.3
     dev: false
 
+  /esbuild-android-64/0.14.28:
+    resolution: {integrity: sha512-A52C3zq+9tNwCqZ+4kVLBxnk/WnrYM8P2+QNvNE9B6d2OVPs214lp3g6UyO+dKDhUdefhfPCuwkP8j2A/+szNA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-android-64/0.14.38:
     resolution: {integrity: sha512-aRFxR3scRKkbmNuGAK+Gee3+yFxkTJO/cx83Dkyzo4CnQl/2zVSurtG6+G86EQIZ+w+VYngVyK7P3HyTBKu3nw==}
     engines: {node: '>=12'}
@@ -20449,6 +20868,15 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    optional: true
+
+  /esbuild-android-arm64/0.14.28:
+    resolution: {integrity: sha512-sm0fDEGElZhMC3HLZeECI2juE4aG7uPfMBMqNUhy9CeX399Pz8rC6e78OXMXInGjSdEAwQmCOHmfsP7uv3Q8rA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-android-arm64/0.14.38:
@@ -20466,6 +20894,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-darwin-64/0.14.28:
+    resolution: {integrity: sha512-nzDd7mQ44FvsFHtOafZdBgn3Li5SMsnMnoz1J2MM37xJmR3wGNTFph88KypjHgWqwbxCI7MXS1U+sN4qDeeW6Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-darwin-64/0.14.38:
     resolution: {integrity: sha512-5JJvgXkX87Pd1Og0u/NJuO7TSqAikAcQQ74gyJ87bqWRVeouky84ICoV4sN6VV53aTW+NE87qLdGY4QA2S7KNA==}
     engines: {node: '>=12'}
@@ -20479,6 +20916,15 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.14.28:
+    resolution: {integrity: sha512-XEq/bLR/glsUl+uGrBimQzOVs/CmwI833fXUhP9xrLI3IJ+rKyrZ5IA8u+1crOEf1LoTn8tV+hInmX6rGjbScw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-darwin-arm64/0.14.38:
@@ -20496,6 +20942,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-freebsd-64/0.14.28:
+    resolution: {integrity: sha512-rTKLgUj/HEcPeE5XZ7IZwWpFx7IWMfprN7QRk/TUJE1s1Ipb58esboIesUpjirJz/BwrgHq+FDG9ChAI8dZAtQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-freebsd-64/0.14.38:
     resolution: {integrity: sha512-epnPbhZUt93xV5cgeY36ZxPXDsQeO55DppzsIgWM8vgiG/Rz+qYDLmh5ts3e+Ln1wA9dQ+nZmVHw+RjaW3I5Ig==}
     engines: {node: '>=12'}
@@ -20509,6 +20964,15 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.14.28:
+    resolution: {integrity: sha512-sBffxD1UMOsB7aWMoExmipycjcy3HJGwmqE4GQZUTZvdiH4GhjgUiVdtPyt7kSCdL40JqnWQJ4b1l8Y51oCF4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-freebsd-arm64/0.14.38:
@@ -20539,6 +21003,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-linux-32/0.14.28:
+    resolution: {integrity: sha512-+Wxidh3fBEQ9kHcCsD4etlBTMb1n6QY2uXv3rFhVn88CY/JP782MhA57/ipLMY4kOLeSKEuFGN4rtjHuhmRMig==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-32/0.14.38:
     resolution: {integrity: sha512-QfgfeNHRFvr2XeHFzP8kOZVnal3QvST3A0cgq32ZrHjSMFTdgXhMhmWdKzRXP/PKcfv3e2OW9tT9PpcjNvaq6g==}
     engines: {node: '>=12'}
@@ -20552,6 +21025,15 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /esbuild-linux-64/0.14.28:
+    resolution: {integrity: sha512-7+xgsC4LvR6cnzaBdiljNnPDjbkwzahogN+S9uy9AoYw7ZjPnnXc6sjQAVCbqGb7MEgrWdpa6u/Tao79i4lWxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-64/0.14.38:
@@ -20569,6 +21051,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-linux-arm/0.14.28:
+    resolution: {integrity: sha512-L5isjmlLbh9E0WVllXiVETbScgMbth/+XkXQii1WwgO1RvLIfaGrVFz8d2n6EH/ImtgYxPYGx+OcvIKQBc91Rg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-arm/0.14.38:
     resolution: {integrity: sha512-FiFvQe8J3VKTDXG01JbvoVRXQ0x6UZwyrU4IaLBZeq39Bsbatd94Fuc3F1RGqPF5RbIWW7RvkVQjn79ejzysnA==}
     engines: {node: '>=12'}
@@ -20582,6 +21073,15 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /esbuild-linux-arm64/0.14.28:
+    resolution: {integrity: sha512-EjRHgwg+kgXABzyoPGPOPg4d5wZqRnZ/ZAxBDzLY+i6DS8OUfTSlZHWIOZzU4XF7125WxRBg9ULbrFJBl+57Eg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-arm64/0.14.38:
@@ -20599,6 +21099,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-linux-mips64le/0.14.28:
+    resolution: {integrity: sha512-krx9SSg7yfiUKk64EmjefOyiEF6nv2bRE4um/LiTaQ6Y/6FP4UF3/Ou/AxZVyR154uSRq63xejcAsmswXAYRsw==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-mips64le/0.14.38:
     resolution: {integrity: sha512-qd1dLf2v7QBiI5wwfil9j0HG/5YMFBAmMVmdeokbNAMbcg49p25t6IlJFXAeLzogv1AvgaXRXvgFNhScYEUXGQ==}
     engines: {node: '>=12'}
@@ -20614,6 +21123,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-linux-ppc64le/0.14.28:
+    resolution: {integrity: sha512-LD0Xxu9g+DNuhsEBV5QuVZ4uKVBMup0xPIruLweuAf9/mHXFnaCuNXUBF5t0DxKl7GQ5MSioKtnb92oMo+QXEw==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-ppc64le/0.14.38:
     resolution: {integrity: sha512-mnbEm7o69gTl60jSuK+nn+pRsRHGtDPfzhrqEUXyCl7CTOCLtWN2bhK8bgsdp6J/2NyS/wHBjs1x8aBWwP2X9Q==}
     engines: {node: '>=12'}
@@ -20622,12 +21140,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-linux-riscv64/0.14.28:
+    resolution: {integrity: sha512-L/DWfRh2P0vxq4Y+qieSNXKGdMg+e9Qe8jkbN2/8XSGYDTPzO2OcAxSujob4qIh7iSl+cknbXV+BvH0YFR0jbg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-linux-riscv64/0.14.38:
     resolution: {integrity: sha512-+p6YKYbuV72uikChRk14FSyNJZ4WfYkffj6Af0/Tw63/6TJX6TnIKE+6D3xtEc7DeDth1fjUOEqm+ApKFXbbVQ==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /esbuild-linux-s390x/0.14.28:
+    resolution: {integrity: sha512-rrgxmsbmL8QQknWGnAL9bGJRQYLOi2AzXy5OTwfhxnj9eqjo5mSVbJXjgiq5LPUAMQZGdPH5yaNK0obAXS81Zw==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-linux-s390x/0.14.38:
@@ -20645,6 +21181,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-netbsd-64/0.14.28:
+    resolution: {integrity: sha512-h8wntIyOR8/xMVVM6TvJxxWKh4AjmLK87IPKpuVi8Pq0kyk0RMA+eo4PFGk5j2XK0D7dj8PcSF5NSlP9kN/j0A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-netbsd-64/0.14.38:
     resolution: {integrity: sha512-cljBAApVwkpnJZfnRVThpRBGzCi+a+V9Ofb1fVkKhtrPLDYlHLrSYGtmnoTVWDQdU516qYI8+wOgcGZ4XIZh0Q==}
     engines: {node: '>=12'}
@@ -20658,6 +21203,15 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    optional: true
+
+  /esbuild-openbsd-64/0.14.28:
+    resolution: {integrity: sha512-HBv18rVapbuDx52/fhZ/c/w6TXyaQAvRxiDDn5Hz/pBcwOs3cdd2WxeIKlWmDoqm2JMx5EVlq4IWgoaRX9mVkw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-openbsd-64/0.14.38:
@@ -20675,6 +21229,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-sunos-64/0.14.28:
+    resolution: {integrity: sha512-zlIxePhZxKYheR2vBCgPVvTixgo/ozOfOMoP6RZj8dxzquU1NgeyhjkcRXucbLCtmoNJ+i4PtWwPZTLuDd3bGg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-sunos-64/0.14.38:
     resolution: {integrity: sha512-2mfIoYW58gKcC3bck0j7lD3RZkqYA7MmujFYmSn9l6TiIcAMpuEvqksO+ntBgbLep/eyjpgdplF7b+4T9VJGOA==}
     engines: {node: '>=12'}
@@ -20688,6 +21251,15 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /esbuild-windows-32/0.14.28:
+    resolution: {integrity: sha512-am9DIJxXlld1BOAY/VlvBQHMUCPL7S3gB/lnXIY3M4ys0gfuRqPf4EvMwZMzYUbFKBY+/Qb8SRgPRRGhwnJ8Kg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-windows-32/0.14.38:
@@ -20705,6 +21277,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-windows-64/0.14.28:
+    resolution: {integrity: sha512-78PhySDnmRZlsPNp/W/5Fim8iivlBQQxfhBFIqR7xwvfDmCFUSByyMKP7LCHgNtb04yNdop8nJJkJaQ8Xnwgiw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /esbuild-windows-64/0.14.38:
     resolution: {integrity: sha512-Khy4wVmebnzue8aeSXLC+6clo/hRYeNIm0DyikoEqX+3w3rcvrhzpoix0S+MF9vzh6JFskkIGD7Zx47ODJNyCw==}
     engines: {node: '>=12'}
@@ -20718,6 +21299,15 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /esbuild-windows-arm64/0.14.28:
+    resolution: {integrity: sha512-VhXGBTo6HELD8zyHXynV6+L2jWx0zkKnGx4TmEdSBK7UVFACtOyfUqpToG0EtnYyRZ0HESBhzPSVpP781ovmvA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /esbuild-windows-arm64/0.14.38:
@@ -20750,6 +21340,34 @@ packages:
       esbuild-windows-32: 0.13.15
       esbuild-windows-64: 0.13.15
       esbuild-windows-arm64: 0.13.15
+
+  /esbuild/0.14.28:
+    resolution: {integrity: sha512-YLNprkCcMVKQ5sekmCKEQ3Obu/L7s6+iij38xNKyBeSmSsTWur4Ky/9zB3XIGT8SCJITG/bZwAR2l7YOAXch4Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      esbuild-android-64: 0.14.28
+      esbuild-android-arm64: 0.14.28
+      esbuild-darwin-64: 0.14.28
+      esbuild-darwin-arm64: 0.14.28
+      esbuild-freebsd-64: 0.14.28
+      esbuild-freebsd-arm64: 0.14.28
+      esbuild-linux-32: 0.14.28
+      esbuild-linux-64: 0.14.28
+      esbuild-linux-arm: 0.14.28
+      esbuild-linux-arm64: 0.14.28
+      esbuild-linux-mips64le: 0.14.28
+      esbuild-linux-ppc64le: 0.14.28
+      esbuild-linux-riscv64: 0.14.28
+      esbuild-linux-s390x: 0.14.28
+      esbuild-netbsd-64: 0.14.28
+      esbuild-openbsd-64: 0.14.28
+      esbuild-sunos-64: 0.14.28
+      esbuild-windows-32: 0.14.28
+      esbuild-windows-64: 0.14.28
+      esbuild-windows-arm64: 0.14.28
+    dev: false
 
   /esbuild/0.14.38:
     resolution: {integrity: sha512-12fzJ0fsm7gVZX1YQ1InkOE5f9Tl7cgf6JPYXRJtPIoE0zkWAbHdPHVPPaLi9tYAcEBqheGzqLn/3RdTOyBfcA==}
@@ -22217,7 +22835,6 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
-      esbuild: 0.13.15
       fs-extra: 9.1.0
       glob: 7.2.0
       memfs: 3.4.1
@@ -22249,7 +22866,6 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
-      esbuild: 0.13.15
       fs-extra: 9.1.0
       glob: 7.2.0
       memfs: 3.4.1
@@ -25765,7 +26381,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.4.2
-      '@types/node': 16.11.18
+      '@types/node': 17.0.21
       chalk: 4.1.2
       ci-info: 3.3.0
       graceful-fs: 4.2.10
@@ -27061,6 +27677,13 @@ packages:
 
   /magic-string/0.25.7:
     resolution: {integrity: sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: false
+
+  /magic-string/0.26.1:
+    resolution: {integrity: sha512-ndThHmvgtieXe8J/VGPjG+Apu7v7ItcD5mhEIvOscWjPF/ccOiLxHaSuCAS2G+3x4GKsAbT8u7zdyamupui8Tg==}
+    engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
     dev: false
@@ -29341,7 +29964,6 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     dependencies:
       cosmiconfig: 7.0.1
-      esbuild: 0.13.15
       klona: 2.0.5
       loader-utils: 2.0.2
       postcss: 7.0.39
@@ -31679,7 +32301,6 @@ packages:
       react: ^17.0.0 || ^16.3.0 || ^15.5.4
       react-dom: ^17.0.0 || ^16.3.0 || ^15.5.4
     dependencies:
-      esbuild: 0.13.15
       flux: 4.0.3_react@17.0.2
       react: 17.0.2
       react-base16-styling: 0.6.0
@@ -32779,6 +33400,30 @@ packages:
     resolution: {integrity: sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w=}
     dev: true
 
+  /rollup-plugin-dts/4.2.1_rollup@2.70.2+typescript@4.5.4:
+    resolution: {integrity: sha512-eaxQZNUJ5iQcxNGlpJ1CUgG4OSVqWjDZ3nNSWBIoGrpcote2aNphSe1RJOaSYkb8dwn3o+rYm1vvld/5z3EGSQ==}
+    engines: {node: '>=v12.22.11'}
+    peerDependencies:
+      rollup: ^2.70
+      typescript: ^4.6
+    dependencies:
+      magic-string: 0.26.1
+      rollup: 2.70.2
+      typescript: 4.5.4
+    optionalDependencies:
+      '@babel/code-frame': 7.16.7
+    dev: false
+
+  /rollup-plugin-hashbang/3.0.0_rollup@2.70.2:
+    resolution: {integrity: sha512-nNC2NeNcvkklPhPCUF8Yb+2a19xI0dSBBJJ2x814+Al2BqIEWOyaGIgEjPVSjjgxhoabkJC5vbO4AeI3cxx3wg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      rollup: '>=2'
+    dependencies:
+      magic-string: 0.25.7
+      rollup: 2.70.2
+    dev: false
+
   /rollup-plugin-inject/3.0.2:
     resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
     dependencies:
@@ -32809,6 +33454,14 @@ packages:
   /rollup/2.62.0:
     resolution: {integrity: sha512-cJEQq2gwB0GWMD3rYImefQTSjrPYaC6s4J9pYqnstVLJ1CHa/aZNVkD4Epuvg4iLeMA4KRiq7UM7awKK6j7jcw==}
     engines: {node: '>=10.0.0'}
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
+
+  /rollup/2.70.2:
+    resolution: {integrity: sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
     dev: false
@@ -35207,6 +35860,7 @@ packages:
 
   /tree-kill/1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
     dev: true
 
   /trim-newlines/3.0.1:
@@ -36054,7 +36708,6 @@ packages:
       file-loader:
         optional: true
     dependencies:
-      esbuild: 0.13.15
       file-loader: 6.2.0_webpack@4.46.0
       loader-utils: 2.0.2
       mime-types: 2.1.35


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Add `buildPreset` config, support bundle 

## Description

<!--- Describe your changes in detail -->
Currently, module-tools only supports transforming output, not bundling them. I've refined and optimized the build configuration by adding a buildPreset, which will support bundling output. For js and css files, I use our own bundler: speedy, for dts files, I use rollup-plugin-dts to complete my bundle task

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1113 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
details in description
## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
i try to use module-tools bundle `css-config`, i can work.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
