### PR TITLE
fix(webpack): fix useBuiltIns entry not work, reduce bundle size

### DIFF
--- a/.changeset/funny-cars-listen.md
+++ b/.changeset/funny-cars-listen.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): fix useBuiltIns entry not work, reduce bundle size

--- a/packages/cli/webpack/src/config/client.ts
+++ b/packages/cli/webpack/src/config/client.ts
@@ -53,11 +53,7 @@ export class ClientWebpackConfig extends BaseWebpackConfig {
     super.entry();
 
     if (this.options.output.polyfill === 'entry') {
-      const entryPoints = Object.keys(this.chain.entryPoints.entries() || {});
-
-      for (const name of entryPoints) {
-        this.chain.entry(name).prepend(require.resolve('core-js'));
-      }
+      this.useCoreJsEntry();
     }
   }
 
@@ -373,6 +369,21 @@ export class ClientWebpackConfig extends BaseWebpackConfig {
           ],
         }));
     }
+  }
+
+  useCoreJsEntry() {
+    const entryPoints = Object.keys(this.chain.entryPoints.entries() || {});
+    const coreJsEntry = path.resolve(__dirname, '../runtime/core-js-entry.js');
+
+    for (const name of entryPoints) {
+      this.chain.entry(name).prepend(coreJsEntry);
+    }
+
+    // let babel to transform core-js-entry, make `useBuiltins: 'entry'` working
+    this.chain.module
+      .rule(RULE.LOADERS)
+      .oneOf(ONE_OF.JS)
+      .include.add(coreJsEntry);
   }
 }
 /* eslint-enable max-lines */

--- a/packages/cli/webpack/src/runtime/core-js-entry.ts
+++ b/packages/cli/webpack/src/runtime/core-js-entry.ts
@@ -1,0 +1,6 @@
+/**
+ * Auto import `core-js` when `output.polyfill === 'entry'`
+ * We should not add `core-js` as an webpack entry,
+ * otherwise the @babel/preset-env can not transform core-js to sub-paths.
+ */
+import 'core-js';

--- a/packages/cli/webpack/tests/client.test.ts
+++ b/packages/cli/webpack/tests/client.test.ts
@@ -8,6 +8,11 @@ describe('@modern-js/webpack#config/client', () => {
     appDirectory: __dirname,
     distDirectory: `${__dirname}/dist`,
     srcDirectory: `${__dirname}/src`,
+    sharedDirectory: `${__dirname}/src/shared`,
+    internalSrcAlias: '@_modern_js_src',
+    internalDirAlias: '@_modern_js_internal',
+    internalDirectory: `${__dirname}/node_modules/.modern-js`,
+    htmlTemplates: {},
     entrypoints: [
       {
         entryName: 'main',
@@ -117,5 +122,46 @@ describe('@modern-js/webpack#config/client', () => {
     }).toThrowError();
 
     fsSpy.mockRestore();
+  });
+
+  const hasCoreJsEntry = (config: any) =>
+    Object.values(config.entry).some((entry: any) =>
+      entry.some((file: string) => file.includes('core-js-entry')),
+    );
+
+  it('should include core-js-entry when output.polyfill is entry', () => {
+    const client = new ClientWebpackConfig(appContext, {
+      ...options,
+      output: {
+        ...options.output,
+        polyfill: 'entry',
+      },
+    });
+
+    expect(hasCoreJsEntry(client.config())).toBeTruthy();
+  });
+
+  it('should not include core-js-entry when output.polyfill is usage', () => {
+    const client = new ClientWebpackConfig(appContext, {
+      ...options,
+      output: {
+        ...options.output,
+        polyfill: 'usage',
+      },
+    });
+
+    expect(hasCoreJsEntry(client.config())).toBeFalsy();
+  });
+
+  it('should not include core-js-entry when output.polyfill is ua', () => {
+    const client = new ClientWebpackConfig(appContext, {
+      ...options,
+      output: {
+        ...options.output,
+        polyfill: 'ua',
+      },
+    });
+
+    expect(hasCoreJsEntry(client.config())).toBeFalsy();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5684,7 +5684,7 @@ packages:
       '@babel/parser': 7.18.4
       '@babel/template': 7.16.7
       '@babel/traverse': 7.16.8
-      '@babel/types': 7.16.8
+      '@babel/types': 7.18.4
       convert-source-map: 1.8.0
       debug: 4.3.3
       gensync: 1.0.0-beta.2
@@ -5709,7 +5709,7 @@ packages:
       '@babel/parser': 7.17.8
       '@babel/template': 7.16.7
       '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -5732,7 +5732,7 @@ packages:
       '@babel/parser': 7.17.8
       '@babel/template': 7.16.7
       '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -5793,7 +5793,7 @@ packages:
     resolution: {integrity: sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.4
       jsesc: 2.5.2
       source-map: 0.5.7
 
@@ -5801,7 +5801,7 @@ packages:
     resolution: {integrity: sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       jsesc: 2.5.2
       source-map: 0.5.7
 
@@ -5809,7 +5809,7 @@ packages:
     resolution: {integrity: sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       jsesc: 2.5.2
       source-map: 0.5.7
 
@@ -6139,7 +6139,7 @@ packages:
     resolution: {integrity: sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.4
 
   /@babel/helper-environment-visitor/7.18.2:
     resolution: {integrity: sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==}
@@ -6158,7 +6158,7 @@ packages:
     dependencies:
       '@babel/helper-get-function-arity': 7.16.7
       '@babel/template': 7.16.7
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.4
 
   /@babel/helper-function-name/7.17.9:
     resolution: {integrity: sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==}
@@ -6171,7 +6171,7 @@ packages:
     resolution: {integrity: sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.4
 
   /@babel/helper-hoist-variables/7.16.7:
     resolution: {integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==}
@@ -6183,7 +6183,7 @@ packages:
     resolution: {integrity: sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.4
     dev: false
 
   /@babel/helper-member-expression-to-functions/7.17.7:
@@ -6209,7 +6209,7 @@ packages:
       '@babel/helper-validator-identifier': 7.16.7
       '@babel/template': 7.16.7
       '@babel/traverse': 7.16.8
-      '@babel/types': 7.16.8
+      '@babel/types': 7.18.4
     transitivePeerDependencies:
       - supports-color
 
@@ -6224,7 +6224,7 @@ packages:
       '@babel/helper-validator-identifier': 7.16.7
       '@babel/template': 7.16.7
       '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.4
     transitivePeerDependencies:
       - supports-color
 
@@ -6280,7 +6280,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.17.7
       '@babel/helper-optimise-call-expression': 7.16.7
       '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6301,7 +6301,7 @@ packages:
     resolution: {integrity: sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.16.8
+      '@babel/types': 7.18.4
 
   /@babel/helper-simple-access/7.17.7:
     resolution: {integrity: sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==}
@@ -6355,7 +6355,7 @@ packages:
     dependencies:
       '@babel/template': 7.16.7
       '@babel/traverse': 7.16.8
-      '@babel/types': 7.16.8
+      '@babel/types': 7.18.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6366,7 +6366,7 @@ packages:
     dependencies:
       '@babel/template': 7.16.7
       '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
     transitivePeerDependencies:
       - supports-color
 
@@ -6392,14 +6392,14 @@ packages:
     resolution: {integrity: sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
 
   /@babel/parser/7.17.8:
     resolution: {integrity: sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.4
 
   /@babel/parser/7.18.4:
     resolution: {integrity: sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==}
@@ -8567,7 +8567,7 @@ packages:
       '@babel/helper-module-imports': 7.16.7
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-jsx': 7.16.7
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.4
     dev: false
 
   /@babel/plugin-transform-react-jsx/7.16.7_@babel+core@7.17.8:
@@ -8581,7 +8581,7 @@ packages:
       '@babel/helper-module-imports': 7.16.7
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-jsx': 7.16.7_@babel+core@7.17.8
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.4
     dev: false
 
   /@babel/plugin-transform-react-jsx/7.17.12:
@@ -9043,7 +9043,7 @@ packages:
       '@babel/plugin-transform-unicode-escapes': 7.16.7_@babel+core@7.17.8
       '@babel/plugin-transform-unicode-regex': 7.16.7_@babel+core@7.17.8
       '@babel/preset-modules': 0.1.5_@babel+core@7.17.8
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       babel-plugin-polyfill-corejs2: 0.3.0_@babel+core@7.17.8
       babel-plugin-polyfill-corejs3: 0.5.0_@babel+core@7.17.8
       babel-plugin-polyfill-regenerator: 0.3.0_@babel+core@7.17.8
@@ -9409,7 +9409,7 @@ packages:
       '@babel/helper-hoist-variables': 7.16.7
       '@babel/helper-split-export-declaration': 7.16.7
       '@babel/parser': 7.16.8
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       debug: 4.3.3
       globals: 11.12.0
     transitivePeerDependencies:
@@ -9426,7 +9426,7 @@ packages:
       '@babel/helper-hoist-variables': 7.16.7
       '@babel/helper-split-export-declaration': 7.16.7
       '@babel/parser': 7.16.8
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       debug: 4.3.3_supports-color@5.5.0
       globals: 11.12.0
     transitivePeerDependencies:
@@ -9444,7 +9444,7 @@ packages:
       '@babel/helper-hoist-variables': 7.16.7
       '@babel/helper-split-export-declaration': 7.16.7
       '@babel/parser': 7.17.8
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -9466,27 +9466,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/types/7.16.8:
-    resolution: {integrity: sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
-      to-fast-properties: 2.0.0
-
-  /@babel/types/7.17.0:
-    resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
-      to-fast-properties: 2.0.0
-
-  /@babel/types/7.17.10:
-    resolution: {integrity: sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
-      to-fast-properties: 2.0.0
 
   /@babel/types/7.18.4:
     resolution: {integrity: sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==}
@@ -13726,7 +13705,7 @@ packages:
       '@babel/plugin-transform-react-jsx': 7.16.7_@babel+core@7.17.8
       '@babel/preset-env': 7.16.11_@babel+core@7.17.8
       '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       '@mdx-js/mdx': 1.6.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
       core-js: 3.21.1
@@ -14337,7 +14316,7 @@ packages:
     resolution: {integrity: sha512-pt7MMkQFDlWJVy9ULJ1h+hZBDGFfSCwlBNW1HkLnVi7jUhyEXUaGYWi1x6bM2IXuAR9l265khBT4Av4lPmaNLQ==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       entities: 3.0.1
     dev: false
 
@@ -14559,7 +14538,7 @@ packages:
     resolution: {integrity: sha512-S7unDjm/C7z2A2R9NzfKCK1I+BAALDtxEmsJBwlB3EzNfb929ykjL++1CK9LO++EIp2fQrC8O+BwjKvz6UeDyQ==}
     dependencies:
       '@babel/parser': 7.16.8
-      '@babel/types': 7.16.8
+      '@babel/types': 7.18.4
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.14.2
@@ -14573,7 +14552,7 @@ packages:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
       '@babel/parser': 7.16.8
-      '@babel/types': 7.16.8
+      '@babel/types': 7.18.4
 
   /@types/babel__traverse/7.14.2:
     resolution: {integrity: sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==}
@@ -17183,7 +17162,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@babel/template': 7.16.7
-      '@babel/types': 7.16.8
+      '@babel/types': 7.18.4
       '@types/babel__core': 7.1.18
       '@types/babel__traverse': 7.14.2
     dev: true
@@ -17193,7 +17172,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@babel/template': 7.16.7
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.4
       '@types/babel__core': 7.1.18
       '@types/babel__traverse': 7.14.2
 
@@ -17202,7 +17181,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@babel/template': 7.16.7
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       '@types/babel__core': 7.1.18
       '@types/babel__traverse': 7.14.2
     dev: true
@@ -17211,7 +17190,7 @@ packages:
     resolution: {integrity: sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==}
     dependencies:
       '@babel/helper-module-imports': 7.16.7
-      '@babel/types': 7.16.8
+      '@babel/types': 7.18.4
       glob: 7.2.0
       lodash: 4.17.21
       require-package-name: 2.0.1
@@ -22581,7 +22560,7 @@ packages:
     engines: {node: '>=8.3.0'}
     dependencies:
       '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       c8: 7.11.0
     transitivePeerDependencies:
       - supports-color
@@ -27061,7 +27040,7 @@ packages:
       '@babel/parser': 7.16.8
       '@babel/plugin-syntax-typescript': 7.16.7_@babel+core@7.16.7
       '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.4
       '@jest/transform': 27.4.5
       '@jest/types': 27.4.2
       '@types/babel__traverse': 7.14.2
@@ -27091,7 +27070,7 @@ packages:
       '@babel/generator': 7.17.3
       '@babel/plugin-syntax-typescript': 7.16.7_@babel+core@7.16.7
       '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.4
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__traverse': 7.14.2


### PR DESCRIPTION
# PR Details

## Description

Fix `useBuiltIns: 'entry'` of `@babel/preset-env` not work, which means `browserslist` can not affect the content of core-js polyfills.

**This change can reduce bundle size by 46.63KB.**

We should not add `core-js` as an webpack entry, otherwise the `@babel/preset-env` can not transform `core-js` to sub-paths.

#### Before

<img width="669" alt="截屏2022-06-07 上午11 45 57" src="https://user-images.githubusercontent.com/7237365/172292334-ad837a64-bc7f-4315-a807-e89881ac2c67.png">

#### After

<img width="662" alt="截屏2022-06-07 上午11 49 54" src="https://user-images.githubusercontent.com/7237365/172292348-637da3d9-b82d-4781-87e9-fe634eb68c56.png">

Ref: https://babeljs.io/docs/en/babel-preset-env#usebuiltins-entry

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
