### PR TITLE
fix: the inferred type of "pluginAPI" cannot be named without a reference

### DIFF
--- a/.changeset/serious-peaches-judge.md
+++ b/.changeset/serious-peaches-judge.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin': patch
+'@modern-js/core': patch
+---
+
+Export some required types

--- a/packages/cli/core/src/pluginAPI.ts
+++ b/packages/cli/core/src/pluginAPI.ts
@@ -17,6 +17,8 @@ export const pluginAPI = {
   useResolvedConfigContext,
 };
 
+export type { IAppContext } from '@modern-js/types';
+
 /** all apis for cli plugin */
 export type PluginAPI = typeof pluginAPI & CommonAPI<CliHooks>;
 

--- a/packages/toolkit/plugin/src/farrow-pipeline/context.ts
+++ b/packages/toolkit/plugin/src/farrow-pipeline/context.ts
@@ -105,6 +105,7 @@ export const createContainer = (
 export type Hooks = {
   useContainer: () => Container;
 };
+export type { AnyFn } from './asyncHooksInterface';
 
 const { run, hooks } = createHooks<Hooks>({
   useContainer: () => {

--- a/packages/toolkit/plugin/src/manager/runner.ts
+++ b/packages/toolkit/plugin/src/manager/runner.ts
@@ -1,5 +1,7 @@
 import { createContext } from '../farrow-pipeline';
 
+export type { Context } from '../farrow-pipeline/context';
+
 export const RunnerContext = createContext<any>(null);
 
 export const useRunner = () => {


### PR DESCRIPTION
# PR Details
I exported some required types.

<!--- Provide a general summary of your changes in the Title above -->

## Description
When i want to bundle  a modern plugin, i found a error about type. 
![4938294d-9632-4b89-9cec-f31bae010fb0](https://user-images.githubusercontent.com/50694858/174801174-b25e9cf7-cdd7-4077-9407-112a0122eb13.jpeg)
It's a problem that have occurred about type.  Look [here](https://github.com/microsoft/TypeScript/issues/42873) for more info.And i found this [answer](https://github.com/microsoft/TypeScript/issues/42873#issuecomment-869057582) can solve my problem. So i exported some required types to fix it.
And i also fix the same problem in @modern-js/plugin.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

look in description

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Only export type and no effects.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
