### PR TITLE
fix(utils): isModernjsMonorepo return false if no package.json

### DIFF
--- a/.changeset/quick-paws-rule.md
+++ b/.changeset/quick-paws-rule.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/utils': patch
+---
+
+fix(utils): isModernjsMonorepo should return false if there is no package.json

--- a/packages/cli/webpack/src/config/node.ts
+++ b/packages/cli/webpack/src/config/node.ts
@@ -26,9 +26,7 @@ export function filterEntriesBySSRConfig(
       (ssr && ssrByEntries[name] === false) ||
       (!ssr && ssrByEntries[name] !== true)
     ) {
-      if (!ssrByEntries[name] || !ssr) {
-        chain.entryPoints.delete(name);
-      }
+      chain.entryPoints.delete(name);
     }
   });
 }

--- a/packages/toolkit/utils/src/monorepo.ts
+++ b/packages/toolkit/utils/src/monorepo.ts
@@ -32,9 +32,13 @@ export const isMonorepo = (root: string) =>
   isLerna(root) || isYarnWorkspaces(root) || isPnpmWorkspaces(root);
 
 export const isModernjsMonorepo = (root: string) => {
-  const json = JSON.parse(
-    fs.readFileSync(path.join(root, 'package.json'), 'utf8'),
-  );
+  const pkgJsonPath = path.join(root, 'package.json');
+
+  if (!fs.existsSync(pkgJsonPath)) {
+    return false;
+  }
+
+  const json = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
 
   const deps = {
     ...(json.dependencies || {}),

--- a/packages/toolkit/utils/tests/monorepo.test.ts
+++ b/packages/toolkit/utils/tests/monorepo.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { isPnpmWorkspaces } from '../src/monorepo';
+import { isPnpmWorkspaces, isModernjsMonorepo } from '../src/monorepo';
 
 describe('isPnpmWorkspaces', () => {
   test('should return correct result', () => {
@@ -12,6 +12,14 @@ describe('isPnpmWorkspaces', () => {
 
     expect(isPnpmWorkspaces('/foo')).toBeTruthy();
 
+    mockExistsSync.mockRestore();
+  });
+});
+
+describe('isModernjsMonorepo', () => {
+  test('should return false if there is no package.json', () => {
+    const mockExistsSync = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    expect(isModernjsMonorepo('/foo')).toBeFalsy();
     mockExistsSync.mockRestore();
   });
 });


### PR DESCRIPTION
# PR Details

## Description

`isModernjsMonorepo` should return false if there is no package.json.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
