### PR TITLE
perf(babel): skip babel-plugin-import if package not installed

### DIFF
--- a/.changeset/weak-monkeys-accept.md
+++ b/.changeset/weak-monkeys-accept.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/babel-preset-base': patch
+'@modern-js/core': patch
+'@modern-js/server-core': patch
+'@modern-js/utils': patch
+---
+
+perf(babel): skip babel-plugin-import if package not installed

--- a/packages/cli/babel-preset-base/src/plugins.ts
+++ b/packages/cli/babel-preset-base/src/plugins.ts
@@ -1,4 +1,5 @@
 import { createBabelChain } from '@modern-js/babel-chain';
+import { isPackageInstalled } from '@modern-js/utils';
 import { IBaseBabelConfigOption } from '.';
 
 export const getPluginsChain = (option: IBaseBabelConfigOption) => {
@@ -27,17 +28,19 @@ export const getPluginsChain = (option: IBaseBabelConfigOption) => {
       .use(require.resolve('../compiled/babel-plugin-dynamic-import-node'));
   }
 
-  const { antd } = babelPluginImport || { antd: { libraryDirectory: 'es' } };
-  chain
-    .plugin('babel-plugin-import')
-    .use(require.resolve('../compiled/babel-plugin-import'), [
-      {
-        libraryName: 'antd',
-        libraryDirectory: antd?.libraryDirectory || 'es',
-        style: true,
-      },
-      'import-antd',
-    ]);
+  if (isPackageInstalled('antd', option.appDirectory)) {
+    const { antd } = babelPluginImport || { antd: { libraryDirectory: 'es' } };
+    chain
+      .plugin('babel-plugin-import')
+      .use(require.resolve('../compiled/babel-plugin-import'), [
+        {
+          libraryName: 'antd',
+          libraryDirectory: antd?.libraryDirectory || 'es',
+          style: true,
+        },
+        'import-antd',
+      ]);
+  }
 
   chain
     .plugin('babel-plugin-lodash')

--- a/packages/cli/core/src/loadPlugins.ts
+++ b/packages/cli/core/src/loadPlugins.ts
@@ -1,4 +1,5 @@
 import {
+  tryResolve,
   isDepExists,
   createDebugger,
   compatRequire,
@@ -44,26 +45,6 @@ type NewPluginConfig =
     };
 
 export type PluginConfig = OldPluginConfig | NewPluginConfig;
-
-/**
- * Try to resolve plugin entry file path.
- * @param name - Plugin name.
- * @param appDirectory - Application root directory.
- * @returns Resolved file path.
- */
-const tryResolve = (name: string, appDirectory: string) => {
-  let filePath = '';
-  try {
-    filePath = require.resolve(name, { paths: [appDirectory] });
-    delete require.cache[filePath];
-  } catch (err) {
-    if ((err as any).code === 'MODULE_NOT_FOUND') {
-      throw new Error(`Can not find plugin ${name}.`);
-    }
-    throw err;
-  }
-  return filePath;
-};
 
 export function getAppPlugins(
   appDirectory: string,

--- a/packages/cli/core/tests/loadPlugin.test.ts
+++ b/packages/cli/core/tests/loadPlugin.test.ts
@@ -83,7 +83,7 @@ describe('load plugins', () => {
       loadPlugins(fixture, {
         plugins: [{ cli: './test-plugin-a' }, { cli: './plugin-b' }],
       });
-    }).toThrowError(/^Can not find plugin /);
+    }).toThrowError(/^Can not find module /);
   });
 
   test(`should load new plugin array correctly`, () => {

--- a/packages/cli/webpack/tests/__snapshots__/utils.test.ts.snap
+++ b/packages/cli/webpack/tests/__snapshots__/utils.test.ts.snap
@@ -40,15 +40,6 @@ Object {
       /cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js,
     ],
     Array [
-      /cli/babel-preset-base/compiled/babel-plugin-import/index.js,
-      Object {
-        "libraryDirectory": "es",
-        "libraryName": "antd",
-        "style": true,
-      },
-      "import-antd",
-    ],
-    Array [
       /cli/babel-preset-base/compiled/babel-plugin-lodash/index.js,
       Object {
         "id": Array [

--- a/packages/server/core/src/loadPlugins.ts
+++ b/packages/server/core/src/loadPlugins.ts
@@ -1,19 +1,5 @@
-import { compatRequire } from '@modern-js/utils';
+import { compatRequire, tryResolve } from '@modern-js/utils';
 import { createPlugin, ServerPlugin } from './plugin';
-
-const tryResolve = (name: string, appDirectory: string) => {
-  let filePath = '';
-  try {
-    filePath = require.resolve(name, { paths: [appDirectory] });
-    delete require.cache[filePath];
-  } catch (err) {
-    if ((err as any).code === 'MODULE_NOT_FOUND') {
-      throw new Error(`Can not find plugin ${name}.`);
-    }
-    throw err;
-  }
-  return filePath;
-};
 
 type Plugin = string | [string, any] | ServerPlugin;
 export const loadPlugins = (plugins: Plugin[], appDirectory: string) => {

--- a/packages/server/core/tests/loadPlugin.test.ts
+++ b/packages/server/core/tests/loadPlugin.test.ts
@@ -27,7 +27,7 @@ describe('test load plugin', () => {
     try {
       loadPlugins(['test-b'], modulePath);
     } catch (e: any) {
-      expect(e.message).toMatch('Can not find plugin test-b.');
+      expect(e.message).toMatch('Can not find module test-b.');
     }
   });
 });

--- a/packages/server/utils/tests/__snapshots__/babel.test.ts.snap
+++ b/packages/server/utils/tests/__snapshots__/babel.test.ts.snap
@@ -7,15 +7,6 @@ Object {
       "/packages/cli/babel-preset-base/compiled/babel-plugin-macros/index.js",
     ],
     Array [
-      "/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-      Object {
-        "libraryDirectory": "es",
-        "libraryName": "antd",
-        "style": true,
-      },
-      "import-antd",
-    ],
-    Array [
       "/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
       Object {
         "id": Array [

--- a/packages/toolkit/utils/src/index.ts
+++ b/packages/toolkit/utils/src/index.ts
@@ -31,5 +31,6 @@ export * from './wait';
 export * from './emptyDir';
 export * from './getServerConfig';
 export * from './ssr';
+export * from './tryResolve';
 export * from './analyzeProject';
 export * from './chainId';

--- a/packages/toolkit/utils/src/tryResolve.ts
+++ b/packages/toolkit/utils/src/tryResolve.ts
@@ -1,3 +1,5 @@
+import { ensureArray } from './ensureArray';
+
 /**
  * Try to resolve npm package entry file path.
  * @param name - Package name.
@@ -21,9 +23,12 @@ export const tryResolve = (name: string, resolvePath: string) => {
 /**
  * Try to resolve npm package, return true if package is installed.
  */
-export const isPackageInstalled = (name: string, resolvePath: string) => {
+export const isPackageInstalled = (
+  name: string,
+  resolvePaths: string | string[],
+) => {
   try {
-    require.resolve(name, { paths: [resolvePath] });
+    require.resolve(name, { paths: ensureArray(resolvePaths) });
     return true;
   } catch (err) {
     return false;

--- a/packages/toolkit/utils/src/tryResolve.ts
+++ b/packages/toolkit/utils/src/tryResolve.ts
@@ -1,0 +1,31 @@
+/**
+ * Try to resolve npm package entry file path.
+ * @param name - Package name.
+ * @param resolvePath - Path to resolve dependencies.
+ * @returns Resolved file path.
+ */
+export const tryResolve = (name: string, resolvePath: string) => {
+  let filePath = '';
+  try {
+    filePath = require.resolve(name, { paths: [resolvePath] });
+    delete require.cache[filePath];
+  } catch (err) {
+    if ((err as any).code === 'MODULE_NOT_FOUND') {
+      throw new Error(`Can not find module ${name}.`);
+    }
+    throw err;
+  }
+  return filePath;
+};
+
+/**
+ * Try to resolve npm package, return true if package is installed.
+ */
+export const isPackageInstalled = (name: string, resolvePath: string) => {
+  try {
+    require.resolve(name, { paths: [resolvePath] });
+    return true;
+  } catch (err) {
+    return false;
+  }
+};

--- a/packages/toolkit/utils/tests/isPackageInstalled.test.ts
+++ b/packages/toolkit/utils/tests/isPackageInstalled.test.ts
@@ -1,0 +1,11 @@
+import { isPackageInstalled } from '../src/tryResolve';
+
+describe('isPackageInstalled', () => {
+  it('should return false if the package not is resolved', () => {
+    expect(isPackageInstalled('@foo/bar', __dirname)).toBeFalsy();
+  });
+
+  it('should return true if the package is resolved', () => {
+    expect(isPackageInstalled('lodash', __dirname)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
# PR Details

## Description

Skip babel-plugin-import if package not installed, which means:

- if `antd` is installed, we will apply the `babel-plugin-import` of `antd`.
- if `antd` is not installed, we can skip this plugin to improve performance.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
