### PR TITLE
fix(webpack): incorrect babel loader options for node target

### DIFF
--- a/.changeset/moody-hats-tap.md
+++ b/.changeset/moody-hats-tap.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): incorrect babel loader options for node target

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -21,6 +21,7 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import type { IAppContext, NormalizedConfig } from '@modern-js/core';
 import { createBabelChain, BabelChain } from '@modern-js/babel-chain';
 import WebpackChain from '@modern-js/utils/webpack-chain';
+import type { Options as BabelPrestAppOptions } from '@modern-js/babel-preset-app';
 import { merge as webpackMerge } from '../../compiled/webpack-merge';
 import WebpackBar from '../../compiled/webpackbar';
 import {
@@ -72,6 +73,8 @@ class BaseWebpackConfig {
   babelChain: BabelChain;
 
   isTsProject: boolean;
+
+  babelPresetAppOptions?: Partial<BabelPrestAppOptions>;
 
   constructor(appContext: IAppContext, options: NormalizedConfig) {
     this.appContext = appContext;
@@ -703,6 +706,7 @@ class BaseWebpackConfig {
       this.appDirectory,
       this.options,
       this.babelChain,
+      this.babelPresetAppOptions,
     );
 
     const rule = loaders

--- a/packages/cli/webpack/src/config/client.ts
+++ b/packages/cli/webpack/src/config/client.ts
@@ -46,6 +46,9 @@ export class ClientWebpackConfig extends BaseWebpackConfig {
         }.html`,
       );
     this.coreJsEntry = path.resolve(__dirname, '../runtime/core-js-entry.js');
+    this.babelPresetAppOptions = {
+      target: 'client',
+    };
   }
 
   name() {

--- a/packages/cli/webpack/src/config/modern.ts
+++ b/packages/cli/webpack/src/config/modern.ts
@@ -1,11 +1,6 @@
 import { createBabelChain } from '@modern-js/babel-chain';
 import type { IAppContext, NormalizedConfig } from '@modern-js/core';
-import {
-  CHAIN_ID,
-  applyOptionsChain,
-  isUseSSRBundle,
-  removeLeadingSlash,
-} from '@modern-js/utils';
+import { CHAIN_ID, removeLeadingSlash } from '@modern-js/utils';
 import { ClientWebpackConfig } from './client';
 
 class ModernWebpackConfig extends ClientWebpackConfig {
@@ -24,6 +19,12 @@ class ModernWebpackConfig extends ClientWebpackConfig {
     this.jsFilename = this.jsFilename.replace(/\.js$/, '-es6.js');
 
     this.babelChain = createBabelChain();
+
+    this.babelPresetAppOptions = {
+      target: 'client',
+      useBuiltIns: false,
+      useModern: true,
+    };
   }
 
   name() {
@@ -42,48 +43,6 @@ class ModernWebpackConfig extends ClientWebpackConfig {
         },
       ]);
     }
-  }
-
-  loaders() {
-    const loaders = super.loaders();
-
-    const babelOptions = loaders
-      .oneOf(CHAIN_ID.ONE_OF.JS)
-      .use(CHAIN_ID.USE.BABEL)
-      .get('options');
-
-    loaders
-      .oneOf(CHAIN_ID.ONE_OF.JS)
-      .use(CHAIN_ID.USE.BABEL)
-      .options({
-        ...babelOptions,
-        presets: [
-          [
-            require.resolve('@modern-js/babel-preset-app'),
-            {
-              metaName: this.appContext.metaName,
-              appDirectory: this.appDirectory,
-              target: 'client',
-              useLegacyDecorators: !this.options.output?.enableLatestDecorators,
-              useBuiltIns: false,
-              useModern: true,
-              chain: this.babelChain,
-              styledComponents: applyOptionsChain(
-                {
-                  pure: true,
-                  displayName: true,
-                  ssr: isUseSSRBundle(this.options),
-                  transpileTemplateLiterals: true,
-                },
-                this.options.tools?.styledComponents,
-              ),
-              userBabelConfig: this.options.tools.babel,
-            },
-          ],
-        ],
-      });
-
-    return loaders;
   }
 }
 

--- a/packages/cli/webpack/src/utils/getBabelOptions.ts
+++ b/packages/cli/webpack/src/utils/getBabelOptions.ts
@@ -1,5 +1,8 @@
 import { isProd, applyOptionsChain, isUseSSRBundle } from '@modern-js/utils';
-import { getBabelConfig } from '@modern-js/babel-preset-app';
+import {
+  getBabelConfig,
+  Options as BabelPresetAppOptions,
+} from '@modern-js/babel-preset-app';
 import type { BabelChain } from '@modern-js/babel-chain';
 import type { NormalizedConfig, TransformOptions } from '@modern-js/core';
 
@@ -16,6 +19,7 @@ export const getBabelOptions = (
   appDirectory: string,
   config: NormalizedConfig,
   chain: BabelChain,
+  babelPresetAppOptions?: Partial<BabelPresetAppOptions>,
 ) => {
   const lodashOptions = applyOptionsChain(
     { id: ['lodash', 'ramda'] },
@@ -59,7 +63,6 @@ export const getBabelOptions = (
     ...getBabelConfig({
       metaName,
       appDirectory,
-      target: 'client',
       lodash: lodashOptions,
       useLegacyDecorators: !config.output?.enableLatestDecorators,
       useBuiltIns: getUseBuiltIns(config),
@@ -67,6 +70,7 @@ export const getBabelOptions = (
       styledComponents: styledComponentsOptions,
       userBabelConfig: config.tools?.babel,
       userBabelConfigUtils: babelUtils,
+      ...babelPresetAppOptions,
     }),
   };
 

--- a/packages/cli/webpack/tests/utils.test.ts
+++ b/packages/cli/webpack/tests/utils.test.ts
@@ -40,6 +40,9 @@ describe('getBabelOptions', () => {
       '/root',
       {} as any,
       createBabelChain(),
+      {
+        target: 'client',
+      },
     );
 
     setBabelConfigSerializer();


### PR DESCRIPTION
# PR Details

## Description

- fix incorrect babel loader options for node target
- fix addExcludes/addIncludes not work for node target

These bugs are introduced in https://github.com/modern-js-dev/modern.js/pull/1200

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
