### PR TITLE
fix(webpack): failed to compile .cjs,.mts,.cts file

### DIFF
--- a/.changeset/ninety-parents-type.md
+++ b/.changeset/ninety-parents-type.md
@@ -2,6 +2,6 @@
 '@modern-js/webpack': patch
 ---
 
-fix(webpack): failed to compile .cjs,.mjs,.mts file
+fix(webpack): failed to compile .cjs,.cts,.mts file
 
-fix(webpack): 修复无法编译 .cjs,.mjs,.mts 文件的问题
+fix(webpack): 修复无法编译 .cjs,.cts,.mts 文件的问题

--- a/.changeset/ninety-parents-type.md
+++ b/.changeset/ninety-parents-type.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): failed to compile .cjs,.mjs,.mts file
+
+fix(webpack): 修复无法编译 .cjs,.mjs,.mts 文件的问题

--- a/packages/cli/webpack/src/utils/constants.ts
+++ b/packages/cli/webpack/src/utils/constants.ts
@@ -4,9 +4,9 @@ export const CSS_MODULE_REGEX = /\.module\.css$/;
 
 export const GLOBAL_CSS_REGEX = /\.global\.css$/;
 
-export const JS_REGEX = /\.(js|mjs|jsx)$/;
+export const JS_REGEX = /\.(js|mjs|cjs|jsx)$/;
 
-export const TS_REGEX = /\.tsx?$/;
+export const TS_REGEX = /\.(ts|tsx)?$/;
 
 export const ASSETS_REGEX =
   /\.(woff|woff2|eot|ttf|otf|ttc|gif|png|jpe?g|webp|bmp|ico|svg)$/i;
@@ -26,9 +26,9 @@ export const JS_RESOLVE_EXTENSIONS = [
   'ts',
   'web.tsx',
   'tsx',
-  'json',
   'web.jsx',
   'jsx',
+  'json',
 ].map(t => `.${t}`);
 
 export const CACHE_DIRECTORY = './node_modules/.cache';

--- a/packages/cli/webpack/src/utils/constants.ts
+++ b/packages/cli/webpack/src/utils/constants.ts
@@ -6,7 +6,7 @@ export const GLOBAL_CSS_REGEX = /\.global\.css$/;
 
 export const JS_REGEX = /\.(js|mjs|cjs|jsx)$/;
 
-export const TS_REGEX = /\.(ts|mts|cts|tsx)?$/;
+export const TS_REGEX = /\.(ts|mts|cts|tsx)$/;
 
 export const ASSETS_REGEX =
   /\.(woff|woff2|eot|ttf|otf|ttc|gif|png|jpe?g|webp|bmp|ico|svg)$/i;

--- a/packages/cli/webpack/src/utils/constants.ts
+++ b/packages/cli/webpack/src/utils/constants.ts
@@ -6,7 +6,7 @@ export const GLOBAL_CSS_REGEX = /\.global\.css$/;
 
 export const JS_REGEX = /\.(js|mjs|cjs|jsx)$/;
 
-export const TS_REGEX = /\.(ts|tsx)?$/;
+export const TS_REGEX = /\.(ts|mts|cts|tsx)?$/;
 
 export const ASSETS_REGEX =
   /\.(woff|woff2|eot|ttf|otf|ttc|gif|png|jpe?g|webp|bmp|ico|svg)$/i;


### PR DESCRIPTION
# PR Details

## Description

Fix failed to compile .cjs,.mjs,.mts file.

Allow `babel-loader` to process these files, rather than fallback to `file-loader`.

<img width="897" alt="截屏2022-07-08 下午4 27 40" src="https://user-images.githubusercontent.com/7237365/177957793-0a5b16ad-e632-49d2-927e-7e282bacc95c.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
