### PR TITLE
feat(devServer): support disable hmr or live reload

### DIFF
--- a/.changeset/cuddly-lemons-remember.md
+++ b/.changeset/cuddly-lemons-remember.md
@@ -4,4 +4,4 @@
 '@modern-js/server': patch
 ---
 
-feat(server): support disable hmr or live reload
+feat(devServer): support disable hmr or live reload

--- a/.changeset/cuddly-lemons-remember.md
+++ b/.changeset/cuddly-lemons-remember.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/core': patch
+'@modern-js/webpack': patch
+'@modern-js/server': patch
+---
+
+feat(server): support disable hmr or live reload

--- a/packages/cli/core/src/config/types/index.ts
+++ b/packages/cli/core/src/config/types/index.ts
@@ -207,6 +207,8 @@ export type RequestHandler = (
 ) => void;
 
 export type DevServerConfig = {
+  hot?: boolean;
+  liveReload?: boolean;
   proxy?: BffProxyOptions;
   headers?: Record<string, string>;
   before?: RequestHandler[];

--- a/packages/cli/webpack/src/config/client.ts
+++ b/packages/cli/webpack/src/config/client.ts
@@ -115,6 +115,10 @@ export class ClientWebpackConfig extends BaseWebpackConfig {
     ]);
   }
 
+  private isUsingHMR() {
+    return isDev() && this.options.tools?.devServer?.hot !== false;
+  }
+
   loaders() {
     const loaders = super.loaders();
     this.includeCoreJsEntry();
@@ -128,7 +132,9 @@ export class ClientWebpackConfig extends BaseWebpackConfig {
     this.useCopyPlugin();
     this.useFastRefresh();
 
-    isDev() && this.chain.plugin(PLUGIN.HMR).use(HotModuleReplacementPlugin);
+    if (this.isUsingHMR()) {
+      this.chain.plugin(PLUGIN.HMR).use(HotModuleReplacementPlugin);
+    }
 
     const { packageName } = this.appContext as IAppContext & {
       entrypoints: Entrypoint[];
@@ -353,7 +359,7 @@ export class ClientWebpackConfig extends BaseWebpackConfig {
   }
 
   useFastRefresh() {
-    if (isFastRefresh()) {
+    if (isFastRefresh() && this.isUsingHMR()) {
       const ReactFastRefreshPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
       this.chain.plugin(PLUGIN.REACT_FAST_REFRESH).use(ReactFastRefreshPlugin, [

--- a/packages/cli/webpack/tests/base.test.ts
+++ b/packages/cli/webpack/tests/base.test.ts
@@ -5,16 +5,7 @@ import { BaseWebpackConfig } from '../src/config/base';
 import { JS_REGEX, TS_REGEX } from '../src/utils/constants';
 import { mergeRegex } from '../src/utils/mergeRegex';
 import { getWebpackUtils } from '../src/config/shared';
-import { userConfig } from './util';
-
-const mockNodeEnv = (value: string) => {
-  const { NODE_ENV } = process.env;
-  process.env.NODE_ENV = value;
-
-  return function restore() {
-    process.env.NODE_ENV = NODE_ENV;
-  };
-};
+import { userConfig, mockNodeEnv } from './util';
 
 describe('base webpack config', () => {
   const fixtures = path.resolve(__dirname, './fixtures');

--- a/packages/cli/webpack/tests/util.ts
+++ b/packages/cli/webpack/tests/util.ts
@@ -1,5 +1,24 @@
 import { defaultsConfig } from '@modern-js/core';
+import type WebpackChain from '@modern-js/utils/webpack-chain';
 
 export const userConfig = {
   ...defaultsConfig,
+};
+
+export const isPluginRegistered = (chain: WebpackChain, pluginId: string) => {
+  try {
+    chain.plugin(pluginId).tap(options => options);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const mockNodeEnv = (value: string) => {
+  const { NODE_ENV } = process.env;
+  process.env.NODE_ENV = value;
+
+  return function restore() {
+    process.env.NODE_ENV = NODE_ENV;
+  };
 };

--- a/packages/server/server/src/dev-tools/dev-server-plugin.ts
+++ b/packages/server/server/src/dev-tools/dev-server-plugin.ts
@@ -9,9 +9,8 @@ export default class DevServerPlugin {
     this.options = options;
   }
 
-  apply(compiler: webpack.Compiler) {
+  injectHMRClient(compiler: webpack.Compiler) {
     const { client } = this.options;
-
     const host = client.host ? `&host=${client.host}` : '';
     const path = client.path ? `&path=${client.path}` : '';
     const port = client.port ? `&port=${client.port}` : '';
@@ -19,13 +18,16 @@ export default class DevServerPlugin {
     const clientEntry = `${require.resolve(
       '@modern-js/hmr-client',
     )}?${host}${path}${port}`;
-    const additionalEntries = [clientEntry];
 
     // use a hook to add entries if available
-    for (const additionalEntry of additionalEntries) {
-      new EntryPlugin(compiler.context, additionalEntry, {
-        name: undefined,
-      }).apply(compiler);
+    new EntryPlugin(compiler.context, clientEntry, {
+      name: undefined,
+    }).apply(compiler);
+  }
+
+  apply(compiler: webpack.Compiler) {
+    if (this.options.hot || this.options.liveReload) {
+      this.injectHMRClient(compiler);
     }
 
     // Todo remove, client must inject.

--- a/packages/server/server/tests/dev.test.ts
+++ b/packages/server/server/tests/dev.test.ts
@@ -68,25 +68,27 @@ describe('test dev tools', () => {
     app.close();
   });
 
+  const getDevServerPluginOptions = () => ({
+    client: {
+      port: '8080',
+      overlay: false,
+      logging: 'error',
+      path: '/',
+      host: '127.0.0.1',
+    },
+    devMiddleware: {
+      writeToDisk: false,
+    },
+    watch: true,
+    hot: true,
+    liveReload: true,
+  });
+
   test('should dev server plugin work correctly with hot plugin', () => {
     const compiler = webpack({
       plugins: [new webpack.HotModuleReplacementPlugin()],
     });
-    new DevServerPlugin({
-      client: {
-        port: '8080',
-        overlay: false,
-        logging: 'error',
-        path: '/',
-        host: '127.0.0.1',
-      },
-      devMiddleware: {
-        writeToDisk: false,
-      },
-      watch: true,
-      hot: true,
-      liveReload: true,
-    }).apply(compiler);
+    new DevServerPlugin(getDevServerPluginOptions()).apply(compiler);
 
     const entryPluginHook = compiler.hooks.compilation.taps.filter(
       tap => tap.name === 'EntryPlugin',
@@ -100,21 +102,7 @@ describe('test dev tools', () => {
 
   test('should dev server plugin work correctly', () => {
     const compiler = webpack({});
-    new DevServerPlugin({
-      client: {
-        port: '8080',
-        overlay: false,
-        logging: 'error',
-        path: '/',
-        host: '127.0.0.1',
-      },
-      devMiddleware: {
-        writeToDisk: false,
-      },
-      watch: true,
-      hot: true,
-      liveReload: true,
-    }).apply(compiler);
+    new DevServerPlugin(getDevServerPluginOptions()).apply(compiler);
 
     const entryPluginHook = compiler.hooks.compilation.taps.filter(
       tap => tap.name === 'EntryPlugin',
@@ -124,5 +112,19 @@ describe('test dev tools', () => {
     );
     expect(entryPluginHook.length).toBe(2);
     expect(hotPluginHook.length).toBe(1);
+  });
+
+  test('should not inject entry when hot and liveReload is disabled', () => {
+    const compiler = webpack({});
+    new DevServerPlugin({
+      ...getDevServerPluginOptions(),
+      hot: false,
+      liveReload: false,
+    }).apply(compiler);
+
+    const entryPluginHook = compiler.hooks.compilation.taps.filter(
+      tap => tap.name === 'EntryPlugin',
+    );
+    expect(entryPluginHook.length).toBe(1);
   });
 });

--- a/website/docs/apis/config/tools/dev-server.md
+++ b/website/docs/apis/config/tools/dev-server.md
@@ -11,7 +11,7 @@ MWA。
 - 类型： `Object`
 - 默认值： `{}`
 
-对应 [DevServer](https://webpack.docschina.org/configuration/dev-server/#devserverlivereload) 的配置，用于配置开发环境运行的服务器的选项：
+对应 DevServer 的配置，用于配置开发环境运行的服务器的选项：
 
 ```js title="modern.config.js"
 export default defineConfig({
@@ -25,13 +25,42 @@ export default defineConfig({
 });
 ```
 
-:::tip 提示
-为了方便接入，Modern.js 大部分配置与 Webpack DevServer 保持一致，部分配置仍有差异。
-:::
-
 ## 配置项
 
-### hot
+Modern.js 基于 [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) 实现 DevServer，大部分配置与 [webpack-dev-server](https://webpack.js.org/api/webpack-dev-server/) 完全一致，少部分配置存在差异。
+
+对于存在差异的配置，一部分可以使用 Modern.js 中的其他配置项代替，也有一部分配置还未实现或无需实现，下方完整列出了这些内容。
+
+### 支持的配置项
+
+| 配置名        | 作用                               | 支持状态 |
+| ------------- | ---------------------------------- | -------- |
+| client        | 配置 dev-server 相关功能，如日志等 | Y        |
+| compress      | 是否开启 gzip 压缩                 | N        |
+| devMiddleware | webpack-dev-middleware 相关配置    | Y        |
+| https         | 开启 https                         | Y        |
+| headers       | 设置自定义响应头                   | Y        |
+| hot           | 是否可以使用 webpack 热模块替换    | Y        |
+| liveReload    | 是否可以 reload 页面               | Y        |
+| onListening   | 监听启动                           | N        |
+| open          | 构建完成后自动打开页面             | N        |
+| proxy         | 代理                               | Y        |
+| watchFiles    | 需要监听的文件                     | N        |
+
+
+### 拥有替代功能的配置项
+
+| 配置名                  | 作用                                                         | 替代方案                            |
+| ----------------------- | ------------------------------------------------------------ | ----------------------------------- |
+| historyApiFallback      | 重定向部分 URL                                               | [server.routes](/docs/apis/config/server/routes)                       |
+| onAfterSetupMiddleware  | 在 webpack-dev-server internal middleware 后执行，可以添加后续中间件 | devServer.after                     |
+| onBeforeSetupMiddleware | 在 webpack-dev-server internal middleware 前执行，可以添加前置中间件 | devServer.before                    |
+| port                    | dev server 监听端口                                          | [server.port](/docs/apis/config/server/port)                         |
+| static                  | 托管静态资源文件                                             | [config/public](/docs/apis/hooks/mwa/config/public) 和 [server.publicRoutes](/docs/apis/config/server/public-routes) 或 [config/upload](/docs/apis/hooks/mwa/config/upload) |
+
+### API
+
+#### hot
 
 - 类型： `boolean`
 - 默认值： `true`
@@ -40,7 +69,7 @@ export default defineConfig({
 
 关闭这项配置后，会移除 [HotModuleReplacementPlugin](https://webpack.js.org/plugins/hot-module-replacement-plugin/) 与 [react-refresh-webpack-plugin](https://github.com/pmmmwh/react-refresh-webpack-plugin)。
 
-### liveReload
+#### liveReload
 
 - 类型： `boolean`
 - 默认值： `true`
@@ -48,8 +77,6 @@ export default defineConfig({
 默认情况下，当监听到文件变化时，dev server 将会刷新页面。
 
 通过这个配置项可以关闭该行为。
-
-## 配置差异
 
 ### before
 

--- a/website/docs/apis/config/tools/dev-server.md
+++ b/website/docs/apis/config/tools/dev-server.md
@@ -5,11 +5,11 @@ sidebar_label: devServer
 # tools.devServer
 
 :::info 适用的工程方案
-* MWA
+MWA。
 :::
 
-* 类型： `Object`
-* 默认值： `{}`
+- 类型： `Object`
+- 默认值： `{}`
 
 对应 [DevServer](https://webpack.docschina.org/configuration/dev-server/#devserverlivereload) 的配置，用于配置开发环境运行的服务器的选项：
 
@@ -19,15 +19,35 @@ export default defineConfig({
     devServer: {
       hot: true,
       https: false,
-      liveReload: false
-    }
-  }
+      liveReload: true,
+    },
+  },
 });
 ```
 
 :::tip 提示
 为了方便接入，Modern.js 大部分配置与 Webpack DevServer 保持一致，部分配置仍有差异。
 :::
+
+## 配置项
+
+### hot
+
+- 类型： `boolean`
+- 默认值： `true`
+
+是否开启 webpack 的 [Hot Module Replacement](https://webpack.js.org/concepts/hot-module-replacement/) 热更新能力。
+
+关闭这项配置后，会移除 [HotModuleReplacementPlugin](https://webpack.js.org/plugins/hot-module-replacement-plugin/) 与 [react-refresh-webpack-plugin](https://github.com/pmmmwh/react-refresh-webpack-plugin)。
+
+### liveReload
+
+- 类型： `boolean`
+- 默认值： `true`
+
+默认情况下，当监听到文件变化时，dev server 将会刷新页面。
+
+通过这个配置项可以关闭该行为。
 
 ## 配置差异
 
@@ -37,8 +57,8 @@ export default defineConfig({
 这是一个实验性功能。
 :::
 
-* 类型： `Array`
-* 默认值： `null`
+- 类型： `Array`
+- 默认值： `null`
 
 在所有开发环境中间件前执行：
 
@@ -59,8 +79,8 @@ devServer: {
 这是一个实验性功能。
 :::
 
-* 类型： `Array`
-* 默认值： `null`
+- 类型： `Array`
+- 默认值： `null`
 
 在所有开发环境中间件后执行：
 


### PR DESCRIPTION
# PR Details

## Description

- support using `devServer.hot` to control HMR.
- support using `devServer.liveReload` to control live reload.

These two APIs have same effect as webpack-dev-server.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
