### PR TITLE
fix(webpack): failed to display compile time in CI environment

### DIFF
--- a/.changeset/empty-hotels-bathe.md
+++ b/.changeset/empty-hotels-bathe.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): failed to display compile time in CI environment

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -420,10 +420,9 @@ class BaseWebpackConfig {
 
   plugins() {
     // progress bar
-    process.stdout.isTTY &&
-      this.chain
-        .plugin(PLUGIN.PROGRESS)
-        .use(WebpackBar, [{ name: this.chain.get('name') }]);
+    this.chain
+      .plugin(PLUGIN.PROGRESS)
+      .use(WebpackBar, [{ name: this.chain.get('name') }]);
 
     if (enableCssExtract(this.options)) {
       this.chain.plugin(PLUGIN.MINI_CSS_EXTRACT).use(MiniCssExtractPlugin, [


### PR DESCRIPTION
# PR Details

## Description

Currently, we disabled `webpackbar` when `process.stdout.isTTY = false`, which caused compile time log missing in CI environment.

We should remove this condition, and `webpackbar` will automatically fallback to basic reporters in CI environment, like:

![image](https://user-images.githubusercontent.com/7237365/174563322-24dd3e24-569c-4402-aa2b-18c8abbb8867.png)

https://github.com/unjs/webpackbar/blob/7ee5c73bf2ecb2bb31cf85df95349c69994ecad6/src/index.ts#L11-L17

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
