### PR TITLE
chore(plugin-jarvis): fix lint-staged type breaks other packages

### DIFF
--- a/.changeset/red-turkeys-decide.md
+++ b/.changeset/red-turkeys-decide.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-jarvis': patch
+---
+
+chore(plugin-jarvis): fix lint-staged type breaks other packages

--- a/packages/cli/plugin-jarvis/src/global.d.ts
+++ b/packages/cli/plugin-jarvis/src/global.d.ts
@@ -1,1 +1,0 @@
-declare module 'lint-staged';

--- a/packages/cli/plugin-jarvis/src/pre-commit.ts
+++ b/packages/cli/plugin-jarvis/src/pre-commit.ts
@@ -1,3 +1,5 @@
+/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+// @ts-expect-error lint-staged is not typed
 import lintStaged from 'lint-staged';
 import { logger, chalk } from '@modern-js/utils';
 


### PR DESCRIPTION
# PR Details

## Description

Fix lint-staged type breaks other packages.

Ref: https://github.com/modern-js-dev/modern.js/runs/7038020847?check_suite_focus=true

![image](https://user-images.githubusercontent.com/7237365/175495838-3d2cdae0-f962-49bc-90a0-e71ad0ed3d3f.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
