### PR TITLE
fix(babel-plugin-preset-app): can't match path in windows system

### DIFF
--- a/packages/cli/babel-preset-app/src/built-in/babel-plugin-lock-corejs-version.ts
+++ b/packages/cli/babel-preset-app/src/built-in/babel-plugin-lock-corejs-version.ts
@@ -1,4 +1,5 @@
 import nodePath from 'path';
+import { normalizeToPosixPath } from '@modern-js/utils';
 import * as t from '@babel/types';
 
 const REWRITE_TARGETS: Record<string, string> = {
@@ -18,7 +19,7 @@ export default (_: any, options: { metaName: string }) => {
   return {
     post({ path, ...stats }: any) {
       const { sourceFileName } = stats.opts;
-      if (regExp.test(sourceFileName)) {
+      if (regExp.test(normalizeToPosixPath(sourceFileName))) {
         return;
       }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5020,7 +5020,6 @@ importers:
 
   tests/integration/mwa-app:
     specifiers:
-      '@babel/runtime': ^7
       '@modern-js/app-tools': workspace:*
       '@modern-js/plugin-jarvis': workspace:*
       '@modern-js/runtime': workspace:*
@@ -5031,7 +5030,6 @@ importers:
       react-dom: ^17.0.1
       typescript: ^4
     dependencies:
-      '@babel/runtime': 7.18.3
       '@modern-js/runtime': link:../../../packages/cli/plugin-runtime
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -24044,7 +24042,7 @@ packages:
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      nan: 2.15.0
+      nan: 2.16.0
     dev: false
     optional: true
 

--- a/tests/integration/mwa-app/package.json
+++ b/tests/integration/mwa-app/package.json
@@ -34,7 +34,6 @@
     "dist/"
   ],
   "dependencies": {
-    "@babel/runtime": "^7",
     "@modern-js/runtime": "workspace:*",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"


### PR DESCRIPTION
# PR Details
fix
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
**babel-runtime can't math path in windows system**

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [  ] My code follows the code style of this project.
- [  ] I have updated changeset
