### PR TITLE
feat(app-tools): support modern inspect command

### DIFF
--- a/.changeset/nice-bikes-smoke.md
+++ b/.changeset/nice-bikes-smoke.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/app-tools': patch
+---
+
+feat(app-tools): support modern inspect command

--- a/packages/solutions/app-tools/src/commands/inspect.ts
+++ b/packages/solutions/app-tools/src/commands/inspect.ts
@@ -1,0 +1,120 @@
+import path from 'path';
+import {
+  Configuration,
+  getWebpackConfig,
+  WebpackConfigTarget,
+} from '@modern-js/webpack';
+import { fs, logger, signale, isUseSSRBundle, chalk } from '@modern-js/utils';
+import WebpackChain from '@modern-js/utils/webpack-chain';
+import type { PluginAPI, NormalizedConfig, IAppContext } from '@modern-js/core';
+import type { InspectOptions } from '../utils/types';
+
+export const formatWebpackConfig = (
+  config: Configuration,
+  verbose?: boolean,
+) => {
+  const stringify = WebpackChain.toString as (
+    config: Configuration,
+    options: { verbose?: boolean },
+  ) => string;
+
+  return `module.exports = ${stringify(config, { verbose })};`;
+};
+
+export const inspect = (api: PluginAPI, options: InspectOptions) => {
+  process.env.NODE_ENV = options.env;
+
+  const resolvedConfig = api.useResolvedConfigContext();
+  const appContext = api.useAppContext();
+
+  const outputFiles: string[] = [];
+
+  outputFiles.push(
+    printInspectResult(
+      WebpackConfigTarget.CLIENT,
+      appContext,
+      resolvedConfig,
+      options,
+    ),
+  );
+
+  if (resolvedConfig.output.enableModernMode) {
+    outputFiles.push(
+      printInspectResult(
+        WebpackConfigTarget.MODERN,
+        appContext,
+        resolvedConfig,
+        options,
+      ),
+    );
+  }
+
+  if (isUseSSRBundle(resolvedConfig)) {
+    outputFiles.push(
+      printInspectResult(
+        WebpackConfigTarget.NODE,
+        appContext,
+        resolvedConfig,
+        options,
+      ),
+    );
+  }
+
+  signale.success(
+    'Inspect succeed, you can open following files to view the full webpack config: \n',
+  );
+  outputFiles.forEach(file => {
+    signale.log(
+      `  - ${chalk.yellow(path.relative(appContext.appDirectory, file))}`,
+    );
+  });
+  signale.log();
+};
+
+export const getTagByWebpackTarget = (webpackTarget: WebpackConfigTarget) => {
+  switch (webpackTarget) {
+    case WebpackConfigTarget.CLIENT:
+      return 'client';
+    case WebpackConfigTarget.MODERN:
+      return 'modern';
+    case WebpackConfigTarget.NODE:
+      return 'ssr';
+    default:
+      throw Error(`Unsupported webpack target: ${webpackTarget as number}`);
+  }
+};
+
+export const printInspectResult = (
+  webpackTarget: WebpackConfigTarget,
+  appContext: IAppContext,
+  resolvedConfig: NormalizedConfig,
+  options: InspectOptions,
+) => {
+  const webpackConfig = getWebpackConfig(
+    webpackTarget,
+    appContext,
+    resolvedConfig,
+  )!;
+  const { output, verbose, console = true } = options;
+  const outputPath = output
+    ? path.posix.join(appContext.distDirectory, output)
+    : appContext.distDirectory;
+
+  const tag = getTagByWebpackTarget(webpackTarget);
+  const outputFile = `webpack.${tag}.inspect.js`;
+  const outputFilePath = path.posix.join(outputPath, outputFile);
+  const rawWebpackConfig = formatWebpackConfig(webpackConfig, verbose);
+
+  fs.outputFileSync(outputFilePath, rawWebpackConfig);
+
+  if (console) {
+    logger.log(
+      `
+webpack config for ${tag} build:
+${rawWebpackConfig}
+    `,
+    );
+  }
+
+  return outputFilePath;
+};

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -106,6 +106,26 @@ export default (): CliPlugin => ({
             const { MWANewAction } = await import('@modern-js/new-action');
             await MWANewAction({ ...options, locale });
           });
+
+        program
+          .command('inspect')
+          .description('inspect internal webpack config')
+          .option(
+            `--env <env>`,
+            i18n.t(localeKeys.command.inspect.env),
+            'development',
+          )
+          .option(
+            '--output <output>',
+            i18n.t(localeKeys.command.inspect.output),
+            '/',
+          )
+          .option('--no-console', i18n.t(localeKeys.command.inspect.noConsole))
+          .option('--verbose', i18n.t(localeKeys.command.inspect.verbose))
+          .action(async options => {
+            const { inspect } = await import('./commands/inspect');
+            inspect(api, options);
+          });
       },
 
       // 这里会被 core/initWatcher 监听的文件变动触发，如果是 src 目录下的文件变动，则不做 restart

--- a/packages/solutions/app-tools/src/locale/en.ts
+++ b/packages/solutions/app-tools/src/locale/en.ts
@@ -21,5 +21,11 @@ export const EN_LOCALE = {
       distTag: `use specified tag version for it's generator`,
       registry: 'set npm registry url to run npm command',
     },
+    inspect: {
+      env: 'specify env mode',
+      output: 'specify inspect content output path',
+      noConsole: 'do not log the result in terminal',
+      verbose: 'show full function definitions in output',
+    },
   },
 };

--- a/packages/solutions/app-tools/src/locale/zh.ts
+++ b/packages/solutions/app-tools/src/locale/zh.ts
@@ -21,5 +21,11 @@ export const ZH_LOCALE = {
       distTag: '生成器使用特殊的 npm Tag 版本',
       registry: '生成器运行过程中定制 npm Registry',
     },
+    inspect: {
+      env: '查看指定环境下的配置',
+      output: '指定在 dist 目录下输出的路径',
+      noConsole: '不在终端中输出完整结果',
+      verbose: '在结果中展示函数的完整内容',
+    },
   },
 };

--- a/packages/solutions/app-tools/src/utils/types.ts
+++ b/packages/solutions/app-tools/src/utils/types.ts
@@ -17,3 +17,10 @@ export type DeployOptions = {
 export type StartOptions = {
   apiOnly?: boolean;
 };
+
+export type InspectOptions = {
+  env?: string;
+  output?: string;
+  console?: boolean;
+  verbose?: boolean;
+};

--- a/packages/solutions/app-tools/tests/commands/__snapshots__/inspect.test.ts.snap
+++ b/packages/solutions/app-tools/tests/commands/__snapshots__/inspect.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`inspect command should format webpack config correctly 1`] = `
+"module.exports = {
+  mode: 'development',
+  plugins: [
+    {
+      definitions: {
+        foo: 'bar'
+      }
+    }
+  ]
+};"
+`;

--- a/packages/solutions/app-tools/tests/commands/inspect.test.ts
+++ b/packages/solutions/app-tools/tests/commands/inspect.test.ts
@@ -1,0 +1,93 @@
+import { fs } from '@modern-js/utils';
+import { NormalizedConfig } from '@modern-js/core';
+import { IAppContext } from '@modern-js/types';
+import {
+  webpack,
+  Configuration,
+  WebpackConfigTarget,
+} from '@modern-js/webpack';
+import {
+  printInspectResult,
+  formatWebpackConfig,
+  getTagByWebpackTarget,
+} from '../../src/commands/inspect';
+
+describe('inspect command', () => {
+  const { DefinePlugin } = webpack;
+
+  const webpackConfig: Configuration = {
+    mode: 'development',
+    plugins: [new DefinePlugin({ foo: 'bar' })],
+  };
+
+  const appContext = {
+    metaName: '',
+    appDirectory: __dirname,
+    distDirectory: `${__dirname}/dist`,
+    srcDirectory: `${__dirname}/src`,
+    sharedDirectory: `${__dirname}/src/shared`,
+    internalSrcAlias: '@_modern_js_src',
+    internalDirAlias: '@_modern_js_internal',
+    internalDirectory: `${__dirname}/node_modules/.modern-js`,
+  } as IAppContext;
+
+  const normalizedConfig = {
+    source: {
+      configDir: '/config',
+    },
+    output: {
+      path: '/',
+      jsPath: '/js',
+      cssPath: '/css',
+    },
+  } as NormalizedConfig;
+
+  test('should format webpack config correctly', () => {
+    expect(formatWebpackConfig(webpackConfig)).toMatchSnapshot();
+  });
+
+  test('should get correct tag by webpack target', () => {
+    expect(getTagByWebpackTarget(WebpackConfigTarget.CLIENT)).toEqual('client');
+    expect(getTagByWebpackTarget(WebpackConfigTarget.NODE)).toEqual('ssr');
+    expect(getTagByWebpackTarget(WebpackConfigTarget.MODERN)).toEqual('modern');
+    expect(() => {
+      getTagByWebpackTarget('foo' as any);
+    }).toThrowError();
+  });
+
+  test('should log result in console', () => {
+    const log = jest.fn();
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(log);
+    const fsSpy = jest.spyOn(fs, 'outputFileSync');
+
+    printInspectResult(
+      WebpackConfigTarget.CLIENT,
+      appContext,
+      normalizedConfig,
+      {},
+    );
+
+    expect(log).toHaveBeenCalledTimes(1);
+    logSpy.mockRestore();
+    fsSpy.mockRestore();
+  });
+
+  test('should not log result in console when console option is false', () => {
+    const log = jest.fn();
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(log);
+    const fsSpy = jest.spyOn(fs, 'outputFileSync');
+
+    printInspectResult(
+      WebpackConfigTarget.CLIENT,
+      appContext,
+      normalizedConfig,
+      {
+        console: false,
+      },
+    );
+
+    expect(log).toHaveBeenCalledTimes(0);
+    logSpy.mockRestore();
+    fsSpy.mockRestore();
+  });
+});

--- a/website/docs/apis/commands/mwa/inspect.md
+++ b/website/docs/apis/commands/mwa/inspect.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 7
+---
+
+```
+Usage: modern inspect [options]
+
+inspect internal webpack config
+
+Options:
+  --env <env>          查看指定环境下的配置 (default: "development")
+  --output <output>    指定在 dist 目录下输出的路径 (default: "/")
+  --no-console         不在终端中输出完整结果
+  --verbose            在结果中展示函数的完整内容
+  -h, --help           显示命令帮助
+```
+
+`modern inspect` 命令，用于查看项目的 webpack 完整配置。
+
+在项目根目录下执行命令 `npx modern inspect`，会将 webpack 配置输出在终端界面，同时也会在项目的 `dist` 目录生成一份 `webpack.client.inspect.js` 文件，开发者可手动打开查看。
+
+## 指定环境
+
+默认情况下，会输出开发环境的 webpack 配置，可以使用 `env` 选项来输出生产环境的配置：
+
+```bash
+modern inspect --env production
+```
+
+## 配置类型
+
+### SSR 配置
+
+如果项目开启了 SSR 能力，则在 `dist` 目录会另外生成一份 `webpack.ssr.inspect.js` 文件，对应 SSR 构建时的 webpack 配置。
+
+### Modern 配置
+
+如果项目开启了 [enableModernMode](/docs/apis/config/output/enable-modern-mode) 选项，则在 `dist` 目录会另外生成一份 `webpack.modern.inspect.js` 文件，对应现代浏览器的 webpack 配置。


### PR DESCRIPTION
# PR Details

## Description

Support modern inspect command, using `WebpackChain.toString` to implement this feature.

![image](https://user-images.githubusercontent.com/7237365/173018143-370dda1b-6838-4814-b116-22d71be1fd50.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
