### PR TITLE
fix(webpack): should not inject CSS sourceMap into js bundles

### DIFF
--- a/.changeset/hot-shirts-crash.md
+++ b/.changeset/hot-shirts-crash.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): should not inject CSS sourcemap in js bundles
+
+fix(webpack): 修复使用 style-loader 时会将 CSS 的 SourceMap 打包到 JS 中的问题

--- a/packages/cli/webpack/src/config/features/css.ts
+++ b/packages/cli/webpack/src/config/features/css.ts
@@ -4,12 +4,15 @@ import {
   GLOBAL_CSS_REGEX,
   CSS_MODULE_REGEX,
 } from '../../utils/constants';
-import { createCSSRule } from '../../utils/createCSSRule';
+import { createCSSRule, enableCssExtract } from '../../utils/createCSSRule';
 import { ChainUtils, isNodeModulesCss } from '../shared';
 
 export function applyCSSLoaders({ chain, config, appContext }: ChainUtils) {
   const disableCssModuleExtension =
     config.output?.disableCssModuleExtension ?? false;
+  const isExtractCSS = enableCssExtract(config);
+  const enableSourceMap =
+    isProd() && isExtractCSS && !config.output?.disableSourceMap;
 
   // CSS modules
   createCSSRule(
@@ -35,7 +38,7 @@ export function applyCSSLoaders({ chain, config, appContext }: ChainUtils) {
           : '',
         exportLocalsConvention: 'camelCase',
       },
-      sourceMap: isProd() && !config.output?.disableSourceMap,
+      sourceMap: enableSourceMap,
     },
   );
 
@@ -53,7 +56,7 @@ export function applyCSSLoaders({ chain, config, appContext }: ChainUtils) {
     {
       importLoaders: 1,
       esModule: false,
-      sourceMap: isProd() && !config.output?.disableSourceMap,
+      sourceMap: enableSourceMap,
     },
   );
 }


### PR DESCRIPTION
# PR Details

Fix inject CSS SourceMap in js bundles when using `style-loader`:

![o52WrFIfcM](https://user-images.githubusercontent.com/7237365/177345554-cc26e0ee-1511-4b25-bfdf-bd6c537cd0e3.jpg)

If using style-loader, we should not enable the `sourceMap` option of css-loader.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
