### PR TITLE
feat(webpack): add more utils for tools.webpack

### DIFF
--- a/.changeset/sour-apes-burn.md
+++ b/.changeset/sour-apes-burn.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': minor
+---
+
+feat(webpack): add more utils for tools.webpack

--- a/packages/cli/core/src/config/types/index.ts
+++ b/packages/cli/core/src/config/types/index.ts
@@ -3,7 +3,10 @@ import type { NextFunction, BffProxyOptions } from '@modern-js/types';
 import type { MetaOptions } from '@modern-js/utils';
 import type { TransformOptions } from '@babel/core';
 import type webpack from 'webpack';
-import type { Configuration as WebpackConfiguration } from 'webpack';
+import type {
+  RuleSetRule,
+  Configuration as WebpackConfiguration,
+} from 'webpack';
 import type { ChainIdentifier, WebpackChain } from '@modern-js/webpack';
 import type autoprefixer from 'autoprefixer';
 import type {
@@ -219,16 +222,18 @@ export type WebpackConfig =
   | WebpackConfiguration
   | ((
       config: WebpackConfiguration,
-      // FIXME: utils type
       utils: {
         env: string;
         name: string;
         webpack: typeof webpack;
+        addRules: (rules: RuleSetRule[]) => void;
+        prependPlugins: (plugins: WebpackConfiguration['plugins']) => void;
+        appendPlugins: (plugins: WebpackConfiguration['plugins']) => void;
+        removePlugin: (pluginName: string) => void;
         /**
          * @deprecated please use `tools.webpackChain` instead.
          */
         chain: WebpackChain;
-        [key: string]: any;
       },
     ) => WebpackConfiguration | void);
 

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -41,7 +41,7 @@ import { ModuleScopePlugin } from '../plugins/module-scope-plugin';
 import { getSourceIncludes } from '../utils/getSourceIncludes';
 import { TsConfigPathsPlugin } from '../plugins/ts-config-paths-plugin';
 import { getWebpackAliases } from '../utils/getWebpackAliases';
-import { CHAIN_ID } from './shared';
+import { CHAIN_ID, getWebpackUtils } from './shared';
 
 export type ResolveAlias = { [index: string]: string };
 
@@ -689,6 +689,7 @@ class BaseWebpackConfig {
           env: process.env.NODE_ENV,
           name: chain.get('name'),
           webpack,
+          ...getWebpackUtils(chainConfig),
         },
         webpackMerge,
       );

--- a/packages/cli/webpack/src/config/shared.ts
+++ b/packages/cli/webpack/src/config/shared.ts
@@ -1,3 +1,4 @@
+import type { Configuration, RuleSetRule } from 'webpack';
 import { BundleAnalyzerPlugin } from '../../compiled/webpack-bundle-analyzer';
 import type { WebpackChain } from '../compiled';
 
@@ -130,4 +131,29 @@ export function enableBundleAnalyzer(
       reportFilename,
     },
   ]);
+}
+
+export function getWebpackUtils(config: Configuration) {
+  return {
+    addRules(rules: RuleSetRule[]) {
+      if (Array.isArray(rules)) {
+        config.module?.rules?.unshift(...rules);
+      }
+    },
+    prependPlugins(plugins: Configuration['plugins']) {
+      if (Array.isArray(plugins)) {
+        config.plugins?.unshift(...plugins);
+      }
+    },
+    appendPlugins(plugins: Configuration['plugins']) {
+      if (Array.isArray(plugins)) {
+        config.plugins?.push(...plugins);
+      }
+    },
+    removePlugin(pluginName: string) {
+      config.plugins = config.plugins?.filter(
+        p => p.constructor.name !== pluginName,
+      );
+    },
+  };
 }

--- a/website/docs/apis/config/tools/webpack.md
+++ b/website/docs/apis/config/tools/webpack.md
@@ -8,7 +8,7 @@ sidebar_label: webpack
 MWA。
 :::
 
-- 类型： `Object | (config, { env, name, webpack }) => void`
+- 类型： `Object | (config, utils) => void`
 - 默认值： `undefined`
 
 Modern.js 默认集成了 [webpack](https://webpack.js.org/)，对构建产物进行编译打包等操作，可通过 `tools.webpack` 对其进行配置。
@@ -94,6 +94,79 @@ export default defineConfig({
 建议优先使用该参数来访问 webpack 对象，而不是通过 import 来引入 `webpack`。
 
 如果需要通过 import 引入，则项目里需要单独安装 webpack 依赖，这样可能会导致 webpack 被重复安装，因此不推荐该做法。
+
+### addRules
+
+通常情况下，使用 Modern.js 不需要添加额外的 [webpack rule](https://webpack.js.org/configuration/module/#rule-conditions)。当有额外需求时，可以使用该工具函数添加对应的 rules。
+
+以处理 [cson](https://github.com/groupon/cson-parser) 文件为例：
+
+```typescript title="modern.config.ts"
+export default defineConfig({
+  tools: {
+    webpack: (config, { addRules }) => {
+      addRules([
+        {
+          test: /\.cson/,
+          loader: require.resolve('cson-loader'),
+        },
+      ]);
+    },
+  },
+});
+```
+
+### prependPlugins
+
+在内部 webpack 插件数组头部添加额外的插件：
+
+```typescript title="modern.config.ts"
+export default defineConfig({
+  tools: {
+    webpack: (config, { prependPlugins, webpack }) => {
+      prependPlugins([
+        new webpack.BannerPlugin({
+          banner: 'hello world!',
+        }),
+      ]);
+    },
+  },
+});
+```
+
+### appendPlugins
+
+在内部 webpack 插件数组尾部添加额外的插件：
+
+```typescript title="modern.config.ts"
+export default defineConfig({
+  tools: {
+    webpack: (config, { appendPlugins, webpack }) => {
+      appendPlugins([
+        new webpack.BannerPlugin({
+          banner: 'hello world!',
+        }),
+      ]);
+    },
+  },
+});
+```
+
+### removePlugin
+
+删除内部的 webpack 插件，参数为该插件的 `constructor.name`。
+
+例如，删除内部的 [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin)：
+
+```typescript title="modern.config.ts"
+export default defineConfig({
+  tools: {
+    webpack: (config, { removePlugin }) => {
+      removePlugin('ForkTsCheckerWebpackPlugin');
+    },
+  },
+});
+```
 
 ### chain (废弃)
 


### PR DESCRIPTION
# PR Details

## Description

Add following utils to `tools.webpack`:

- addRules
- prependPlugins
- appendPlugins
- removePlugin

So jupiter and modern.js can provide the same `tools.webpack` API.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
