### PR TITLE
feat(webpack): tools.webpack support modify or return config object

### DIFF
--- a/.changeset/spicy-trainers-attack.md
+++ b/.changeset/spicy-trainers-attack.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': minor
+---
+
+feat(webpack): tools.webpack support modify or return config object

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 import path from 'path';
 import {
+  chalk,
   isProd,
   isDev,
   signale,
@@ -695,12 +696,17 @@ class BaseWebpackConfig {
       // Compatible with the legacy `chain` usage, if `chain` is called in `tools.webpack`,
       // using the chained config as finalConfig, otherwise using the merged webpack config.
       if (isChainUsed) {
+        finalConfig = chain.toConfig();
+
         if (isDev()) {
           signale.warn(
-            'The `chain` param of `tools.webpack` is deprecated, please use `tools.webpackChain` instead.',
+            `The ${chalk.cyan('chain')} param of ${chalk.cyan(
+              'tools.webpack',
+            )} is deprecated, please use ${chalk.cyan(
+              'tools.webpackChain',
+            )} instead.`,
           );
         }
-        finalConfig = chain.toConfig();
       } else {
         finalConfig = mergedConfig;
       }

--- a/packages/cli/webpack/tests/base.test.ts
+++ b/packages/cli/webpack/tests/base.test.ts
@@ -8,7 +8,7 @@ import { userConfig } from './util';
 
 describe('base webpack config', () => {
   const fixtures = path.resolve(__dirname, './fixtures');
-  const appContext = {
+  const appContext: any = {
     appDirectory: fixtures,
     internalDirectory: '/node_modules/.modern-js',
     srcDirectory: '/src',
@@ -27,7 +27,7 @@ describe('base webpack config', () => {
     userConfig.source.include = ['query-string'];
 
     const config = new BaseWebpackConfig(
-      appContext as any,
+      appContext,
       userConfig as any,
     ).config();
 
@@ -68,18 +68,66 @@ describe('base webpack config', () => {
       expect(webpack.DefinePlugin).toBeTruthy();
     };
 
-    const baseConfig = new BaseWebpackConfig(
-      appContext as any,
-      {
-        ...userConfig,
-        tools: {
-          webpackChain: chainFunction,
-        },
-      } as any,
-    );
+    const baseConfig = new BaseWebpackConfig(appContext, {
+      ...userConfig,
+      tools: {
+        webpackChain: chainFunction,
+      },
+    } as any);
 
     baseConfig.applyToolsWebpackChain();
 
     expect(baseConfig.config().name).toEqual('foo');
+  });
+
+  test(`apply tools.webpack with legacy chain usage`, () => {
+    const configFunction: NormalizedConfig['tools']['webpack'] = (
+      config,
+      { chain },
+    ) => {
+      chain.name('foo');
+    };
+
+    const baseConfig = new BaseWebpackConfig(appContext, {
+      ...userConfig,
+      tools: {
+        webpack: configFunction,
+      },
+    } as any);
+
+    expect(baseConfig.config().name).toEqual('foo');
+  });
+
+  test(`apply tools.webpack and modify the config object`, () => {
+    const configFunction: NormalizedConfig['tools']['webpack'] = config => {
+      config.name = 'foo';
+    };
+
+    const baseConfig = new BaseWebpackConfig(appContext, {
+      ...userConfig,
+      tools: {
+        webpack: configFunction,
+      },
+    } as any);
+
+    expect(baseConfig.config().name).toEqual('foo');
+  });
+
+  test(`apply tools.webpack and return a new config object`, () => {
+    const configFunction: NormalizedConfig['tools']['webpack'] = config => {
+      config.name = 'foo';
+      return {
+        name: 'bar',
+      };
+    };
+
+    const baseConfig = new BaseWebpackConfig(appContext, {
+      ...userConfig,
+      tools: {
+        webpack: configFunction,
+      },
+    } as any);
+
+    expect(baseConfig.config().name).toEqual('bar');
   });
 });

--- a/website/docs/apis/config/tools/webpack.md
+++ b/website/docs/apis/config/tools/webpack.md
@@ -5,61 +5,63 @@ sidebar_label: webpack
 # tools.webpack
 
 :::info 适用的工程方案
-- MWA
+MWA。
 :::
 
-- 类型： `(config, { env, chain, webpack }) => void`
+- 类型： `Object | (config, { env, name, webpack }) => void`
 - 默认值： `undefined`
 
-对应 [webpack](https://webpack.js.org/) 的配置，值为 `Function` 类型。
+Modern.js 默认集成了 [webpack](https://webpack.js.org/)，对构建产物进行编译打包等操作，可通过 `tools.webpack` 对其进行配置。
 
-- 函数的第一个参数为内部的默认配置（只读）。
-- 函数的第二个参数为修改 webpack 配置的工具集合，包括 `env`、`chain`、`webpack` 等。
+:::info
+[tools.webpackChain](/docs/apis/config/tools/webpack-chain) 同样可以修改 webpack 配置，并且功能更加强大，建议优先使用 `tools.webpackChain`。
+:::
 
-### chain
+## 类型
 
-函数第二个参数中的 `chain` 对象是一个 [webpack-chain](https://github.com/neutrinojs/webpack-chain) 实例，通过 `chain` 可以对 webpack 配置进行变更:
+### Object 类型
 
-```js title="modern.config.js"
+当值为 `Object` 类型时，Modern.js 会通过 [webpack-merge](https://github.com/survivejs/webpack-merge) 将 `tools.webpack` 参数值和框架的默认 `webpack` 配置合并，得到最终的 `webpack` 配置。
+
+例如，修改 `mode` 配置为 `development`：
+
+```typescript title="modern.config.ts"
+import { defineConfig } from '@modern-js/app-tools';
+
 export default defineConfig({
   tools: {
-    webpack: (config, { chain }) => {
-      chain.resolve.alias.set('@example', `${appDirectory}/src/example`);
+    webpack: {
+      mode: 'development',
     },
   },
 });
 ```
 
-以下是 `chain` 常见用法的示例：
+### Function 类型
 
-```js title="modern.config.js"
+当值为 `Function` 类型时，内部默认配置作为第一参数传入，可以直接修改配置对象不做返回，也可以返回一个对象作为最终结果；第二个参数为修改 webpack 配置的工具集合。
+
+例如，用函数的方式修改 `mode` 为 `development`：
+
+```typescript title="modern.config.ts"
+import { defineConfig } from '@modern-js/app-tools';
+
 export default defineConfig({
   tools: {
-    webpack: (config, { chain }) => {
-      // 自定义 loader
-      chain.module
-        .rule('compile-svg')
-        .test(/\.svg$/)
-        .use('svg-inline')
-        .loader('svg-inline-loader');
-
-      // 自定义 plugin
-      chain
-        .plugin('clean')
-        .use(CleanPlugin, [['dist'], { root: '/dir' }]);
-
-      // 修改 SourceMap 格式
-      chain.devtool('source-map');
+    webpack: config => {
+      config.mode = 'development';
     },
   },
 });
 ```
 
-完整 API 请参考 [webpack-chain 文档](https://github.com/neutrinojs/webpack-chain)。
+## 工具函数
+
+`tools.webpack` 值为 `Function` 时，第二个参数对象可用的属性如下。
 
 ### env
 
-获取当前环境值为 `development` 还是 `production`：
+通过 `env` 参数可以判断当前环境为 `development` 还是 `production`：
 
 ```js title="modern.config.js"
 export default defineConfig({
@@ -73,7 +75,7 @@ export default defineConfig({
 
 ### webpack
 
-获取 Modern.js 内部使用的 webpack 对象：
+通过 `webpack` 参数可以获取 Modern.js 内部使用的 webpack 对象。
 
 ```js title="modern.config.js"
 export default defineConfig({
@@ -82,9 +84,19 @@ export default defineConfig({
       console.log(
         new webpack.BannerPlugin({
           banner: 'hello world!',
-        })
+        }),
       );
     },
   },
 });
 ```
+
+建议优先使用该参数来访问 webpack 对象，而不是通过 import 来引入 `webpack`。
+
+如果需要通过 import 引入，则项目里需要单独安装 webpack 依赖，这样可能会导致 webpack 被重复安装，因此不推荐该做法。
+
+### chain (废弃)
+
+此参数已废弃，请使用 [tools.webpackChain](/docs/apis/config/tools/webpack-chain)。
+
+当使用 `chain` 参数时，修改 config 对象或返回 config 对象都不会产生任何效果。


### PR DESCRIPTION
# PR Details

## Description

`tools.webpack` support modify or return config object.

### Usage 1

```js
export default defineConfig({
  tools: {
    webpack: {
      mode: 'development',
    },
  },
});
```

### Usage 2

```js
export default defineConfig({
  tools: {
    webpack: config => {
      config.mode = 'development';
    },
  },
});
```

### Usage 3

```js
export default defineConfig({
  tools: {
    webpack: config => {
      return {
        ...config,
        mode: 'development',
      };
    },
  },
});
```

### Deprecated

The legacy `chain` param can still work as before, but there will be a deprecation warning.

![image](https://user-images.githubusercontent.com/7237365/169971491-8da06f1e-3f90-4d6a-a3d5-9f818b1f1534.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
