### PR TITLE
fix: monorepo new command plugin params not work

### DIFF
--- a/.changeset/chatty-squids-camp.md
+++ b/.changeset/chatty-squids-camp.md
@@ -2,5 +2,6 @@
 '@modern-js/module-tools': patch
 ---
 
-ignore cjs and mjs in dts bundle
-在对dts做bundle时忽略cjs和mjs资源
+fix: ignore cjs and mjs in d.ts bundle
+
+fix: 对 d.ts 做 bundle 时忽略 cjs 和 mjs 资源

--- a/.changeset/nasty-ads-destroy.md
+++ b/.changeset/nasty-ads-destroy.md
@@ -1,0 +1,20 @@
+---
+'@modern-js/generator-plugin': patch
+'@modern-js/bff-generator': patch
+'@modern-js/cloud-deploy-generator': patch
+'@modern-js/dependence-generator': patch
+'@modern-js/electron-generator': patch
+'@modern-js/electron-independence-generator': patch
+'@modern-js/entry-generator': patch
+'@modern-js/generator-generator': patch
+'@modern-js/module-generator': patch
+'@modern-js/monorepo-generator': patch
+'@modern-js/mwa-generator': patch
+'@modern-js/server-generator': patch
+'@modern-js/ssg-generator': patch
+'@modern-js/storybook-generator': patch
+'@modern-js/test-generator': patch
+'@modern-js/unbundle-generator': patch
+---
+
+feat: update codesmith json api version

--- a/.changeset/nasty-ads-destroy.md
+++ b/.changeset/nasty-ads-destroy.md
@@ -18,3 +18,5 @@
 ---
 
 feat: update codesmith json api version
+
+feat: 升级 `@modern-js/codesmith-api-json` 版本

--- a/.changeset/smooth-pigs-applaud.md
+++ b/.changeset/smooth-pigs-applaud.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/new-action': patch
+---
+
+fix: monorepo-tools new command plugin params not work
+
+fix: 修复 monorepo-tools new 命令 plugin 参数不生效问题

--- a/.changeset/smooth-pigs-applaud.md
+++ b/.changeset/smooth-pigs-applaud.md
@@ -1,5 +1,6 @@
 ---
 '@modern-js/new-action': patch
+'@modern-js/monorepo-tools': patch
 ---
 
 fix: monorepo-tools new command plugin params not work

--- a/.changeset/sour-rice-breathe.md
+++ b/.changeset/sour-rice-breathe.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/generator-plugin': patch
+---
+
+fix(generator-plugin): remove `addManyFiles` destination empty validate
+
+fix(generator-plugin): 移除 `addManyFiles` destination 参数为空的校验

--- a/.changeset/sour-rice-breathe.md
+++ b/.changeset/sour-rice-breathe.md
@@ -1,5 +1,7 @@
 ---
 '@modern-js/generator-plugin': patch
+'@modern-js/repo-generator': patch
+'@modern-js/generator-plugin-plugin': patch
 ---
 
 fix(generator-plugin): remove `addManyFiles` destination empty validate

--- a/packages/generator/generator-plugin/package.json
+++ b/packages/generator/generator-plugin/package.json
@@ -20,7 +20,7 @@
     "@modern-js/generator-utils": "workspace:^1.2.7",
     "@modern-js/generator-common": "workspace:^1.4.13",
     "@modern-js/new-action": "workspace:^1.3.11",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@modern-js/codesmith-api-npm": "^1.2.1",
     "@modern-js/codesmith-api-git": "^1.2.1",
     "@modern-js/plugin-i18n": "workspace:^1.2.7",

--- a/packages/generator/generator-plugin/src/utils/file.ts
+++ b/packages/generator/generator-plugin/src/utils/file.ts
@@ -102,7 +102,7 @@ export async function addManyFiles(
   renderString: (content?: string, data?: Record<string, string>) => string,
 ) {
   const dest = config.destination;
-  if (typeof dest !== 'string' || dest.length === 0) {
+  if (typeof dest !== 'string') {
     throw Error(`Invalid destination "${dest}"`);
   }
   if (typeof config.templateFiles === 'function') {

--- a/packages/generator/generators/bff-generator/package.json
+++ b/packages/generator/generators/bff-generator/package.json
@@ -31,7 +31,7 @@
     "@babel/runtime": "^7.18.0",
     "@modern-js/codesmith": "^1.3.0",
     "@modern-js/codesmith-api-app": "^1.2.5",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@modern-js/codesmith-tools": "^1.2.1",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/cloud-deploy-generator/package.json
+++ b/packages/generator/generators/cloud-deploy-generator/package.json
@@ -33,7 +33,7 @@
     "@modern-js/codesmith": "^1.3.0",
     "@modern-js/codesmith-tools": "^1.2.1",
     "@modern-js/codesmith-api-app": "^1.2.5",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/dependence-generator": "workspace:*",

--- a/packages/generator/generators/dependence-generator/package.json
+++ b/packages/generator/generators/dependence-generator/package.json
@@ -30,7 +30,7 @@
     "@babel/runtime": "^7.18.0",
     "@modern-js/codesmith": "^1.3.0",
     "@modern-js/codesmith-api-app": "^1.2.5",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@modern-js/codesmith-tools": "^1.2.1",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/electron-generator/package.json
+++ b/packages/generator/generators/electron-generator/package.json
@@ -30,7 +30,7 @@
     "@babel/runtime": "^7.18.0",
     "@modern-js/codesmith": "^1.3.0",
     "@modern-js/codesmith-api-app": "^1.2.5",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@modern-js/codesmith-api-fs": "^1.2.1",
     "@modern-js/codesmith-tools": "^1.2.1",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/electron-independence-generator/package.json
+++ b/packages/generator/generators/electron-independence-generator/package.json
@@ -30,7 +30,7 @@
     "@babel/runtime": "^7.18.0",
     "@modern-js/codesmith": "^1.3.0",
     "@modern-js/codesmith-api-app": "^1.2.5",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@modern-js/codesmith-tools": "^1.2.1",
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",

--- a/packages/generator/generators/entry-generator/package.json
+++ b/packages/generator/generators/entry-generator/package.json
@@ -30,7 +30,7 @@
     "@babel/runtime": "^7.18.0",
     "@modern-js/codesmith": "^1.3.0",
     "@modern-js/codesmith-api-app": "^1.2.5",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@modern-js/codesmith-api-handlebars": "^1.2.1",
     "@modern-js/codesmith-tools": "^1.2.1",
     "@modern-js/generator-common": "workspace:*",

--- a/packages/generator/generators/generator-generator/package.json
+++ b/packages/generator/generators/generator-generator/package.json
@@ -30,7 +30,7 @@
     "@babel/runtime": "^7.18.0",
     "@modern-js/codesmith": "^1.3.0",
     "@modern-js/codesmith-api-app": "^1.2.5",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@modern-js/codesmith-tools": "^1.2.1",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/module-generator/package.json
+++ b/packages/generator/generators/module-generator/package.json
@@ -32,7 +32,7 @@
     "@modern-js/changeset-generator": "workspace:*",
     "@modern-js/codesmith": "^1.3.0",
     "@modern-js/codesmith-api-app": "^1.2.5",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@modern-js/codesmith-tools": "^1.2.1",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/monorepo-generator/package.json
+++ b/packages/generator/generators/monorepo-generator/package.json
@@ -34,7 +34,7 @@
     "@modern-js/codesmith": "^1.3.0",
     "@modern-js/codesmith-api-app": "^1.2.5",
     "@modern-js/codesmith-tools": "^1.2.1",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@scripts/build": "workspace:*",

--- a/packages/generator/generators/mwa-generator/package.json
+++ b/packages/generator/generators/mwa-generator/package.json
@@ -31,7 +31,7 @@
     "@modern-js/base-generator": "workspace:*",
     "@modern-js/codesmith": "^1.3.0",
     "@modern-js/codesmith-api-app": "^1.2.5",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@modern-js/codesmith-tools": "^1.2.1",
     "@modern-js/entry-generator": "workspace:*",
     "@modern-js/electron-generator": "workspace:*",

--- a/packages/generator/generators/server-generator/package.json
+++ b/packages/generator/generators/server-generator/package.json
@@ -31,7 +31,7 @@
     "@babel/runtime": "^7.18.0",
     "@modern-js/codesmith": "^1.3.0",
     "@modern-js/codesmith-api-app": "^1.2.5",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@modern-js/codesmith-tools": "^1.2.1",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/ssg-generator/package.json
+++ b/packages/generator/generators/ssg-generator/package.json
@@ -34,7 +34,7 @@
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/dependence-generator": "workspace:*",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@types/jest": "^27",
     "@types/node": "^14",
     "typescript": "^4",

--- a/packages/generator/generators/storybook-generator/package.json
+++ b/packages/generator/generators/storybook-generator/package.json
@@ -36,7 +36,7 @@
     "@modern-js/dependence-generator": "workspace:*",
     "@modern-js/eslint-generator": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@types/jest": "^27",
     "@types/node": "^14",
     "typescript": "^4",

--- a/packages/generator/generators/test-generator/package.json
+++ b/packages/generator/generators/test-generator/package.json
@@ -35,7 +35,7 @@
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/dependence-generator": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@types/jest": "^27",
     "@types/node": "^14",
     "typescript": "^4",

--- a/packages/generator/generators/unbundle-generator/package.json
+++ b/packages/generator/generators/unbundle-generator/package.json
@@ -35,7 +35,7 @@
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
-    "@modern-js/codesmith-api-json": "^1.2.1",
+    "@modern-js/codesmith-api-json": "^1.2.2",
     "@types/jest": "^27",
     "@types/node": "^14",
     "typescript": "^4",

--- a/packages/generator/new-action/src/monorepo.ts
+++ b/packages/generator/new-action/src/monorepo.ts
@@ -10,7 +10,7 @@ interface IMonorepoNewActionOption {
   debug?: boolean;
   registry?: string;
   config?: string;
-  plugins?: string[];
+  plugin?: string[];
   cwd?: string;
 }
 
@@ -23,7 +23,7 @@ export const MonorepoNewAction = async (options: IMonorepoNewActionOption) => {
     debug = false,
     registry = '',
     config = '{}',
-    plugins = [],
+    plugin = [],
     cwd = process.cwd(),
   } = options;
 
@@ -51,7 +51,7 @@ export const MonorepoNewAction = async (options: IMonorepoNewActionOption) => {
     packageManager: UserConfig.packageManager || (await getPackageManager(cwd)),
     isMonorepo: true,
     distTag,
-    plugins,
+    plugins: plugin,
   });
 
   let generator = REPO_GENERATOR;

--- a/packages/generator/new-action/src/monorepo.ts
+++ b/packages/generator/new-action/src/monorepo.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { merge } from '@modern-js/utils/lodash';
 import { CodeSmith } from '@modern-js/codesmith';
 import { i18n } from '@modern-js/generator-common';
@@ -46,12 +47,21 @@ export const MonorepoNewAction = async (options: IMonorepoNewActionOption) => {
     smith.logger.warn('not valid modern.js repo');
   }
 
+  // Determine if the plugin is a Monorepo dependency
+  const plugins = plugin.map(plugin => {
+    try {
+      return path.join(require.resolve(plugin), '../../../../');
+    } catch (e) {
+      return plugin;
+    }
+  });
+
   const finalConfig = merge(UserConfig, {
     locale: (UserConfig.locale as string) || locale,
     packageManager: UserConfig.packageManager || (await getPackageManager(cwd)),
     isMonorepo: true,
     distTag,
-    plugins: plugin,
+    plugins,
   });
 
   let generator = REPO_GENERATOR;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1815,7 +1815,7 @@ importers:
       '@babel/runtime': ^7.18.0
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-git': ^1.2.1
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-api-npm': ^1.2.1
       '@modern-js/easy-form-core': ^1.0.0
       '@modern-js/generator-common': workspace:^1.4.13
@@ -1839,7 +1839,7 @@ importers:
       '@babel/runtime': 7.18.6
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-git': 1.2.1
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-api-npm': 1.2.1
       '@modern-js/easy-form-core': 1.2.1
       '@modern-js/generator-common': link:../generator-common
@@ -1917,7 +1917,7 @@ importers:
       '@babel/runtime': ^7.18.0
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -1931,7 +1931,7 @@ importers:
       '@babel/runtime': 7.18.6
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -1999,7 +1999,7 @@ importers:
       '@babel/runtime': ^7.18.0
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
@@ -2015,7 +2015,7 @@ importers:
       '@babel/runtime': 7.18.6
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
@@ -2033,7 +2033,7 @@ importers:
       '@babel/runtime': ^7.18.0
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -2047,7 +2047,7 @@ importers:
       '@babel/runtime': 7.18.6
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -2094,7 +2094,7 @@ importers:
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
       '@modern-js/codesmith-api-fs': ^1.2.1
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/generator-utils': workspace:*
       '@modern-js/plugin-i18n': workspace:*
@@ -2109,7 +2109,7 @@ importers:
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
       '@modern-js/codesmith-api-fs': 1.2.1
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/generator-utils': link:../../generator-utils
       '@modern-js/plugin-i18n': link:../../../cli/plugin-i18n
@@ -2125,7 +2125,7 @@ importers:
       '@babel/runtime': ^7.18.0
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/generator-utils': workspace:*
       '@modern-js/plugin-i18n': workspace:*
@@ -2139,7 +2139,7 @@ importers:
       '@babel/runtime': 7.18.6
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/generator-utils': link:../../generator-utils
       '@modern-js/plugin-i18n': link:../../../cli/plugin-i18n
@@ -2156,7 +2156,7 @@ importers:
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
       '@modern-js/codesmith-api-handlebars': ^1.2.1
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -2173,7 +2173,7 @@ importers:
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
       '@modern-js/codesmith-api-handlebars': 1.2.1
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -2219,7 +2219,7 @@ importers:
       '@babel/runtime': ^7.18.0
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -2235,7 +2235,7 @@ importers:
       '@babel/runtime': 7.18.6
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -2255,7 +2255,7 @@ importers:
       '@modern-js/changeset-generator': workspace:*
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
@@ -2273,7 +2273,7 @@ importers:
       '@modern-js/changeset-generator': link:../changeset-generator
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
@@ -2293,7 +2293,7 @@ importers:
       '@modern-js/changeset-generator': workspace:*
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -2310,7 +2310,7 @@ importers:
       '@modern-js/changeset-generator': link:../changeset-generator
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -2328,7 +2328,7 @@ importers:
       '@modern-js/base-generator': workspace:*
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/electron-generator': workspace:*
@@ -2347,7 +2347,7 @@ importers:
       '@modern-js/base-generator': link:../base-generator
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/electron-generator': link:../electron-generator
@@ -2410,7 +2410,7 @@ importers:
       '@babel/runtime': ^7.18.0
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -2424,7 +2424,7 @@ importers:
       '@babel/runtime': 7.18.6
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -2440,7 +2440,7 @@ importers:
       '@babel/runtime': ^7.18.0
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
@@ -2455,7 +2455,7 @@ importers:
       '@babel/runtime': 7.18.6
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
@@ -2472,7 +2472,7 @@ importers:
       '@babel/runtime': ^7.18.0
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/eslint-generator': workspace:*
@@ -2489,7 +2489,7 @@ importers:
       '@babel/runtime': 7.18.6
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/eslint-generator': link:../eslint-generator
@@ -2538,7 +2538,7 @@ importers:
       '@babel/runtime': ^7.18.0
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
@@ -2554,7 +2554,7 @@ importers:
       '@babel/runtime': 7.18.6
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
@@ -2572,7 +2572,7 @@ importers:
       '@babel/runtime': ^7.18.0
       '@modern-js/codesmith': ^1.3.0
       '@modern-js/codesmith-api-app': ^1.2.5
-      '@modern-js/codesmith-api-json': ^1.2.1
+      '@modern-js/codesmith-api-json': ^1.2.2
       '@modern-js/codesmith-tools': ^1.2.1
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
@@ -2588,7 +2588,7 @@ importers:
       '@babel/runtime': 7.18.6
       '@modern-js/codesmith': 1.3.0
       '@modern-js/codesmith-api-app': 1.2.5
-      '@modern-js/codesmith-api-json': 1.2.1
+      '@modern-js/codesmith-api-json': 1.2.2
       '@modern-js/codesmith-tools': 1.2.1_esbuild@0.14.47
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
@@ -9797,8 +9797,8 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /@modern-js/codesmith-api-json/1.2.1:
-    resolution: {integrity: sha512-5OFjUb3okjkrOkJ9wx2wME5ykxTVu96ZcfZDjYfeEOYtx+0jFBnqIVwj+5Q6l02HhYloA0oN6Wpm97vTJiYmkw==}
+  /@modern-js/codesmith-api-json/1.2.2:
+    resolution: {integrity: sha512-K0DVb+DNoTHtgPZ3JvMdfqAXf1b+pm3yXe2lPBplt7I0qnY5TjgG1uz8Rx0OHOz/DPLWmSfLLGs2yo74QDX3bg==}
     dependencies:
       '@babel/runtime': 7.18.6
       '@modern-js/codesmith': 1.3.0


### PR DESCRIPTION
# PR Details

- 升级 @modern-js/codesmith-api-json，修复生成器插件中更新 json 文件路径问题
- 修复 monorepo new 命令 plugin 参数不生效问题
- 移除 `addManyFiles` destination 参数为空字符串的校验
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
