### PR TITLE
feat(webpack): improve utils of tools.webpack

### DIFF
--- a/.changeset/many-rats-help.md
+++ b/.changeset/many-rats-help.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/babel-preset-base': patch
+'@modern-js/webpack': patch
+'@modern-js/utils': patch
+---
+
+feat(webpack): improve utils of tools.webpack

--- a/packages/cli/babel-preset-base/src/babel-utils.ts
+++ b/packages/cli/babel-preset-base/src/babel-utils.ts
@@ -1,12 +1,6 @@
 import { sep, isAbsolute } from 'path';
+import { ensureArray } from '@modern-js/utils';
 import type { TransformOptions, PluginItem } from '@babel/core';
-
-const ensureArray = <T>(params: T | T[]): T[] => {
-  if (Array.isArray(params)) {
-    return params;
-  }
-  return [params];
-};
 
 // compatible with windows path
 const formatPath = (originPath: string) => {

--- a/packages/cli/core/src/config/types/index.ts
+++ b/packages/cli/core/src/config/types/index.ts
@@ -6,6 +6,7 @@ import type webpack from 'webpack';
 import type {
   RuleSetRule,
   Configuration as WebpackConfiguration,
+  WebpackPluginInstance,
 } from 'webpack';
 import type WebpackChain from '@modern-js/utils/webpack-chain';
 import type autoprefixer from 'autoprefixer';
@@ -233,9 +234,13 @@ export type WebpackConfigUtils = {
   env: string;
   name: string;
   webpack: typeof webpack;
-  addRules: (rules: RuleSetRule[]) => void;
-  prependPlugins: (plugins: WebpackConfiguration['plugins']) => void;
-  appendPlugins: (plugins: WebpackConfiguration['plugins']) => void;
+  addRules: (rules: RuleSetRule | RuleSetRule[]) => void;
+  prependPlugins: (
+    plugins: WebpackPluginInstance | WebpackPluginInstance[],
+  ) => void;
+  appendPlugins: (
+    plugins: WebpackPluginInstance | WebpackPluginInstance[],
+  ) => void;
   removePlugin: (pluginName: string) => void;
   /**
    * @deprecated please use `tools.webpackChain` instead.

--- a/packages/cli/webpack/src/config/shared.ts
+++ b/packages/cli/webpack/src/config/shared.ts
@@ -1,5 +1,9 @@
-import { CHAIN_ID } from '@modern-js/utils';
-import type { Configuration, RuleSetRule } from 'webpack';
+import { CHAIN_ID, ensureArray } from '@modern-js/utils';
+import type {
+  Configuration,
+  RuleSetRule,
+  WebpackPluginInstance,
+} from 'webpack';
 import type WebpackChain from '@modern-js/utils/webpack-chain';
 import { BundleAnalyzerPlugin } from '../../compiled/webpack-bundle-analyzer';
 import {
@@ -23,32 +27,17 @@ export function enableBundleAnalyzer(
 
 export function getWebpackUtils(config: Configuration) {
   return {
-    addRules(rules: RuleSetRule[]) {
-      if (Array.isArray(rules)) {
-        config.module?.rules?.unshift(...rules);
-      } else {
-        throw new TypeError(
-          'The argument of `addRules` function should be array type, please check the `tools.webpack` config.',
-        );
-      }
+    addRules(rules: RuleSetRule | RuleSetRule[]) {
+      const ruleArr = ensureArray(rules);
+      config.module?.rules?.unshift(...ruleArr);
     },
-    prependPlugins(plugins: Configuration['plugins']) {
-      if (Array.isArray(plugins)) {
-        config.plugins?.unshift(...plugins);
-      } else {
-        throw new TypeError(
-          'The argument of `prependPlugins` function should be array type, please check the `tools.webpack` config.',
-        );
-      }
+    prependPlugins(plugins: WebpackPluginInstance | WebpackPluginInstance[]) {
+      const pluginArr = ensureArray(plugins);
+      config.plugins?.unshift(...pluginArr);
     },
-    appendPlugins(plugins: Configuration['plugins']) {
-      if (Array.isArray(plugins)) {
-        config.plugins?.push(...plugins);
-      } else {
-        throw new TypeError(
-          'The argument of `appendPlugins` function should be array type, please check the `tools.webpack` config.',
-        );
-      }
+    appendPlugins(plugins: WebpackPluginInstance | WebpackPluginInstance[]) {
+      const pluginArr = ensureArray(plugins);
+      config.plugins?.push(...pluginArr);
     },
     removePlugin(pluginName: string) {
       config.plugins = config.plugins?.filter(

--- a/packages/cli/webpack/tests/base.test.ts
+++ b/packages/cli/webpack/tests/base.test.ts
@@ -7,7 +7,6 @@ import { CHAIN_ID } from '@modern-js/utils';
 import { BaseWebpackConfig } from '../src/config/base';
 import { JS_REGEX, TS_REGEX } from '../src/utils/constants';
 import { mergeRegex } from '../src/utils/mergeRegex';
-import { getWebpackUtils } from '../src/config/shared';
 import { userConfig, mockNodeEnv } from './util';
 
 describe('base webpack config', () => {
@@ -155,6 +154,7 @@ describe('base webpack config', () => {
       config,
       utils,
     ) => {
+      utils.addRules(newRule);
       utils.addRules([newRule]);
     };
 
@@ -166,6 +166,7 @@ describe('base webpack config', () => {
     } as any);
 
     expect(baseConfig.config().module.rules[0]).toEqual(newRule);
+    expect(baseConfig.config().module.rules[1]).toEqual(newRule);
   });
 
   test(`apply tools.webpack and using utils.prependPlugins`, () => {
@@ -173,6 +174,7 @@ describe('base webpack config', () => {
       config,
       utils,
     ) => {
+      utils.prependPlugins(new MyPlugin());
       utils.prependPlugins([new MyPlugin()]);
     };
 
@@ -184,6 +186,7 @@ describe('base webpack config', () => {
     } as any);
 
     expect(baseConfig.config().plugins[0].constructor.name).toEqual('MyPlugin');
+    expect(baseConfig.config().plugins[1].constructor.name).toEqual('MyPlugin');
   });
 
   test(`apply tools.webpack and using utils.appendPlugins`, () => {
@@ -191,6 +194,7 @@ describe('base webpack config', () => {
       config,
       utils,
     ) => {
+      utils.appendPlugins(new MyPlugin());
       utils.appendPlugins([new MyPlugin()]);
     };
 
@@ -202,6 +206,7 @@ describe('base webpack config', () => {
     } as any);
 
     const { plugins } = baseConfig.config();
+    expect(plugins[plugins.length - 2].constructor.name).toEqual('MyPlugin');
     expect(plugins[plugins.length - 1].constructor.name).toEqual('MyPlugin');
   });
 
@@ -225,34 +230,6 @@ describe('base webpack config', () => {
     expect(
       plugins[plugins.length - 1].constructor.name === 'MyPlugin',
     ).toBeFalsy();
-  });
-
-  test('utils.appendPlugins should throw an error with incorrect argument type', () => {
-    const utils = getWebpackUtils({ plugins: [] });
-
-    expect(() => {
-      utils.appendPlugins(new MyPlugin() as any);
-    }).toThrowError();
-  });
-
-  test('utils.prependPlugins should throw an error with incorrect argument type', () => {
-    const utils = getWebpackUtils({ plugins: [] });
-
-    expect(() => {
-      utils.prependPlugins(new MyPlugin() as any);
-    }).toThrowError();
-  });
-
-  test('utils.addRules should throw an error with incorrect argument type', () => {
-    const utils = getWebpackUtils({
-      module: {
-        rules: [],
-      },
-    });
-
-    expect(() => {
-      utils.addRules({} as any);
-    }).toThrowError();
   });
 
   test(`should using output.assetPrefix as publicPath in dev`, () => {

--- a/packages/toolkit/utils/src/ensureArray.ts
+++ b/packages/toolkit/utils/src/ensureArray.ts
@@ -1,0 +1,6 @@
+export const ensureArray = <T>(params: T | T[]): T[] => {
+  if (Array.isArray(params)) {
+    return params;
+  }
+  return [params];
+};

--- a/packages/toolkit/utils/src/index.ts
+++ b/packages/toolkit/utils/src/index.ts
@@ -8,6 +8,7 @@ export * from './is';
 export * from './compatRequire';
 export * from './logger';
 export * from './constants';
+export * from './ensureArray';
 export * from './ensureAbsolutePath';
 export * from './clearConsole';
 export * from './applyOptionsChain';

--- a/website/docs/apis/config/tools/webpack.md
+++ b/website/docs/apis/config/tools/webpack.md
@@ -97,6 +97,8 @@ export default defineConfig({
 
 ### addRules
 
+- 类型： `(rules: RuleSetRule | RuleSetRule[]) => void`
+
 通常情况下，使用 Modern.js 不需要添加额外的 [webpack rule](https://webpack.js.org/configuration/module/#rule-conditions)。当有额外需求时，可以使用该工具函数添加对应的 rules。
 
 以处理 [cson](https://github.com/groupon/cson-parser) 文件为例：
@@ -105,10 +107,21 @@ export default defineConfig({
 export default defineConfig({
   tools: {
     webpack: (config, { addRules }) => {
+      // 添加单条规则
+      addRules({
+        test: /\.cson/,
+        loader: require.resolve('cson-loader'),
+      });
+
+      // 以数组形式添加多条规则
       addRules([
         {
-          test: /\.cson/,
-          loader: require.resolve('cson-loader'),
+          test: /\.foo/,
+          loader: require.resolve('foo-loader'),
+        },
+        {
+          test: /\.bar/,
+          loader: require.resolve('bar-loader'),
         },
       ]);
     },
@@ -118,17 +131,23 @@ export default defineConfig({
 
 ### prependPlugins
 
-在内部 webpack 插件数组头部添加额外的插件：
+- 类型： `(plugins: WebpackPluginInstance | WebpackPluginInstance[]) => void`
+
+在内部 webpack 插件数组头部添加额外的插件（数组头部的插件会优先执行）。
 
 ```ts title="modern.config.ts"
 export default defineConfig({
   tools: {
     webpack: (config, { prependPlugins, webpack }) => {
-      prependPlugins([
+      // 添加单个插件
+      prependPlugins(
         new webpack.BannerPlugin({
           banner: 'hello world!',
         }),
-      ]);
+      );
+
+      // 以数组形式添加多个插件
+      prependPlugins([new PluginA(), new PluginB()]);
     },
   },
 });
@@ -136,23 +155,31 @@ export default defineConfig({
 
 ### appendPlugins
 
-在内部 webpack 插件数组尾部添加额外的插件：
+- 类型： `(plugins: WebpackPluginInstance | WebpackPluginInstance[]) => void`
+
+在内部 webpack 插件数组尾部添加额外的插件（数组尾部的插件会在最后执行）。
 
 ```ts title="modern.config.ts"
 export default defineConfig({
   tools: {
     webpack: (config, { appendPlugins, webpack }) => {
+      // 添加单个插件
       appendPlugins([
         new webpack.BannerPlugin({
           banner: 'hello world!',
         }),
       ]);
+
+      // 以数组形式添加多个插件
+      appendPlugins([new PluginA(), new PluginB()]);
     },
   },
 });
 ```
 
 ### removePlugin
+
+- 类型： `(name: string) => void`
 
 删除内部的 webpack 插件，参数为该插件的 `constructor.name`。
 


### PR DESCRIPTION
# PR Details

## Description

Improve utils of `tools.webpack`, allow `addRules` `appendPlugins`, `prependPlugins` to using non-array params.

This change will making it easier to use these utils.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
