### PR TITLE
feat(webpack): filter SSR bundles by server.ssrByEntries

### DIFF
--- a/.changeset/strange-radios-burn.md
+++ b/.changeset/strange-radios-burn.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+feat: filter ssr bundles by server.ssrByEntries

--- a/packages/cli/webpack/tests/node.test.ts
+++ b/packages/cli/webpack/tests/node.test.ts
@@ -1,5 +1,9 @@
 import path from 'path';
-import { NodeWebpackConfig } from '../src/config/node';
+import { WebpackChain } from '../src';
+import {
+  NodeWebpackConfig,
+  filterEntriesBySSRConfig,
+} from '../src/config/node';
 import { userConfig } from './util';
 
 describe('node webpack config', () => {
@@ -18,6 +22,7 @@ describe('node webpack config', () => {
     internalDirAlias: '@_modern_js_internal',
     internalSrcAlias: '@_modern_js_src',
   };
+
   test(`webpack config target should be node`, () => {
     const config = new NodeWebpackConfig(
       appContext as any,
@@ -37,5 +42,48 @@ describe('node webpack config', () => {
     expect(config.optimization?.runtimeChunk).toBe(false);
 
     // TODO: css & babel
+  });
+});
+
+describe('filterEntriesBySSRConfig', () => {
+  const createChain = () => {
+    const chain = new WebpackChain();
+    chain.entry('foo').add('src/foo.js');
+    chain.entry('bar').add('src/bar.js');
+    return chain;
+  };
+
+  test('should return all entires when ssr is true', () => {
+    const chain = createChain();
+    filterEntriesBySSRConfig(chain, { ssr: true });
+    expect(chain.toConfig().entry).toEqual({
+      foo: ['src/foo.js'],
+      bar: ['src/bar.js'],
+    });
+  });
+
+  test('should allow to delete entry by ssrByEntries', () => {
+    const chain = createChain();
+    filterEntriesBySSRConfig(chain, {
+      ssr: true,
+      ssrByEntries: {
+        bar: false,
+      },
+    });
+    expect(chain.toConfig().entry).toEqual({
+      foo: ['src/foo.js'],
+    });
+  });
+
+  test('should allow to enable some entries by ssrByEntries', () => {
+    const chain = createChain();
+    filterEntriesBySSRConfig(chain, {
+      ssrByEntries: {
+        bar: true,
+      },
+    });
+    expect(chain.toConfig().entry).toEqual({
+      bar: ['src/bar.js'],
+    });
   });
 });


### PR DESCRIPTION
# PR Details

## Description

Filter SSR bundles by `server.ssrByEntries`.

For example, a project contains two entries: `foo` and `bar`, and only `foo` is using SSR:

```js
{
  ssrByEntries: {
    foo: true,
  },
}
```

In this case, the bundle of bar is never used, we don't need to bundle bar.

## Motivation

Make SSR compile speed faster.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
