### PR TITLE
fix: fix duplicate `useLoader` id by compilation

### DIFF
--- a/.changeset/itchy-mayflies-drive.md
+++ b/.changeset/itchy-mayflies-drive.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/babel-preset-app': patch
+---
+
+fix(babel): fix duplicate `useLoader` id by compilation'


### PR DESCRIPTION
# PR Details

When combined with `react-refresh`,  `useLoader` id generated by compilation would duplicate as following:

![origin_img_v2_5d4fdbee-52fa-4442-98e0-7204a1ace50g](https://user-images.githubusercontent.com/5110783/170488331-45b0720c-3bd8-4345-ae75-872b2c062926.jpg)

This PR  will fix the issue.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
