### PR TITLE
fix(webpack): failed to import SVG from a CSS file in some cases

### DIFF
--- a/.changeset/khaki-numbers-bathe.md
+++ b/.changeset/khaki-numbers-bathe.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): failed to import SVG from a CSS file in some cases
+
+fix(webpack): 修复从 CSS 文件中引用 SVG 图片时，可能会出现编译报错的问题

--- a/packages/cli/webpack/src/config/features/svgr.ts
+++ b/packages/cli/webpack/src/config/features/svgr.ts
@@ -1,5 +1,5 @@
 import { CHAIN_ID } from '@modern-js/utils';
-import { SVG_REGEX } from '../../utils/constants';
+import { JS_REGEX, SVG_REGEX, TS_REGEX } from '../../utils/constants';
 import type { ChainUtils } from '../shared';
 
 export function applySvgrLoader({
@@ -45,6 +45,9 @@ export function applySvgrLoader({
   loaders
     .oneOf(CHAIN_ID.ONE_OF.SVG)
     .test(SVG_REGEX)
+    // The issuer option ensures that SVGR will only apply if the SVG is imported from a JS file.
+    // If we import SVG from a CSS file, it will be processed as assets.
+    .set('issuer', [JS_REGEX, TS_REGEX])
     .type('javascript/auto')
     .use(CHAIN_ID.USE.SVGR)
     .loader(require.resolve('@svgr/webpack'))

--- a/packages/cli/webpack/src/utils/constants.ts
+++ b/packages/cli/webpack/src/utils/constants.ts
@@ -9,7 +9,7 @@ export const JS_REGEX = /\.(js|mjs|jsx)$/;
 export const TS_REGEX = /\.tsx?$/;
 
 export const ASSETS_REGEX =
-  /\.(woff|woff2|eot|ttf|otf|ttc|gif|png|jpe?g|webp|bmp|ico)$/i;
+  /\.(woff|woff2|eot|ttf|otf|ttc|gif|png|jpe?g|webp|bmp|ico|svg)$/i;
 
 export const NODE_MODULES_REGEX = /node_modules/;
 


### PR DESCRIPTION
# PR Details

## Description

Fix failed to import SVG from a CSS file in some cases.

Add an issuer option ensures that SVGR will only apply if the SVG is imported from a JS file.

If we import SVG from a CSS file, it will be processed as assets.

Ref: https://react-svgr.com/docs/webpack/#use-svg-in-css-files

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
