### PR TITLE
feat(app-tools): support dev --analyze

### DIFF
--- a/.changeset/rotten-chicken-guess.md
+++ b/.changeset/rotten-chicken-guess.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/app-tools': patch
+---
+
+feat(app-tools): support dev --analyze

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -1,6 +1,6 @@
 import { fs, logger, chalk, isSSR, clearConsole } from '@modern-js/utils';
+import { manager, PluginAPI, ResolvedConfigContext } from '@modern-js/core';
 import type { Configuration } from '@modern-js/webpack';
-import type { PluginAPI } from '@modern-js/core';
 
 import { createCompiler } from '../utils/createCompiler';
 import { createServer } from '../utils/createServer';
@@ -11,9 +11,14 @@ import { getSpecifiedEntries } from '../utils/getSpecifiedEntries';
 import { buildServerConfig } from '../utils/config';
 
 export const dev = async (api: PluginAPI, options: DevOptions) => {
+  let userConfig = api.useResolvedConfigContext();
   const appContext = api.useAppContext();
-  const userConfig = api.useResolvedConfigContext();
   const hookRunners = api.useHookRunners();
+
+  manager.run(() => {
+    userConfig = { ...userConfig, cliOptions: options };
+    ResolvedConfigContext.set(userConfig);
+  });
 
   const {
     appDirectory,

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -39,6 +39,7 @@ export default (): CliPlugin => ({
           .description(i18n.t(localeKeys.command.dev.describe))
           .option('-c --config <config>', i18n.t(localeKeys.command.dev.config))
           .option('-e --entry [entry...]', i18n.t(localeKeys.command.dev.entry))
+          .option('--analyze', i18n.t(localeKeys.command.dev.analyze))
           .option('--api-only', i18n.t(localeKeys.command.dev.apiOnly))
           .action(async (options: DevOptions) => {
             await dev(api, options);

--- a/packages/solutions/app-tools/src/locale/en.ts
+++ b/packages/solutions/app-tools/src/locale/en.ts
@@ -5,8 +5,9 @@ export const EN_LOCALE = {
       config: 'specify config file',
       entry: 'compiler by entry',
       apiOnly: 'start api server only',
+      analyze: 'analyze bundle size',
     },
-    build: { describe: 'build application', analyze: 'analyze bundle' },
+    build: { describe: 'build application', analyze: 'analyze bundle size' },
     start: { describe: 'start server' },
     deploy: { describe: 'deploy application' },
     new: {

--- a/packages/solutions/app-tools/src/locale/zh.ts
+++ b/packages/solutions/app-tools/src/locale/zh.ts
@@ -2,9 +2,10 @@ export const ZH_LOCALE = {
   command: {
     dev: {
       describe: '本地开发命令',
-      config: '制定配置文件路径',
-      entry: '按入口编译',
+      config: '指定配置文件路径',
+      entry: '指定入口，编译特定的页面',
       apiOnly: '仅启动 API 接口服务',
+      analyze: '分析构建产物体积，查看各个模块打包后的大小',
     },
     build: {
       describe: '构建应用命令',

--- a/packages/solutions/app-tools/src/utils/types.ts
+++ b/packages/solutions/app-tools/src/utils/types.ts
@@ -1,6 +1,7 @@
 export type DevOptions = {
   entry?: string[] | boolean;
   apiOnly?: boolean;
+  analyze?: boolean;
 };
 
 export type BuildOptions = {

--- a/website/docs/apis/commands/mwa/dev.md
+++ b/website/docs/apis/commands/mwa/dev.md
@@ -10,9 +10,11 @@ Usage: modern dev [options]
 本地开发命令
 
 Options:
+  -e --entry <entry>    指定入口，编译特定的页面
   -c --config <config>  指定配置文件路径
-  -h, --help            display help for command
-  --api-only            start api server only
+  -h, --help            显示命令帮助
+  --analyze             分析构建产物体积，查看各个模块打包后的大小
+  --api-only            仅启动 API 接口服务
 ```
 
 `modern dev` 命令启动一个开发服务器，同时监听源文件变化，默认支持 React Fast Refresh：


### PR DESCRIPTION
# PR Details

## Description

support using `dev --analyze` to analyze bundle size (same as `build --analyze`), it can be used to:

- compare the module graph between dev and build
- view the bundle size of single page by `dev --entry --analyze`

dev is faster than build, but the analysis results are not as accurate as build.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
