### PR TITLE
feat: add plugin-jarvis to dependencies of solutions

### DIFF
--- a/.changeset/itchy-readers-impress.md
+++ b/.changeset/itchy-readers-impress.md
@@ -1,0 +1,10 @@
+---
+'@modern-js/module-generator': patch
+'@modern-js/monorepo-generator': patch
+'@modern-js/mwa-generator': patch
+'@modern-js/app-tools': patch
+'@modern-js/module-tools': patch
+'@modern-js/monorepo-tools': patch
+---
+
+feat: add plugin-jarvis to dependencies of solutions

--- a/packages/generator/generators/module-generator/templates/base-template/package.json.handlebars
+++ b/packages/generator/generators/module-generator/templates/base-template/package.json.handlebars
@@ -65,7 +65,6 @@
   "devDependencies": {
     "react": "^17",
     "@modern-js/module-tools": "^1.1.5",
-    "@modern-js/plugin-jarvis": "^1.0.0",
     "@modern-js/plugin-testing": "^1.0.0",
     "@modern-js/tsconfig":"^1.0.0",
     "rimraf": "^3.0.2",

--- a/packages/generator/generators/monorepo-generator/templates/base-template/package.json.handlebars
+++ b/packages/generator/generators/monorepo-generator/templates/base-template/package.json.handlebars
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "@modern-js/monorepo-tools": "^1.2.0",
-    "@modern-js/plugin-jarvis": "^1.1.1",
     "@modern-js/tsconfig":"^1.0.0",
     "lint-staged": "^11.2.6",
     "prettier": "^2.6.2",

--- a/packages/generator/generators/mwa-generator/templates/base-template/package.json.handlebars
+++ b/packages/generator/generators/mwa-generator/templates/base-template/package.json.handlebars
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@modern-js/app-tools": "^1.0.0",
-    "@modern-js/plugin-jarvis": "^1.0.0",
     "@modern-js/tsconfig":"^1.0.0",
     "rimraf": "^3.0.2",
     "lint-staged": "^11.2.6",

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -72,6 +72,7 @@
     "@modern-js/plugin": "workspace:^1.3.8",
     "@modern-js/plugin-analyze": "workspace:^1.4.6",
     "@modern-js/plugin-i18n": "workspace:^1.2.7",
+    "@modern-js/plugin-jarvis": "workspace:^1.2.13",
     "@modern-js/prod-server": "workspace:^1.1.8",
     "@modern-js/server": "workspace:^1.4.21",
     "@modern-js/types": "workspace:^1.5.4",

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { defineConfig, cli, CliPlugin } from '@modern-js/core';
 import AnalyzePlugin from '@modern-js/plugin-analyze';
+import LintPlugin from '@modern-js/plugin-jarvis';
 import { cleanRequireCache } from '@modern-js/utils';
 import { hooks } from './hooks';
 import { i18n, localeKeys } from './locale';
@@ -22,7 +23,7 @@ export default (): CliPlugin => ({
 
   registerHook: hooks,
 
-  usePlugins: [AnalyzePlugin()],
+  usePlugins: [AnalyzePlugin(), LintPlugin()],
 
   setup: api => {
     const locale = getLocaleLanguage();

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -71,6 +71,7 @@
     "@modern-js/plugin-analyze": "workspace:^1.4.6",
     "@modern-js/plugin-changeset": "workspace:^1.2.8",
     "@modern-js/plugin-i18n": "workspace:^1.2.7",
+    "@modern-js/plugin-jarvis": "workspace:^1.2.13",
     "@modern-js/style-compiler": "workspace:^1.2.10",
     "@modern-js/utils": "workspace:^1.7.7",
     "normalize-path": "^3.0.0",

--- a/packages/solutions/module-tools/src/index.ts
+++ b/packages/solutions/module-tools/src/index.ts
@@ -1,6 +1,7 @@
 import { Import } from '@modern-js/utils';
 import ChangesetPlugin from '@modern-js/plugin-changeset';
 import AnalyzePlugin from '@modern-js/plugin-analyze';
+import LintPlugin from '@modern-js/plugin-jarvis';
 import type { CliPlugin } from '@modern-js/core';
 import { hooks } from './hooks';
 
@@ -21,7 +22,7 @@ export default (): CliPlugin => ({
 
   registerHook: hooks,
 
-  usePlugins: [ChangesetPlugin(), AnalyzePlugin()],
+  usePlugins: [ChangesetPlugin(), AnalyzePlugin(), LintPlugin()],
 
   setup: api => {
     const locale = lang.getLocaleLanguage();

--- a/packages/solutions/monorepo-tools/package.json
+++ b/packages/solutions/monorepo-tools/package.json
@@ -49,6 +49,7 @@
     "@modern-js/plugin": "workspace:^1.3.6",
     "@modern-js/plugin-changeset": "workspace:^1.2.8",
     "@modern-js/plugin-i18n": "workspace:^1.2.7",
+    "@modern-js/plugin-jarvis": "workspace:^1.2.13",
     "@modern-js/utils": "workspace:^1.7.3",
     "@rushstack/node-core-library": "^3.39.1",
     "@rushstack/package-deps-hash": "^3.0.54",

--- a/packages/solutions/monorepo-tools/src/index.ts
+++ b/packages/solutions/monorepo-tools/src/index.ts
@@ -1,5 +1,6 @@
 import type { CliPlugin } from '@modern-js/core';
 import ChangesetPlugin from '@modern-js/plugin-changeset';
+import LintPlugin from '@modern-js/plugin-jarvis';
 import { i18n } from './locale';
 import { newCli, deployCli, clearCli } from './cli';
 import { getLocaleLanguage } from './utils/language';
@@ -7,7 +8,7 @@ import { hooks } from './hooks';
 
 export default (): CliPlugin => ({
   name: '@modern-js/monorepo-tools',
-  usePlugins: [ChangesetPlugin()],
+  usePlugins: [ChangesetPlugin(), LintPlugin()],
   registerHook: hooks,
   setup: api => {
     const locale = getLocaleLanguage();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2706,7 +2706,7 @@ importers:
       eslint-config-prettier: 8.5.0_eslint@7.32.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.32.0
       eslint-plugin-filenames: 1.3.2_eslint@7.32.0
-      eslint-plugin-import: 2.26.0_eslint@7.32.0
+      eslint-plugin-import: 2.26.0_410c877659bcf2aa0d4d6abb003bb22f
       eslint-plugin-markdown: 2.2.1_eslint@7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
       eslint-plugin-prettier: 4.0.0_f9a5537566b3ca3b5b68fc99385c0ca6
@@ -3574,6 +3574,7 @@ importers:
       '@modern-js/plugin': workspace:^1.3.8
       '@modern-js/plugin-analyze': workspace:^1.4.6
       '@modern-js/plugin-i18n': workspace:^1.2.7
+      '@modern-js/plugin-jarvis': workspace:^1.2.13
       '@modern-js/prod-server': workspace:^1.1.8
       '@modern-js/server': workspace:^1.4.21
       '@modern-js/server-core': workspace:*
@@ -3597,6 +3598,7 @@ importers:
       '@modern-js/plugin': link:../../toolkit/plugin
       '@modern-js/plugin-analyze': link:../../cli/plugin-analyze
       '@modern-js/plugin-i18n': link:../../cli/plugin-i18n
+      '@modern-js/plugin-jarvis': link:../../cli/plugin-jarvis
       '@modern-js/prod-server': link:../../server/prod-server
       '@modern-js/server': link:../../server/server
       '@modern-js/types': link:../../toolkit/types
@@ -3630,6 +3632,7 @@ importers:
       '@modern-js/plugin-analyze': workspace:^1.4.6
       '@modern-js/plugin-changeset': workspace:^1.2.8
       '@modern-js/plugin-i18n': workspace:^1.2.7
+      '@modern-js/plugin-jarvis': workspace:^1.2.13
       '@modern-js/style-compiler': workspace:^1.2.10
       '@modern-js/utils': workspace:^1.7.7
       '@scripts/build': workspace:*
@@ -3664,6 +3667,7 @@ importers:
       '@modern-js/plugin-analyze': link:../../cli/plugin-analyze
       '@modern-js/plugin-changeset': link:../../cli/plugin-changeset
       '@modern-js/plugin-i18n': link:../../cli/plugin-i18n
+      '@modern-js/plugin-jarvis': link:../../cli/plugin-jarvis
       '@modern-js/style-compiler': link:../../toolkit/compiler/style
       '@modern-js/utils': link:../../toolkit/utils
       normalize-path: 3.0.0
@@ -3693,6 +3697,7 @@ importers:
       '@modern-js/plugin': workspace:^1.3.6
       '@modern-js/plugin-changeset': workspace:^1.2.8
       '@modern-js/plugin-i18n': workspace:^1.2.7
+      '@modern-js/plugin-jarvis': workspace:^1.2.13
       '@modern-js/utils': workspace:^1.7.3
       '@rushstack/node-core-library': ^3.39.1
       '@rushstack/package-deps-hash': ^3.0.54
@@ -3716,6 +3721,7 @@ importers:
       '@modern-js/plugin': link:../../toolkit/plugin
       '@modern-js/plugin-changeset': link:../../cli/plugin-changeset
       '@modern-js/plugin-i18n': link:../../cli/plugin-i18n
+      '@modern-js/plugin-jarvis': link:../../cli/plugin-jarvis
       '@modern-js/utils': link:../../toolkit/utils
       '@rushstack/node-core-library': 3.45.7
       '@rushstack/package-deps-hash': 3.2.24
@@ -5086,7 +5092,6 @@ importers:
   tests/integration/mwa-app:
     specifiers:
       '@modern-js/app-tools': workspace:*
-      '@modern-js/plugin-jarvis': workspace:*
       '@modern-js/runtime': workspace:*
       '@types/node': ^14
       '@types/react': ^17
@@ -5100,7 +5105,6 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@modern-js/app-tools': link:../../../packages/solutions/app-tools
-      '@modern-js/plugin-jarvis': link:../../../packages/cli/plugin-jarvis
       '@types/node': 14.18.21
       '@types/react': 17.0.47
       '@types/react-dom': 17.0.17
@@ -6000,11 +6004,15 @@ packages:
     resolution: {integrity: sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.18.4
 
   /@babel/parser/7.18.5:
     resolution: {integrity: sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.18.4
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.17.12_@babel+core@7.18.5:
     resolution: {integrity: sha512-xCJQXl4EeQ3J9C4yOmpTrtVGmzpm2iSzyxbkZHw7UCnZBftHpF/hpII80uWVyVrc40ytIClHjgWGTG1g/yB+aw==}
@@ -7667,11 +7675,13 @@ packages:
       uuid: 8.3.2
     dev: true
 
-  /@cypress/xvfb/1.2.4:
+  /@cypress/xvfb/1.2.4_supports-color@8.1.1:
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7_supports-color@8.1.1
       lodash.once: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@develar/schema-utils/2.6.5:
@@ -8479,6 +8489,8 @@ packages:
       path-to-regexp: 1.8.0
       urijs: 1.19.11
       utility: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@emotion/is-prop-valid/1.1.3:
@@ -9682,7 +9694,6 @@ packages:
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
-    dev: true
 
   /@nestjs/core/8.4.7_2aa064eef171d5a7957432d22e4b3f20:
     resolution: {integrity: sha512-XB9uexHqzr2xkPo6QSiQWJJttyYYLmvQ5My64cFvWFi7Wk2NIus0/xUNInwX3kmFWB6pF1ab5Y2ZBvWdPwGBhw==}
@@ -9715,7 +9726,6 @@ packages:
       uuid: 8.3.2
     transitivePeerDependencies:
       - encoding
-    dev: true
 
   /@nestjs/platform-express/8.4.7_fce4c3b686c1225eb94686491d30b061:
     resolution: {integrity: sha512-lPE5Ltg2NbQGRQIwXWY+4cNrXhJdycbxFDQ8mNxSIuv+LbrJBIdEB/NONk+LLn9N/8d2+I2LsIETGQrPvsejBg==}
@@ -9730,7 +9740,8 @@ packages:
       express: 4.18.1
       multer: 1.4.4-lts.1
       tslib: 2.4.0
-    dev: false
+    transitivePeerDependencies:
+      - supports-color
 
   /@node-rs/jieba-android-arm-eabi/1.6.1:
     resolution: {integrity: sha512-R1YQfsPr7sK3Tq1sM0//6lNAGJK9RnMT0ShITT+7EJYr5OufUBb38lf/mRhrLxR0NF1pycEsMjdCAwrWrHd8rA==}
@@ -9915,7 +9926,6 @@ packages:
       node-fetch: 2.6.7
     transitivePeerDependencies:
       - encoding
-    dev: true
 
   /@pmmmwh/react-refresh-webpack-plugin/0.5.7_0518714fbd97967111ebc0bdad16eea3:
     resolution: {integrity: sha512-bcKCAzF0DV2IIROp9ZHkRJa6O4jy7NlnHdWL3GmcUxYWNjLXkK5kfELELwEfSP5hXPfVL/qOGMAROuMQb9GG8Q==}
@@ -10847,7 +10857,7 @@ packages:
       css-loader: 3.6.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6
+      fork-ts-checker-webpack-plugin: 4.1.6_typescript@4.7.4+webpack@4.46.0
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       global: 4.4.0
@@ -13974,7 +13984,6 @@ packages:
 
   /append-field/1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
-    dev: false
 
   /application-config-path/0.1.0:
     resolution: {integrity: sha512-lljTpVvFteShrHuKRvweZfa9o/Nc34Y8r5/1Lqh/yyKaspRT2J3fkEiSSk1YLG8ZSVyU7yHysRy9zcDDS2aH1Q==}
@@ -14452,7 +14461,6 @@ packages:
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
-    dev: true
 
   /b-tween/0.3.3:
     resolution: {integrity: sha512-oEHegcRpA7fAuc9KC4nktucuZn2aS8htymCPcP3qkEGPqiBH+GfqtqoG2l7LxHngg6O0HFM7hOeOYExl1Oz4ZA==}
@@ -15026,6 +15034,8 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   /bonjour-service/1.0.13:
     resolution: {integrity: sha512-LWKRU/7EqDUC9CTAQtuZl5HzBALoCYwtLhffW3et7vZMwv3bWLpJf8bRYlMD5OCcDpTfnPgNCV4yo9ZIaJGMiA==}
@@ -15424,7 +15434,6 @@ packages:
     engines: {node: '>=10.16.0'}
     dependencies:
       streamsearch: 1.1.0
-    dev: false
 
   /byte/2.0.0:
     resolution: {integrity: sha512-rNiK8YxOMvquToaBubKxA10sjRIZ/taDqtc/1jLQA4X7aNDlA1XGx4Ciml3YxL8DskFz1XX3WFskSp0peKYSKg==}
@@ -15433,6 +15442,8 @@ packages:
       debug: 3.2.7
       long: 4.0.0
       utility: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /bytes/2.2.0:
@@ -16395,6 +16406,8 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   /compute-scroll-into-view/1.0.11:
     resolution: {integrity: sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A==}
@@ -16415,7 +16428,6 @@ packages:
       inherits: 2.0.4
       readable-stream: 2.3.7
       typedarray: 0.0.6
-    dev: false
 
   /conf/4.1.0:
     resolution: {integrity: sha512-/G++SsVVt4MkKYZ1E+XdNEyCYghM7e7SSgx4PA55lQrmJjUY1APGGfz42YX9YpRkhLFvlhkJ5S341FWsufZZ5w==}
@@ -16692,7 +16704,6 @@ packages:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
-    dev: false
 
   /cos-nodejs-sdk-v5/2.11.12:
     resolution: {integrity: sha512-XtSlcrwgcyO8K0LCwNmimtkBErC1yJ55cvZ7nWFWsT0c2AWBw8F/ftGvUhZIZhh7B2SlPdXsFZg+QOU7cwI2GQ==}
@@ -17308,7 +17319,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@cypress/request': 2.88.10
-      '@cypress/xvfb': 1.2.4
+      '@cypress/xvfb': 1.2.4_supports-color@8.1.1
       '@types/node': 14.18.21
       '@types/sinonjs__fake-timers': 8.1.1
       '@types/sizzle': 2.3.3
@@ -17423,19 +17434,46 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
 
   /debug/3.1.0:
     resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
+
+  /debug/3.2.7_supports-color@8.1.1:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+      supports-color: 8.1.1
+    dev: true
 
   /debug/4.1.1:
     resolution: {integrity: sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==}
@@ -17762,6 +17800,8 @@ packages:
     dependencies:
       address: 1.2.0
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /detect-port/1.3.0:
@@ -17771,6 +17811,8 @@ packages:
     dependencies:
       address: 1.2.0
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
 
   /detective/5.2.1:
     resolution: {integrity: sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==}
@@ -17811,6 +17853,8 @@ packages:
       sudo-prompt: 8.2.5
       tmp: 0.0.33
       tslib: 1.14.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /devtools-protocol/0.0.901419:
@@ -18234,6 +18278,8 @@ packages:
       scmp: 2.1.0
       should-send-same-site-none: 2.0.5
       utility: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /egg-core/4.24.1:
@@ -18283,6 +18329,8 @@ packages:
     dependencies:
       debug: 3.2.7
       koa-locales: 1.12.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /egg-jsonp/2.0.0:
@@ -18305,6 +18353,8 @@ packages:
       iconv-lite: 0.4.24
       mkdirp: 0.5.6
       utility: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /egg-logrotator/3.1.0:
@@ -18448,6 +18498,8 @@ packages:
       tslib: 2.4.0
       typescript: 4.7.4
       yn: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /egg-utils/2.4.1:
@@ -18676,6 +18728,7 @@ packages:
       yeast: 0.1.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
       - utf-8-validate
     dev: false
 
@@ -19357,14 +19410,34 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /eslint-module-utils/2.7.3:
+  /eslint-module-utils/2.7.3_997a240915676dc771d6b5349fa398d5:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.29.0_eslint@7.32.0+typescript@4.7.4
       debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /eslint-plugin-es/3.0.1_eslint@7.32.0:
@@ -19401,19 +19474,24 @@ packages:
       lodash.upperfirst: 4.3.1
     dev: false
 
-  /eslint-plugin-import/2.26.0_eslint@7.32.0:
+  /eslint-plugin-import/2.26.0_410c877659bcf2aa0d4d6abb003bb22f:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.29.0_eslint@7.32.0+typescript@4.7.4
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3
+      eslint-module-utils: 2.7.3_997a240915676dc771d6b5349fa398d5
       has: 1.0.3
       is-core-module: 2.9.0
       is-glob: 4.0.3
@@ -19421,6 +19499,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.1
       tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: false
 
   /eslint-plugin-markdown/2.2.1_eslint@7.32.0:
@@ -19931,6 +20013,8 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   /ext/1.6.0:
     resolution: {integrity: sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==}
@@ -20002,6 +20086,8 @@ packages:
       debug: 2.6.9
       mkdirp: 0.5.6
       yauzl: 2.10.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /extract-zip/2.0.1:
@@ -20330,6 +20416,8 @@ packages:
       parseurl: 1.3.3
       statuses: 1.5.0
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /finalhandler/1.2.0:
@@ -20343,6 +20431,8 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   /find-babel-config/1.2.0:
     resolution: {integrity: sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==}
@@ -20584,9 +20674,19 @@ packages:
   /forever-agent/0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
-  /fork-ts-checker-webpack-plugin/4.1.6:
+  /fork-ts-checker-webpack-plugin/4.1.6_typescript@4.7.4+webpack@4.46.0:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
+    peerDependencies:
+      eslint: '>= 6'
+      typescript: '>= 2.7'
+      vue-template-compiler: '*'
+      webpack: '>= 4'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      vue-template-compiler:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.16.7
       chalk: 2.4.2
@@ -20594,6 +20694,8 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
+      typescript: 4.7.4
+      webpack: 4.46.0
       worker-rpc: 0.1.1
     dev: false
 
@@ -21357,6 +21459,8 @@ packages:
     dependencies:
       '@sindresorhus/is': 0.14.0
       '@szmarczak/http-timer': 1.1.2
+      '@types/keyv': 3.1.4
+      '@types/responselike': 1.0.0
       cacheable-request: 6.1.0
       decompress-response: 3.3.0
       duplexer3: 0.1.4
@@ -23121,7 +23225,6 @@ packages:
   /iterare/1.2.1:
     resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
     engines: {node: '>=6'}
-    dev: true
 
   /iterate-iterator/1.0.2:
     resolution: {integrity: sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==}
@@ -24590,6 +24693,8 @@ packages:
       uuid: 3.4.0
     optionalDependencies:
       snappy: 6.3.5
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /keygrip/1.1.0:
@@ -24733,6 +24838,8 @@ packages:
       humanize-ms: 1.2.1
       ini: 1.3.8
       object-assign: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /koa-onerror/4.2.0:
@@ -26035,7 +26142,6 @@ packages:
       object-assign: 4.1.1
       type-is: 1.6.18
       xtend: 4.0.2
-    dev: false
 
   /multer2/1.1.0:
     resolution: {integrity: sha512-+YC2ODgFa13CSMgyrLL/Kgb7Quf6vSYafJi5sQEDhacOy6BjViuci6v7wNsPi+r6CI4HAut+/8AmGFYK/6gGJg==}
@@ -26502,7 +26608,6 @@ packages:
   /object-hash/3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
-    dev: true
 
   /object-inspect/1.12.2:
     resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
@@ -27127,7 +27232,6 @@ packages:
 
   /path-to-regexp/3.2.0:
     resolution: {integrity: sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==}
-    dev: true
 
   /path-to-regexp/6.2.1:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
@@ -27330,6 +27434,8 @@ packages:
       async: 2.6.4
       debug: 3.2.7
       mkdirp: 0.5.6
+    transitivePeerDependencies:
+      - supports-color
 
   /posix-character-classes/0.1.1:
     resolution: {integrity: sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==}
@@ -29132,6 +29238,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - eslint
+      - supports-color
       - typescript
       - vue-template-compiler
       - webpack
@@ -29293,6 +29400,9 @@ packages:
   /react-live/2.4.1_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-r+32f7oV/kBs3QZBRvaT+9vOkQW47UZrDpgwUe5FiIMOl7sdo5pmISgb7Zpj5PGHgY6XQaiXs3FEh+IWw3KbRg==}
     engines: {node: '>= 0.12.0', npm: '>= 2.0.0'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@types/buble': 0.20.1
       buble: 0.19.6
@@ -29300,11 +29410,10 @@ packages:
       dom-iterator: 1.0.0
       prism-react-renderer: 1.3.3_react@17.0.2
       prop-types: 15.8.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
       react-simple-code-editor: 0.11.2_react-dom@17.0.2+react@17.0.2
       unescape: 1.0.1
-    transitivePeerDependencies:
-      - react
-      - react-dom
     dev: false
 
   /react-loadable-ssr-addon-v5-slorber/1.0.1_7b827e45b1e51a8cc8793eccc648d09d:
@@ -29645,6 +29754,8 @@ packages:
       get-ready: 2.0.1
       once: 1.4.0
       uuid: 3.4.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /rechoir/0.6.2:
@@ -29712,7 +29823,6 @@ packages:
 
   /reflect-metadata/0.1.13:
     resolution: {integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==}
-    dev: false
 
   /refractor/3.6.0:
     resolution: {integrity: sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==}
@@ -29873,6 +29983,7 @@ packages:
       ws: 7.4.6
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
       - utf-8-validate
     dev: false
 
@@ -30673,6 +30784,8 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   /sendmessage/1.1.0:
     resolution: {integrity: sha512-riI/U2etmtMKaVPe7zMnr++eG46F191F6Zycwrkm+/sEiHzucNXJETPJ5dQryNaDuHTpYdzmesEJQ2le1DxlMQ==}
@@ -30703,6 +30816,8 @@ packages:
       debug: 3.2.7
       is-type-of: 1.2.1
       utility: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /serve-favicon/2.5.0:
@@ -30739,6 +30854,8 @@ packages:
       http-errors: 1.6.3
       mime-types: 2.1.35
       parseurl: 1.3.3
+    transitivePeerDependencies:
+      - supports-color
 
   /serve-static/1.14.2:
     resolution: {integrity: sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==}
@@ -31036,6 +31153,7 @@ packages:
       to-array: 0.1.4
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
       - utf-8-validate
     dev: false
 
@@ -31045,6 +31163,8 @@ packages:
       component-emitter: 1.3.0
       debug: 3.1.0
       isarray: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /sockjs/0.3.24:
@@ -31473,6 +31593,8 @@ packages:
       debug: 3.2.7
       fs-extra: 7.0.1
       lodash: 4.17.21
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /streamsearch/0.1.2:
@@ -31482,7 +31604,6 @@ packages:
   /streamsearch/1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
-    dev: false
 
   /strict-uri-encode/2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
@@ -32281,6 +32402,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
+      acorn: 8.7.1
       commander: 2.20.3
       source-map: 0.6.1
       source-map-support: 0.5.21
@@ -32934,7 +33056,6 @@ packages:
 
   /typedarray/0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
-    dev: false
 
   /typescript/3.4.5:
     resolution: {integrity: sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==}
@@ -33970,6 +34091,8 @@ packages:
     resolution: {integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==}
     dependencies:
       debug: 3.2.7
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /webpack-virtual-modules/0.4.4:
@@ -34087,6 +34210,8 @@ packages:
       typedarray-to-buffer: 3.1.5
       utf-8-validate: 5.0.9
       yaeti: 0.0.6
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /weinre2/1.3.1:

--- a/tests/integration/css-modules/test/index.test.js
+++ b/tests/integration/css-modules/test/index.test.js
@@ -8,7 +8,6 @@ const {
   modernStart,
   // launchApp,
   killApp,
-  installDeps,
   clearBuildDist,
 } = require('../../../utils/modernTestUtils');
 
@@ -18,7 +17,6 @@ const fixturesDir = join(__dirname, '../fixtures');
 
 let appPort;
 beforeAll(async () => {
-  installDeps(fixturesDir);
   appPort = await getPort();
 });
 

--- a/tests/integration/css/test/css.test.js
+++ b/tests/integration/css/test/css.test.js
@@ -4,7 +4,6 @@ const { resolve } = require('path');
 const { fs } = require('@modern-js/utils');
 const {
   modernBuild,
-  installDeps,
   clearBuildDist,
   getPort,
   launchApp,
@@ -16,10 +15,6 @@ const { getCssFiles, readCssFile, copyModules } = require('./utils');
 const { readdirSync, readFileSync } = fs;
 
 const fixtures = path.resolve(__dirname, '../fixtures');
-
-beforeAll(async () => {
-  await installDeps(fixtures);
-});
 
 afterAll(() => {
   clearBuildDist(fixtures);

--- a/tests/integration/css/test/twin.macro.test.js
+++ b/tests/integration/css/test/twin.macro.test.js
@@ -2,7 +2,6 @@
 const path = require('path');
 const { resolve } = require('path');
 const {
-  installDeps,
   clearBuildDist,
   getPort,
   launchApp,
@@ -10,10 +9,6 @@ const {
 } = require('../../../utils/modernTestUtils');
 
 const fixtures = path.resolve(__dirname, '../fixtures');
-
-beforeAll(async () => {
-  await installDeps(fixtures);
-});
 
 afterAll(() => {
   clearBuildDist(fixtures);

--- a/tests/integration/mwa-app/package.json
+++ b/tests/integration/mwa-app/package.json
@@ -40,7 +40,6 @@
   },
   "devDependencies": {
     "@modern-js/app-tools": "workspace:*",
-    "@modern-js/plugin-jarvis": "workspace:*",
     "typescript": "^4",
     "@types/react": "^17",
     "@types/react-dom": "^17",

--- a/tests/integration/mwa-app/src/App.tsx
+++ b/tests/integration/mwa-app/src/App.tsx
@@ -31,7 +31,8 @@ const App = () => (
               href="https://modernjs.dev/coming-soon"
               target="_blank"
               rel="noopener noreferrer"
-              className="card">
+              className="card"
+            >
               <h2>Community </h2>
             </a>
           </div>
@@ -40,7 +41,8 @@ const App = () => (
           <a
             href="https://modernjs.dev"
             target="_blank"
-            rel="noopener noreferrer">
+            rel="noopener noreferrer"
+          >
             Powered by Modern.js
           </a>
         </footer>

--- a/tests/integration/server-prod/test/index.test.js
+++ b/tests/integration/server-prod/test/index.test.js
@@ -3,7 +3,6 @@ const fs = require('fs');
 const axios = require('axios');
 const {
   modernBuild,
-  installDeps,
   clearBuildDist,
   modernStart,
   getPort,
@@ -15,7 +14,6 @@ const successStatus = 200;
 let app, appPort;
 
 beforeAll(async () => {
-  await installDeps(appPath);
   await modernBuild(appPath);
   appPort = await getPort();
 });

--- a/tests/utils/modernTestUtils.js
+++ b/tests/utils/modernTestUtils.js
@@ -17,7 +17,6 @@ function runModernCommand(argv, options = {}) {
   };
 
   return new Promise((resolve, reject) => {
-    // console.log(`Running command "modern ${argv.join(' ')}"`);
     const instance = spawn(process.execPath, [kModernBin, ...argv], {
       ...options.spawnOptions,
       cwd,
@@ -201,20 +200,6 @@ async function killApp(instance) {
   });
 }
 
-function markGuardian() {
-  // IGNORE
-}
-
-// eslint-disable-next-line no-unused-vars
-function installDeps(dir) {
-  // console.log(`Installing dependencies in ${dir}`);
-  // FIXME: 跳过本地依赖的安装，因为在根目录执行 pnpm install --ignore-scripts 的时候已经安装好了
-  // spawn.sync('pnpm', ['install', '--filter', './', '--ignore-scripts'], {
-  //   stdio: 'inherit',
-  //   cwd: dir,
-  // });
-}
-
 // eslint-disable-next-line no-unused-vars
 function clearBuildDist(dir) {
   // console.log(`Clearing build dist in ${dir}`);
@@ -253,9 +238,7 @@ module.exports = {
   modernStart,
   launchApp,
   killApp,
-  markGuardian,
   getPort,
-  installDeps,
   clearBuildDist,
   sleep,
 };

--- a/website/docs/start/component.md
+++ b/website/docs/start/component.md
@@ -600,7 +600,6 @@ pnpm add internal-lib -D
 {
   "devDependencies": {
     "@modern-js/app-tools": "^1",
-    "@modern-js/plugin-jarvis": "^1",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@types/react": "^17",

--- a/website/docs/start/library.md
+++ b/website/docs/start/library.md
@@ -315,7 +315,6 @@ pnpm add internal-lib -D
 {
   "devDependencies": {
     "@modern-js/app-tools": "^1",
-    "@modern-js/plugin-jarvis": "^1",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@types/react": "^17",


### PR DESCRIPTION
# PR Details

## Description

Add the `plugin-jarvis` to dependencies of solutions (`app-tools`, `module-tools` and `monorepo-tools`).

And remove `plugin-jarvis` from our generator templates, so users will no longer notice this plugin.

This change makes it easier for users to upgrade modern.js version.

> This Pull Request also removed an unused `installDeps` utils from integration test folder.

#### Before

```json
{
  "name": "mwa",
  "dependencies": {
    "@modern-js/runtime": "^1.0.0"
  },
  "devDependencies": {
    "@modern-js/app-tools": "^1.0.0",
    "@modern-js/plugin-jarvis": "^1.0.0"
  }
}
```

#### After

```json
{
  "name": "mwa",
  "dependencies": {
    "@modern-js/runtime": "^1.0.0"
  },
  "devDependencies": {
    "@modern-js/app-tools": "^1.0.0"
  }
}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
