### PR TITLE
fix(webpack): tsconfig paths should work with files in node_modules

### DIFF
--- a/.changeset/fresh-rules-march.md
+++ b/.changeset/fresh-rules-march.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): tsconfig paths should work with files in node_modules

--- a/packages/cli/webpack/src/plugins/ts-config-paths-plugin.ts
+++ b/packages/cli/webpack/src/plugins/ts-config-paths-plugin.ts
@@ -64,12 +64,7 @@ export class TsConfigPathsPlugin {
       .tapAsync('TsConfigPathsPlugin', (request, resolveContext, callback) => {
         const requestName = request.request;
 
-        if (
-          // If this resolves to a node_module, we don't care what happens next
-          request.descriptionFileRoot?.includes('/node_modules/') ||
-          request.descriptionFileRoot?.includes('\\node_modules\\') ||
-          !requestName
-        ) {
+        if (!requestName) {
           return callback();
         }
 


### PR DESCRIPTION
# PR Details

## Description

webpack `alias` works on files in node_modules, and `paths` are expected to have the same effect as `alias`, so `paths` should works on files in node_modules,

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
