### PR TITLE
fix(core): failed to load user plugins of modern.config.js

### DIFF
--- a/.changeset/fresh-garlics-sniff.md
+++ b/.changeset/fresh-garlics-sniff.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/core': patch
+---
+
+fix(core): failed to load user plugins in modern.config.js

--- a/packages/cli/core/src/config/index.ts
+++ b/packages/cli/core/src/config/index.ts
@@ -6,10 +6,11 @@ import {
   isDev,
   PLUGIN_SCHEMAS,
   chalk,
+  isPlainObject,
   getServerConfig,
   getPackageManager,
 } from '@modern-js/utils';
-import { isPlainObject, mergeWith } from '@modern-js/utils/lodash';
+import { mergeWith } from '@modern-js/utils/lodash';
 
 import Ajv, { ErrorObject } from '../../compiled/ajv';
 import ajvKeywords from '../../compiled/ajv-keywords';

--- a/packages/cli/core/src/config/index.ts
+++ b/packages/cli/core/src/config/index.ts
@@ -44,19 +44,18 @@ export const defineConfig = (config: ConfigParam): ConfigParam => config;
  * Assign the pkg config into the user config.
  */
 export const assignPkgConfig = (
-  config: UserConfig = {},
+  userConfig: UserConfig = {},
   pkgConfig: ConfigParam = {},
-) => {
-  return mergeWith({}, config, pkgConfig, (objValue, srcValue) => {
+) =>
+  mergeWith({}, userConfig, pkgConfig, (objValue, srcValue) => {
     // mergeWith can not merge object with symbol, but plugins object contains symbol,
     // so we need to handle it manually.
     if (objValue === undefined && isPlainObject(srcValue)) {
-      return Array.isArray(srcValue) ? [...srcValue] : { ...srcValue };
+      return { ...srcValue };
     }
     // return undefined to use the default behavior of mergeWith
     return undefined;
   });
-};
 
 export const loadUserConfig = async (
   appDirectory: string,

--- a/packages/cli/core/tests/__snapshots__/mergeConfig.test.ts.snap
+++ b/packages/cli/core/tests/__snapshots__/mergeConfig.test.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`assign pkg config should merge properties deeply 1`] = `
+Object {
+  "runtime": Object {
+    "router": true,
+    "state": true,
+  },
+}
+`;
+
+exports[`assign pkg config should preserve symbol of plugins 1`] = `
+Object {
+  "plugins": Array [
+    Object {
+      Symbol(test): "test",
+    },
+  ],
+  "runtime": Object {
+    "router": true,
+  },
+}
+`;

--- a/packages/cli/core/tests/mergeConfig.test.ts
+++ b/packages/cli/core/tests/mergeConfig.test.ts
@@ -1,6 +1,7 @@
 import { mergeConfig } from '../src/config/mergeConfig';
+import { assignPkgConfig, WebpackConfig } from '../src';
 
-describe('load plugins', () => {
+describe('merge config', () => {
   test('should replace property deeply', () => {
     expect(
       mergeConfig([
@@ -50,7 +51,7 @@ describe('load plugins', () => {
       },
     });
     expect(Array.isArray(config.tools.webpack)).toBe(true);
-    expect(config.tools.webpack?.length).toBe(1);
+    expect((config.tools.webpack as WebpackConfig[]).length).toBe(1);
   });
 
   test(`should merge array value`, () => {
@@ -90,8 +91,46 @@ describe('load plugins', () => {
     expect(config?.source?.alias?.length).toBe(2);
     expect(typeof (config.source.alias as Array<any>)[1]).toBe('function');
     expect(Array.isArray(config.tools.webpack)).toBe(true);
-    expect(config.tools.webpack?.length).toBe(3);
+    expect((config.tools.webpack as WebpackConfig[]).length).toBe(3);
     expect(typeof (config.tools.webpack as Array<any>)[0]).toBe('function');
     expect(typeof (config.tools.webpack as Array<any>)[2]).toBe('function');
+  });
+});
+
+describe('assign pkg config', () => {
+  test('should preserve symbol of plugins', () => {
+    expect(
+      assignPkgConfig(
+        {
+          plugins: [
+            {
+              [Symbol.for('test')]: 'test',
+            },
+          ],
+        },
+        {
+          runtime: {
+            router: true,
+          },
+        },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('should merge properties deeply', () => {
+    expect(
+      assignPkgConfig(
+        {
+          runtime: {
+            state: true,
+          },
+        },
+        {
+          runtime: {
+            router: true,
+          },
+        },
+      ),
+    ).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
# PR Details

## Description

Fix failed to load user plugins of modern.config.js in some cases.

Such as:

```ts
import { defineConfig } from '@modern-js/app-tools';
import { createWaterfall } from '@modern-js/plugin';
import type { CliPlugin } from '@modern-js/core';

const message = createWaterfall<string[]>();

const MyPlugin = (): CliPlugin => ({
  name: 'my-plugin',

  registerHook: {
    message,
  },
});

export default defineConfig({
  plugins: [MyPlugin()],
  runtime: {
    router: true,
  },
});
```

Will get an error like this (because we lost the symbol of plugins when merging config):

![image](https://user-images.githubusercontent.com/7237365/174986011-9031f0c0-adab-4588-b765-e1576ed71afa.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
