### PR TITLE
fix(server): HMR not working when using proxy

### DIFF
--- a/.changeset/sour-buttons-report.md
+++ b/.changeset/sour-buttons-report.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/server': patch
+'@modern-js/app-tools': patch
+'@modern-js/utils': patch
+---
+
+fix(server): hmr not working when using proxy

--- a/packages/server/server/src/constants.ts
+++ b/packages/server/server/src/constants.ts
@@ -1,17 +1,20 @@
-import { HMR_SOCK_PATH } from '@modern-js/utils';
+import { getIpv4Interfaces, HMR_SOCK_PATH } from '@modern-js/utils';
 import { DevServerOptions } from './types';
 
-export const DEFAULT_DEV_OPTIONS: DevServerOptions = {
-  client: {
-    port: '8080',
-    overlay: false,
-    logging: 'none',
-    path: HMR_SOCK_PATH,
-    host: 'localhost',
-  },
-  https: false,
-  devMiddleware: { writeToDisk: true },
-  watch: true,
-  hot: true,
-  liveReload: true,
+export const getDefaultDevOptions = (): DevServerOptions => {
+  const network = getIpv4Interfaces().find(item => !item.internal);
+  return {
+    client: {
+      port: '8080',
+      overlay: false,
+      logging: 'none',
+      path: HMR_SOCK_PATH,
+      host: network?.address || 'localhost',
+    },
+    https: false,
+    devMiddleware: { writeToDisk: true },
+    watch: true,
+    hot: true,
+    liveReload: true,
+  };
 };

--- a/packages/server/server/src/dev-tools/dev-server-plugin.ts
+++ b/packages/server/server/src/dev-tools/dev-server-plugin.ts
@@ -1,5 +1,4 @@
 import Webpack from 'webpack';
-import { DEFAULT_DEV_OPTIONS } from '../constants';
 import { DevServerOptions } from '../types';
 
 const { EntryPlugin } = Webpack;
@@ -11,13 +10,11 @@ export default class DevServerPlugin {
   }
 
   apply(compiler: Webpack.Compiler) {
-    const { options } = this;
+    const { client } = this.options;
 
-    const client = { ...DEFAULT_DEV_OPTIONS.client, ...options.client };
-
-    const host = `&host=${client.host}`;
-    const path = `&path=${client.path}`;
-    const port = `&port=${client.port}`;
+    const host = client.host ? `&host=${client.host}` : '';
+    const path = client.path ? `&path=${client.path}` : '';
+    const port = client.port ? `&port=${client.port}` : '';
 
     const clientEntry = `${require.resolve(
       '@modern-js/hmr-client',

--- a/packages/server/server/src/server/dev-server.ts
+++ b/packages/server/server/src/server/dev-server.ts
@@ -20,7 +20,7 @@ import {
   BuildOptions,
 } from '@modern-js/prod-server';
 import { ModernServerContext } from '@modern-js/types';
-import { DEFAULT_DEV_OPTIONS } from '../constants';
+import { getDefaultDevOptions } from '../constants';
 import { createMockHandler } from '../dev-tools/mock';
 import SocketServer from '../dev-tools/socket-server';
 import DevServerPlugin from '../dev-tools/dev-server-plugin';
@@ -54,12 +54,23 @@ export class ModernDevServer extends ModernServer {
     this.compiler = options.compiler!;
 
     // set dev server options, like webpack-dev-server
-    this.dev = {
-      ...DEFAULT_DEV_OPTIONS,
-      ...(typeof options.dev === 'boolean' ? {} : options.dev),
-    };
+    this.dev = this.getDevOptions(options);
 
     enableRegister(this.pwd, this.conf);
+  }
+
+  private getDevOptions(options: ModernDevServerOptions) {
+    const devOptions = typeof options.dev === 'boolean' ? {} : options.dev;
+    const defaultOptions = getDefaultDevOptions();
+
+    return {
+      ...defaultOptions,
+      ...devOptions,
+      client: {
+        ...defaultOptions.client,
+        ...devOptions?.client,
+      },
+    };
   }
 
   // Complete the preparation of services

--- a/packages/server/server/src/types.ts
+++ b/packages/server/server/src/types.ts
@@ -4,11 +4,11 @@ import type Webpack from 'webpack';
 export type DevServerOptions = {
   // hmr client 配置
   client: {
-    port: string;
-    overlay: boolean;
-    logging: string;
-    path: string;
-    host: string;
+    path?: string;
+    port?: string;
+    host?: string;
+    logging?: string;
+    overlay?: boolean;
     progress?: boolean;
   };
   devMiddleware: {

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -1,12 +1,5 @@
+import { fs, logger, chalk, isSSR, clearConsole } from '@modern-js/utils';
 import type { Configuration } from '@modern-js/webpack';
-import {
-  fs,
-  logger,
-  HMR_SOCK_PATH,
-  clearConsole,
-  chalk,
-  isSSR,
-} from '@modern-js/utils';
 import type { PluginAPI } from '@modern-js/core';
 
 import { createCompiler } from '../utils/createCompiler';
@@ -83,10 +76,7 @@ export const dev = async (api: PluginAPI, options: DevOptions) => {
       ...{
         client: {
           port: port!.toString(),
-          overlay: false,
           logging: 'none',
-          path: HMR_SOCK_PATH,
-          host: 'localhost',
         },
         devMiddleware: {
           writeToDisk: (file: string) => !file.includes('.hot-update.'),

--- a/packages/toolkit/utils/tests/__snapshots__/prettyInstructions.test.ts.snap
+++ b/packages/toolkit/utils/tests/__snapshots__/prettyInstructions.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`prettyInstructions The src directory does not exist 1`] = `
 "App running at:
 
-  > Network:  http://127.0.0.1:8080/api
+  > Local:    http://localhost:8080/api
   > Network:  http://11.11.111.11:8080/api
   > Network:  http://10.100.100.100:8080/api
 "
@@ -12,7 +12,7 @@ exports[`prettyInstructions The src directory does not exist 1`] = `
 exports[`prettyInstructions basic usage 1`] = `
 "App running at:
 
-  > Network:  http://127.0.0.1:8080/
+  > Local:    http://localhost:8080/
   > Network:  http://11.11.111.11:8080/
   > Network:  http://10.100.100.100:8080/
 "


### PR DESCRIPTION
# PR Details

## Description

fix HMR not working when using proxy:

```js
export default defineConfig({
  dev: {
    proxy: {
      name: 'app',
      rules: `
https://www.foo.com/ http://127.0.0.1:8080/
      `,
    },
  },
})
```

To fix this issue, we should always use `local ip` instead of `localhost` to create socket URL (same as `webpack-dev-server`).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
