### PR TITLE
fix(module-tools): ignore cjs and mjs in dts bundle

### DIFF
--- a/.changeset/chatty-squids-camp.md
+++ b/.changeset/chatty-squids-camp.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+ignore cjs and mjs in dts bundle
+在对dts做bundle时忽略cjs和mjs资源

--- a/packages/solutions/module-tools/src/features/build/bundle/runRollup.ts
+++ b/packages/solutions/module-tools/src/features/build/bundle/runRollup.ts
@@ -48,7 +48,7 @@ const getRollupConfig = async (
   const ignoreFiles: Plugin = {
     name: 'ignore-files',
     load(id) {
-      if (!/\.(js|cjs|mjs|jsx|ts|tsx|mts|json)$/.test(id)) {
+      if (!/\.(js|jsx|ts|tsx|json)$/.test(id)) {
         return '';
       }
       return null;


### PR DESCRIPTION
# PR Details
When bundle dts, if contains .mjs or .cjs files, the output  will have some code which are not transformed by rollup-plugin-dts, so we should ignore it. 

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
