### PR TITLE
feat(webpack): only display error messages of type checker

### DIFF
--- a/.changeset/long-books-move.md
+++ b/.changeset/long-books-move.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+feat(webpack): only display error messages of type checker

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -453,6 +453,14 @@ class BaseWebpackConfig {
             // use typescript of user project
             typescriptPath: require.resolve('typescript'),
           },
+          // only display error messages
+          logger: {
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            log() {},
+            error(message: string) {
+              console.error(chalk.red.bold('TYPE'), message);
+            },
+          },
           issue: {
             include: [{ file: '**/src/**/*' }],
             exclude: [


### PR DESCRIPTION
# PR Details

## Description

Improve dev logs, only display error messages of type checker.

Following logs are no longer displayed:

![oUzxtKhTSB](https://user-images.githubusercontent.com/7237365/176099489-adec26b6-43c9-43da-97ea-3eb544cdbafc.jpg)

Only log error messages like:

![Ee23mLQdU4](https://user-images.githubusercontent.com/7237365/176099589-626c544f-7632-4030-a902-d86d63ddb221.jpg)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
