### PR TITLE
perf(app-tools): speed up modern start command

### DIFF
--- a/.changeset/ten-owls-watch.md
+++ b/.changeset/ten-owls-watch.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/plugin': patch
+---
+
+perf(app-tools): speed up modern start command

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -1,13 +1,10 @@
-import * as path from 'path';
+import path from 'path';
 import { defineConfig, cli, CliPlugin } from '@modern-js/core';
 import AnalyzePlugin from '@modern-js/plugin-analyze';
 import { cleanRequireCache } from '@modern-js/utils';
 import { hooks } from './hooks';
 import { i18n, localeKeys } from './locale';
 import { getLocaleLanguage } from './utils/language';
-import { start } from './commands/start';
-import { dev } from './commands/dev';
-import { closeServer } from './utils/createServer';
 import type { DevOptions, BuildOptions, DeployOptions } from './utils/types';
 
 export { defineConfig };
@@ -45,6 +42,7 @@ export default (): CliPlugin => ({
           .option('--analyze', i18n.t(localeKeys.command.shared.analyze))
           .option('--api-only', i18n.t(localeKeys.command.dev.apiOnly))
           .action(async (options: DevOptions) => {
+            const { dev } = await import('./commands/dev');
             await dev(api, options);
           });
 
@@ -71,6 +69,7 @@ export default (): CliPlugin => ({
           .description(i18n.t(localeKeys.command.start.describe))
           .option('--api-only', i18n.t(localeKeys.command.dev.apiOnly))
           .action(async () => {
+            const { start } = await import('./commands/start');
             await start(api);
           });
 
@@ -138,6 +137,7 @@ export default (): CliPlugin => ({
           !absolutePath.includes(srcDirectory) &&
           (eventType === 'change' || eventType === 'unlink')
         ) {
+          const { closeServer } = await import('./utils/createServer');
           await closeServer();
           await cli.restart();
         }

--- a/packages/toolkit/plugin/src/farrow-pipeline/asyncHooks.node.ts
+++ b/packages/toolkit/plugin/src/farrow-pipeline/asyncHooks.node.ts
@@ -60,14 +60,21 @@ const createAsyncHooks = <T>() => {
   };
 };
 
+let enabled = false;
+
 export const enable = () => {
+  if (enabled) {
+    return;
+  }
+
+  enabled = true;
   const hooks = createAsyncHooks<asyncHooksInterface.Hooks>();
-  disable();
   asyncHooksInterface.impl(hooks);
   hooks.enable();
 };
 
 export const disable = () => {
+  enabled = false;
   asyncHooksInterface.asyncHooks?.disable();
   asyncHooksInterface.reset();
 };


### PR DESCRIPTION
# PR Details

## Description

Lazy import the `dev` and `start` action to improve the boot time of `modern start`.

The boot time decreased from `1000ms` to `600ms`.

![image](https://user-images.githubusercontent.com/7237365/174953189-21687da4-59ae-4cdf-9e34-6e305628feaf.png)

#### Before:

![origin_img_v2_61ac1080-accf-438e-bac7-3ef62c14991g](https://user-images.githubusercontent.com/7237365/174952625-9b04a8d8-59df-434d-87cb-f4c36ffe4408.jpg)

#### After

![psBz9t7Oun](https://user-images.githubusercontent.com/7237365/174952651-a2d227e9-b37b-4acc-bb43-acc855881a68.jpg)

Also fixed a bug of `@modern-js/plugin` when `enable` is called twice.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
