### PR TITLE
fix: utils.addIncludes is not a function

### DIFF
--- a/.changeset/tasty-weeks-drive.md
+++ b/.changeset/tasty-weeks-drive.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/babel-preset-app': patch
+---
+
+fix: utils.addIncludes is not a function

--- a/packages/cli/babel-preset-base/src/babel-utils.ts
+++ b/packages/cli/babel-preset-base/src/babel-utils.ts
@@ -1,5 +1,6 @@
 import { sep, isAbsolute } from 'path';
 import { ensureArray } from '@modern-js/utils';
+import type { BabelConfigUtils } from '@modern-js/core';
 import type { TransformOptions, PluginItem } from '@babel/core';
 
 // compatible with windows path
@@ -74,9 +75,19 @@ const removePresets = (
   });
 };
 
-export const getBabelUtils = (config: TransformOptions) => ({
-  addPlugins: (plugins: PluginItem[]) => addPlugins(plugins, config),
-  addPresets: (presets: PluginItem[]) => addPresets(presets, config),
-  removePlugins: (plugins: string | string[]) => removePlugins(plugins, config),
-  removePresets: (presets: string | string[]) => removePresets(presets, config),
-});
+export const getBabelUtils = (config: TransformOptions): BabelConfigUtils => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const noop = () => {};
+  return {
+    addPlugins: (plugins: PluginItem[]) => addPlugins(plugins, config),
+    addPresets: (presets: PluginItem[]) => addPresets(presets, config),
+    removePlugins: (plugins: string | string[]) =>
+      removePlugins(plugins, config),
+    removePresets: (presets: string | string[]) =>
+      removePresets(presets, config),
+    // `addIncludes` and `addExcludes` are noop functions by default,
+    // It can be overridden by `extraBabelUtils`.
+    addIncludes: noop,
+    addExcludes: noop,
+  };
+};


### PR DESCRIPTION
# PR Details

## Description

Fix error when using `addIncludes` util in `tools.babel`:

```js
export default defineConfig({
  tools: {
    babel(opt, utils) {
      utils.addIncludes(require.resolve('test-a'));
    },
  },
});
```

The `tools.babel` is also used by `@modern-js/server-utils`, which does not provide the `addIncludes` and `addExcludes` utils, so we should preset the default noop function.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
