### PR TITLE
fix(eslint-config): inconsistent experience between format and auto fix

### DIFF
--- a/.changeset/polite-bats-love.md
+++ b/.changeset/polite-bats-love.md
@@ -1,0 +1,5 @@
+---
+'@modern-js-app/eslint-config': patch
+---
+
+fix(eslint-config): inconsistent experience between format and auto fix

--- a/packages/review/eslint-config-app/base.js
+++ b/packages/review/eslint-config-app/base.js
@@ -44,8 +44,6 @@ module.exports = {
     'promise',
     // https://www.npmjs.com/package/eslint-plugin-node
     'node',
-    // https://github.com/gajus/eslint-plugin-jsdoc
-    // 'jsdoc',
     // https: //github.com/eslint/eslint-plugin-markdown
     'markdown',
   ],

--- a/packages/review/eslint-config-app/base.js
+++ b/packages/review/eslint-config-app/base.js
@@ -828,11 +828,6 @@ module.exports = {
     // https://eslint.org/docs/rules/wrap-regex
     'wrap-regex': 'off',
 
-    /*
-     * ECMAScript 6
-     * https://eslint.org/docs/rules/arrow-body-style
-     */
-    'arrow-body-style': ['error', 'as-needed'],
     // https://eslint.org/docs/rules/arrow-parens
     'arrow-parens': ['error', 'as-needed', { requireForBlockBody: true }],
     // https://eslint.org/docs/rules/arrow-spacing
@@ -893,8 +888,6 @@ module.exports = {
     'no-var': 'error',
     // https://eslint.org/docs/rules/object-shorthand
     'object-shorthand': ['error', 'always'],
-    // https://eslint.org/docs/rules/prefer-arrow-callback
-    'prefer-arrow-callback': ['error', { allowNamedFunctions: true }],
     // https://eslint.org/docs/rules/prefer-const
     'prefer-const': [
       'error',
@@ -942,22 +935,11 @@ module.exports = {
     /*
      * prettier
      * https://github.com/prettier/prettier#options
+     * https://github.com/prettier/eslint-plugin-prettier#recommended-configuration
      */
-    'prettier/prettier': [
-      'error',
-      {
-        printWidth: 80,
-        tabWidth: 2,
-        useTabs: false,
-        semi: true,
-        singleQuote: true,
-        trailingComma: 'all',
-        bracketSpacing: true,
-        bracketSameLine: true,
-        arrowParens: 'avoid',
-        endOfLine: 'auto',
-      },
-    ],
+    'prettier/prettier': 'error',
+    'arrow-body-style': 'off',
+    'prefer-arrow-callback': 'off',
 
     /*
      * import


### PR DESCRIPTION
# PR Details

## Description

Remove prettier options in our ESLint config, so the editor extensions can read the `.prettierrc` config, this change can fix the inconsistent experience between prettier format and ESLint auto fix.

Detailed explanation in official document:

> Note: While it is possible to pass options to Prettier via your ESLint configuration file, it is not recommended because editor extensions such as prettier-atom and prettier-vscode will read [.prettierrc](https://prettier.io/docs/en/configuration.html), but won't read settings from ESLint, which can lead to an inconsistent experience.

Also add "arrow-body-style": "off" and "prefer-arrow-callback": "off"

> turns off two ESLint core rules that unfortunately are problematic with this plugin – see the next section.

Official guide: https://github.com/prettier/eslint-plugin-prettier#recommended-configuration

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
