### PR TITLE
fix: fix `useLoader` returning undefined when setting _cache prop

### DIFF
--- a/.changeset/tame-pets-deny.md
+++ b/.changeset/tame-pets-deny.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/runtime-core': patch
+---
+
+fix: fix `useLoader` returning undefined when setting \_cache prop

--- a/packages/runtime/src/loader/useLoader.ts
+++ b/packages/runtime/src/loader/useLoader.ts
@@ -49,7 +49,7 @@ export interface LoaderOptions<
   skip?: boolean;
 
   /**
-   * User params, it will bypass to loader's second parameter.
+   * User params, it will pass to loader's second parameter.
    */
   params?: Params;
 
@@ -72,6 +72,11 @@ const useLoader = <TData = any, Params = any, E = any>(
   const { loaderManager } = context;
   const loaderRef = useRef<Loader>();
   const unlistenLoaderChangeRef = useRef<(() => void) | null>(null);
+
+  // SSR render should ignore `_cache` prop
+  if (isSSRRender && Object.prototype.hasOwnProperty.call(options, '_cache')) {
+    delete (options as any)._cache;
+  }
 
   const load = useCallback(
     (params?: Params) => {
@@ -104,7 +109,6 @@ const useLoader = <TData = any, Params = any, E = any>(
       unlistenLoaderChangeRef.current?.();
 
       if (isSSRRender) {
-        unlistenLoaderChangeRef.current?.();
         return undefined;
       }
 


### PR DESCRIPTION
# PR Details

Fix `useLoader` returning undefined when setting `_cache` prop.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
