### PR TITLE
fix(plugin): incorrect runners if multiple managers are created

### DIFF
--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@modern-js/load-config": "workspace:^1.3.6",
-    "@modern-js/plugin": "workspace:^1.4.0",
+    "@modern-js/plugin": "workspace:^1.4.1",
     "@modern-js/utils": "workspace:^1.7.11"
   },
   "devDependencies": {

--- a/packages/cli/core/src/index.ts
+++ b/packages/cli/core/src/index.ts
@@ -21,7 +21,6 @@ import {
   ResolvedConfigContext,
 } from './context';
 import { initWatcher } from './initWatcher';
-import type { NormalizedConfig } from './config/mergeConfig';
 import { loadEnv } from './loadEnv';
 import { manager, HooksRunner } from './manager';
 
@@ -50,7 +49,7 @@ export {
 } from './pluginAPI';
 export type { PluginAPI } from './pluginAPI';
 
-export type { NormalizedConfig, IAppContext };
+export type { IAppContext };
 
 const initAppDir = async (cwd?: string): Promise<string> => {
   if (!cwd) {

--- a/packages/cli/core/tests/config.test.ts
+++ b/packages/cli/core/tests/config.test.ts
@@ -10,7 +10,6 @@ import {
   manager,
   createPlugin,
   registerHook,
-  useRunner,
 } from '../src';
 import { defaults } from '../src/config/defaults';
 
@@ -82,7 +81,6 @@ describe('config', () => {
     expect(manager).toBeDefined();
     expect(createPlugin).toBeDefined();
     expect(registerHook).toBeDefined();
-    expect(useRunner).toBeDefined();
   });
 
   it('initAppDir', async () => {

--- a/packages/cli/plugin-analyze/package.json
+++ b/packages/cli/plugin-analyze/package.json
@@ -44,7 +44,7 @@
     "@babel/runtime": "^7.18.0",
     "@babel/traverse": "^7.18.0",
     "@babel/types": "^7.18.0",
-    "@modern-js/plugin": "workspace:^1.4.0",
+    "@modern-js/plugin": "workspace:^1.4.1",
     "@modern-js/utils": "workspace:^1.7.11"
   },
   "devDependencies": {

--- a/packages/cli/plugin-unbundle/package.json
+++ b/packages/cli/plugin-unbundle/package.json
@@ -49,7 +49,7 @@
     "@modern-js/create-request": "workspace:^1.3.0",
     "@modern-js/css-config": "workspace:^1.2.7",
     "@modern-js/esmpack": "workspace:^1.3.3",
-    "@modern-js/plugin": "workspace:^1.4.0",
+    "@modern-js/plugin": "workspace:^1.4.1",
     "@modern-js/server": "workspace:^1.5.0",
     "@modern-js/utils": "workspace:^1.7.11",
     "@rollup/plugin-alias": "^3.1.2",

--- a/packages/review/testing/package.json
+++ b/packages/review/testing/package.json
@@ -39,7 +39,7 @@
     "@babel/core": "^7.18.0",
     "@babel/runtime": "^7.18.0",
     "@modern-js/babel-preset-app": "workspace:^1.4.2",
-    "@modern-js/plugin": "workspace:^1.4.0",
+    "@modern-js/plugin": "workspace:^1.4.1",
     "@modern-js/utils": "workspace:^1.7.11",
     "babel-jest": "^27.0.6",
     "enhanced-resolve": "^5.8.3",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.0",
-    "@modern-js/plugin": "workspace:^1.4.0",
+    "@modern-js/plugin": "workspace:^1.4.1",
     "@types/styled-components": "^5.1.14",
     "hoist-non-react-statics": "^3.3.2",
     "invariant": "^2.2.4",

--- a/packages/server/bff-utils/package.json
+++ b/packages/server/bff-utils/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@babel/runtime": "^7.18.0",
     "@modern-js/bff-runtime": "workspace:^1.3.0",
-    "@modern-js/plugin": "workspace:^1.4.0",
+    "@modern-js/plugin": "workspace:^1.4.1",
     "@modern-js/utils": "workspace:^1.7.9",
     "es-module-lexer": "^0.4.1",
     "farrow-api": "^1.10.9"

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -35,7 +35,7 @@
     "test": "wireit"
   },
   "dependencies": {
-    "@modern-js/plugin": "workspace:^1.4.0",
+    "@modern-js/plugin": "workspace:^1.4.1",
     "@modern-js/utils": "workspace:^1.7.11"
   },
   "devDependencies": {

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -43,7 +43,7 @@
     "@babel/preset-typescript": "^7.17.12",
     "@babel/runtime": "^7.18.0",
     "@modern-js/babel-preset-lib": "workspace:^1.3.1",
-    "@modern-js/plugin": "workspace:^1.4.0",
+    "@modern-js/plugin": "workspace:^1.4.1",
     "@modern-js/utils": "workspace:^1.7.11",
     "babel-plugin-module-resolver": "^4.1.0",
     "babel-plugin-transform-typescript-metadata": "^0.3.2"

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -69,7 +69,7 @@
     "@modern-js/i18n-cli-language-detector": "workspace:^1.2.4",
     "@modern-js/new-action": "workspace:^1.3.11",
     "@modern-js/node-bundle-require": "workspace:^1.3.7",
-    "@modern-js/plugin": "workspace:^1.4.0",
+    "@modern-js/plugin": "workspace:^1.4.1",
     "@modern-js/plugin-analyze": "workspace:^1.4.7",
     "@modern-js/plugin-i18n": "workspace:^1.2.7",
     "@modern-js/plugin-jarvis": "workspace:^1.2.14",

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -68,7 +68,7 @@
     "@modern-js/css-config": "workspace:^1.2.7",
     "@modern-js/i18n-cli-language-detector": "workspace:^1.2.4",
     "@modern-js/new-action": "workspace:^1.3.11",
-    "@modern-js/plugin": "workspace:^1.4.0",
+    "@modern-js/plugin": "workspace:^1.4.1",
     "@modern-js/plugin-analyze": "workspace:^1.4.7",
     "@modern-js/plugin-changeset": "workspace:^1.3.1",
     "@modern-js/plugin-i18n": "workspace:^1.2.7",

--- a/packages/solutions/monorepo-tools/package.json
+++ b/packages/solutions/monorepo-tools/package.json
@@ -46,7 +46,7 @@
     "@babel/runtime": "^7.18.0",
     "@modern-js/i18n-cli-language-detector": "workspace:^1.2.4",
     "@modern-js/new-action": "workspace:^1.3.11",
-    "@modern-js/plugin": "workspace:^1.4.0",
+    "@modern-js/plugin": "workspace:^1.4.1",
     "@modern-js/plugin-changeset": "workspace:^1.3.1",
     "@modern-js/plugin-i18n": "workspace:^1.2.7",
     "@modern-js/plugin-jarvis": "workspace:^1.2.14",

--- a/packages/toolkit/plugin/package.json
+++ b/packages/toolkit/plugin/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.4.0",
+  "version": "1.4.1",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/toolkit/plugin/src/manager/async.ts
+++ b/packages/toolkit/plugin/src/manager/async.ts
@@ -1,5 +1,4 @@
 import { generateRunner, DEFAULT_OPTIONS } from './sync';
-import { useRunner } from './runner';
 import {
   checkPlugins,
   isObject,
@@ -96,7 +95,10 @@ export const createAsyncManager = <
   api?: API,
 ): AsyncManager<Hooks, API> => {
   let index = 0;
+  let runners: ToRunners<Hooks>;
   let currentHooks = { ...hooks } as Hooks;
+
+  const useRunner = () => runners;
 
   const registerHook: AsyncManager<Hooks, API>['registerHook'] = extraHooks => {
     currentHooks = {
@@ -193,7 +195,8 @@ export const createAsyncManager = <
         sortedPlugins.map(plugin => plugin.setup(mergedPluginAPI)),
       );
 
-      return generateRunner<Hooks>(hooksList, currentHooks);
+      runners = generateRunner<Hooks>(hooksList, currentHooks);
+      return runners;
     };
 
     const run: AsyncManager<Hooks, API>['run'] = cb => cb();

--- a/packages/toolkit/plugin/src/manager/index.ts
+++ b/packages/toolkit/plugin/src/manager/index.ts
@@ -1,4 +1,3 @@
 export * from './sync';
 export * from './async';
-export * from './runner';
 export * from './types';

--- a/packages/toolkit/plugin/src/manager/runner.ts
+++ b/packages/toolkit/plugin/src/manager/runner.ts
@@ -1,5 +1,0 @@
-import { createContext } from '../farrow-pipeline';
-
-export const RunnerContext = createContext<any>(null);
-
-export const useRunner = () => RunnerContext.get();

--- a/packages/toolkit/plugin/src/manager/sync.ts
+++ b/packages/toolkit/plugin/src/manager/sync.ts
@@ -13,7 +13,6 @@ import {
   isParallelWorkflow,
   createParallelWorkflow,
 } from '../workflow';
-import { RunnerContext, useRunner } from './runner';
 import {
   checkPlugins,
   hasOwnProperty,
@@ -121,7 +120,10 @@ export const createManager = <
   api?: API,
 ): Manager<Hooks, API> => {
   let index = 0;
+  let runners: ToRunners<Hooks>;
   let currentHooks = { ...hooks } as Hooks;
+
+  const useRunner = () => runners;
 
   const registerHook: Manager<Hooks, API>['registerHook'] = extraHooks => {
     currentHooks = {
@@ -218,7 +220,8 @@ export const createManager = <
         plugin.setup(mergedPluginAPI),
       );
 
-      return generateRunner<Hooks>(hooksList, currentHooks);
+      runners = generateRunner<Hooks>(hooksList, currentHooks);
+      return runners;
     };
 
     const run: Manager<Hooks, API>['run'] = cb => cb();
@@ -267,8 +270,7 @@ export const generateRunner = <Hooks extends Record<string, any>>(
     }
   }
 
-  RunnerContext.set(runner);
-  return runner as any;
+  return runner as ToRunners<Hooks>;
 };
 
 export const cloneHook = (hook: Hook): Hook => {

--- a/packages/toolkit/plugin/tests/fixtures/async/dynamic/foo.ts
+++ b/packages/toolkit/plugin/tests/fixtures/async/dynamic/foo.ts
@@ -18,7 +18,6 @@ const foo = createPlugin(() => {
   return {
     preDev: () => {
       // run new lifecycle
-      // eslint-disable-next-line react-hooks/rules-of-hooks
       useRunner().fooWaterfall();
     },
   };

--- a/packages/toolkit/plugin/tests/fixtures/sync/dynamic/foo.ts
+++ b/packages/toolkit/plugin/tests/fixtures/sync/dynamic/foo.ts
@@ -18,7 +18,6 @@ const foo = createPlugin(() => {
   return {
     preDev: () => {
       // run new lifecycle
-      // eslint-disable-next-line react-hooks/rules-of-hooks
       useRunner().fooWaterfall();
     },
   };

--- a/packages/toolkit/plugin/tests/sync.test.ts
+++ b/packages/toolkit/plugin/tests/sync.test.ts
@@ -6,7 +6,7 @@ import {
   createContext,
 } from '../src/farrow-pipeline';
 import type { PluginOptions, Setup } from '../src';
-import { createManager, createAsyncManager, useRunner } from '../src/manager';
+import { createManager, createAsyncManager } from '../src/manager';
 import { createWaterfall, createAsyncWaterfall } from '../src/waterfall';
 import {
   createWorkflow,
@@ -531,8 +531,8 @@ describe('sync manager', () => {
 
       const plugin = manager.createPlugin(() => ({
         foo: () => {
-          const runner = useRunner();
-          runner.bar();
+          const runner = manager.useRunner();
+          (runner as any).bar();
         },
         bar: () => {
           count = 1;

--- a/packages/toolkit/types/package.json
+++ b/packages/toolkit/types/package.json
@@ -14,7 +14,7 @@
   "version": "1.5.5",
   "types": "./index.d.ts",
   "dependencies": {
-    "@modern-js/plugin": "workspace:^1.4.0",
+    "@modern-js/plugin": "workspace:^1.4.1",
     "http-proxy-middleware": "^2.0.4",
     "webpack": "^5.54.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,7 +210,7 @@ importers:
     specifiers:
       '@jest/types': ^27.0.6
       '@modern-js/load-config': workspace:^1.3.6
-      '@modern-js/plugin': workspace:^1.4.0
+      '@modern-js/plugin': workspace:^1.4.1
       '@modern-js/types': workspace:*
       '@modern-js/utils': workspace:^1.7.11
       '@scripts/build': workspace:*
@@ -312,7 +312,7 @@ importers:
       '@babel/traverse': ^7.18.0
       '@babel/types': ^7.18.0
       '@modern-js/core': workspace:*
-      '@modern-js/plugin': workspace:^1.4.0
+      '@modern-js/plugin': workspace:^1.4.1
       '@modern-js/types': workspace:*
       '@modern-js/utils': workspace:^1.7.11
       '@scripts/build': workspace:*
@@ -1526,7 +1526,7 @@ importers:
       '@modern-js/create-request': workspace:^1.3.0
       '@modern-js/css-config': workspace:^1.2.7
       '@modern-js/esmpack': workspace:^1.3.3
-      '@modern-js/plugin': workspace:^1.4.0
+      '@modern-js/plugin': workspace:^1.4.1
       '@modern-js/server': workspace:^1.5.0
       '@modern-js/tsconfig': workspace:*
       '@modern-js/types': workspace:*
@@ -2724,7 +2724,7 @@ importers:
       '@jest/types': ^27.0.6
       '@modern-js/babel-preset-app': workspace:^1.4.2
       '@modern-js/core': workspace:*
-      '@modern-js/plugin': workspace:^1.4.0
+      '@modern-js/plugin': workspace:^1.4.1
       '@modern-js/utils': workspace:^1.7.11
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
@@ -2816,7 +2816,7 @@ importers:
   packages/runtime:
     specifiers:
       '@babel/runtime': ^7.18.0
-      '@modern-js/plugin': workspace:^1.4.0
+      '@modern-js/plugin': workspace:^1.4.1
       '@modern-js/types': workspace:*
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
@@ -2957,7 +2957,7 @@ importers:
     specifiers:
       '@babel/runtime': ^7.18.0
       '@modern-js/bff-runtime': workspace:^1.3.0
-      '@modern-js/plugin': workspace:^1.4.0
+      '@modern-js/plugin': workspace:^1.4.1
       '@modern-js/utils': workspace:^1.7.9
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
@@ -2991,7 +2991,7 @@ importers:
   packages/server/core:
     specifiers:
       '@modern-js/core': workspace:*
-      '@modern-js/plugin': workspace:^1.4.0
+      '@modern-js/plugin': workspace:^1.4.1
       '@modern-js/types': workspace:*
       '@modern-js/utils': workspace:^1.7.11
       '@scripts/build': workspace:*
@@ -3522,7 +3522,7 @@ importers:
       '@babel/runtime': ^7.18.0
       '@modern-js/babel-preset-lib': workspace:^1.3.1
       '@modern-js/core': workspace:*
-      '@modern-js/plugin': workspace:^1.4.0
+      '@modern-js/plugin': workspace:^1.4.1
       '@modern-js/utils': workspace:^1.7.11
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
@@ -3569,7 +3569,7 @@ importers:
       '@modern-js/i18n-cli-language-detector': workspace:^1.2.4
       '@modern-js/new-action': workspace:^1.3.11
       '@modern-js/node-bundle-require': workspace:^1.3.7
-      '@modern-js/plugin': workspace:^1.4.0
+      '@modern-js/plugin': workspace:^1.4.1
       '@modern-js/plugin-analyze': workspace:^1.4.7
       '@modern-js/plugin-i18n': workspace:^1.2.7
       '@modern-js/plugin-jarvis': workspace:^1.2.14
@@ -3626,7 +3626,7 @@ importers:
       '@modern-js/css-config': workspace:^1.2.7
       '@modern-js/i18n-cli-language-detector': workspace:^1.2.4
       '@modern-js/new-action': workspace:^1.3.11
-      '@modern-js/plugin': workspace:^1.4.0
+      '@modern-js/plugin': workspace:^1.4.1
       '@modern-js/plugin-analyze': workspace:^1.4.7
       '@modern-js/plugin-changeset': workspace:^1.3.1
       '@modern-js/plugin-i18n': workspace:^1.2.7
@@ -3714,7 +3714,7 @@ importers:
       '@modern-js/core': workspace:^1.12.2
       '@modern-js/i18n-cli-language-detector': workspace:^1.2.4
       '@modern-js/new-action': workspace:^1.3.11
-      '@modern-js/plugin': workspace:^1.4.0
+      '@modern-js/plugin': workspace:^1.4.1
       '@modern-js/plugin-changeset': workspace:^1.3.1
       '@modern-js/plugin-i18n': workspace:^1.2.7
       '@modern-js/plugin-jarvis': workspace:^1.2.14
@@ -4118,7 +4118,7 @@ importers:
 
   packages/toolkit/types:
     specifiers:
-      '@modern-js/plugin': workspace:^1.4.0
+      '@modern-js/plugin': workspace:^1.4.1
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@types/jest': ^27


### PR DESCRIPTION
# PR Details

## Description

- Fix incorrect runners if multiple managers are created, the RunnerContext is incorrectly overridden.
- Release `@modern-js/plugin` v1.4.1 hotfix version.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
