### PR TITLE
fix(webpack): webpackChunkName magic comments not work

### DIFF
--- a/.changeset/sweet-frogs-act.md
+++ b/.changeset/sweet-frogs-act.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): webpackChunkName magic comments not work

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -66,11 +66,11 @@ class BaseWebpackConfig {
 
   jsFilename: string;
 
-  jsChunkname: string;
+  jsChunkName: string;
 
-  cssChunkname: string;
+  cssChunkName: string;
 
-  mediaChunkname: string;
+  mediaChunkName: string;
 
   babelChain: BabelChain;
 
@@ -93,45 +93,34 @@ class BaseWebpackConfig {
 
     this.coreJsEntry = path.resolve(__dirname, '../runtime/core-js-entry.js');
 
-    this.dist = ensureAbsolutePath(
-      this.appDirectory,
-      this.options.output ? this.options.output.path! : '',
-    );
+    const { output = {} } = this.options;
+    const { disableAssetsCache } = output;
+    const jsPath = (output.jsPath || '').trim();
+    const cssPath = (output.cssPath || '').trim();
+    const mediaPath = (output.mediaPath || '').trim();
+
+    this.dist = ensureAbsolutePath(this.appDirectory, output.path || '');
 
     this.jsFilename = removeLeadingSlash(
-      `${(this.options.output
-        ? this.options.output.jsPath!
-        : ''
-      ).trim()}/[name]${
-        isProd() && !this.options.output?.disableAssetsCache
-          ? '.[contenthash:8]'
-          : ''
+      `${jsPath}/[name]${
+        isProd() && !disableAssetsCache ? '.[contenthash:8]' : ''
       }.js`,
     );
 
-    this.jsChunkname = removeLeadingSlash(
-      `${(this.options.output ? this.options.output.jsPath! : '').trim()}/[id]${
-        isProd() && !this.options.output.disableAssetsCache
-          ? '.[contenthash:8]'
-          : ''
+    this.jsChunkName = removeLeadingSlash(
+      `${jsPath}/[name]${
+        isProd() && !disableAssetsCache ? '.[contenthash:8]' : ''
       }.js`,
     );
 
-    this.cssChunkname = removeLeadingSlash(
-      `${(this.options.output
-        ? this.options.output.cssPath!
-        : ''
-      ).trim()}/[name]${
-        isProd() && !this.options.output?.disableAssetsCache
-          ? '.[contenthash:8]'
-          : ''
+    this.cssChunkName = removeLeadingSlash(
+      `${cssPath.trim()}/[name]${
+        isProd() && !disableAssetsCache ? '.[contenthash:8]' : ''
       }.css`,
     );
 
-    this.mediaChunkname = removeLeadingSlash(
-      `${this.options.output ? this.options.output.mediaPath! : ''}/[name]${
-        this.options.output?.disableAssetsCache ? '' : '.[hash:8]'
-      }[ext]`,
+    this.mediaChunkName = removeLeadingSlash(
+      `${mediaPath}/[name]${disableAssetsCache ? '' : '.[hash:8]'}[ext]`,
     );
 
     this.babelChain = createBabelChain();
@@ -181,7 +170,7 @@ class BaseWebpackConfig {
     this.chain.output
       .hashFunction('xxhash64')
       .filename(this.jsFilename)
-      .chunkFilename(this.jsChunkname)
+      .chunkFilename(this.jsChunkName)
       .globalObject('window')
       .path(this.dist)
       .pathinfo(!isProd())
@@ -203,7 +192,7 @@ class BaseWebpackConfig {
       .publicPath(this.publicPath());
 
     this.chain.output.merge({
-      assetModuleFilename: this.mediaChunkname,
+      assetModuleFilename: this.mediaChunkName,
       environment: {
         arrowFunction: false,
         bigIntLiteral: false,
@@ -320,7 +309,7 @@ class BaseWebpackConfig {
       .loader(require.resolve('../../compiled/url-loader'))
       .options({
         limit: Infinity,
-        name: this.mediaChunkname.replace(/\[ext\]$/, '.[ext]'),
+        name: this.mediaChunkName.replace(/\[ext\]$/, '.[ext]'),
       });
 
     loaders
@@ -336,7 +325,7 @@ class BaseWebpackConfig {
       .loader(require.resolve('../../compiled/url-loader'))
       .options({
         limit: false,
-        name: this.mediaChunkname.replace(/\[ext\]$/, '.[ext]'),
+        name: this.mediaChunkName.replace(/\[ext\]$/, '.[ext]'),
       });
 
     loaders
@@ -351,7 +340,7 @@ class BaseWebpackConfig {
       .loader(require.resolve('../../compiled/url-loader'))
       .options({
         limit: this.options.output?.dataUriLimit,
-        name: this.mediaChunkname.replace(/\[ext\]$/, '.[ext]'),
+        name: this.mediaChunkName.replace(/\[ext\]$/, '.[ext]'),
       });
 
     // img, font assets
@@ -421,8 +410,8 @@ class BaseWebpackConfig {
     if (enableCssExtract(this.options)) {
       this.chain.plugin(PLUGIN.MINI_CSS_EXTRACT).use(MiniCssExtractPlugin, [
         {
-          filename: this.cssChunkname,
-          chunkFilename: this.cssChunkname,
+          filename: this.cssChunkName,
+          chunkFilename: this.cssChunkName,
           ignoreOrder: true,
         },
       ]);

--- a/packages/cli/webpack/src/config/modern.ts
+++ b/packages/cli/webpack/src/config/modern.ts
@@ -14,7 +14,7 @@ class ModernWebpackConfig extends ClientWebpackConfig {
             : `${name}/index-es6`
         }.html`,
       );
-    this.jsChunkname = this.jsChunkname.replace(/\.js$/, '-es6.js');
+    this.jsChunkName = this.jsChunkName.replace(/\.js$/, '-es6.js');
 
     this.jsFilename = this.jsFilename.replace(/\.js$/, '-es6.js');
 


### PR DESCRIPTION
# PR Details

## Description

Fix webpackChunkName magic comments not work:

```js
import(
  /* webpackChunkName: "my-chunk-name" */
  'module'
);
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
