### PR TITLE
fix(plugin-ssr): the  tag in html template will replace by empty content

### DIFF
--- a/.changeset/shiny-kiwis-cheat.md
+++ b/.changeset/shiny-kiwis-cheat.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-ssr': patch
+---
+
+fix: the `<title>` tag in html template will replace by empty content, when deveploper open ssr.
+
+fix: 当开启SSR时，html 中的 `<title>` 标签将被空白内容替换。

--- a/packages/cli/plugin-ssr/src/serverRender/helmet.ts
+++ b/packages/cli/plugin-ssr/src/serverRender/helmet.ts
@@ -5,6 +5,8 @@ const RE_HTML_ATTR = /<html[^>]*>/;
 const RE_BODY_ATTR = /<body[^>]*>/;
 const RE_LAST_IN_HEAD = /<\/head>/;
 const RE_TITLE = /<title[^>]*>([\s\S\n\r]*?)<\/title>/g;
+const RE_TITLE_CONTENT =
+  /(?<=<title[^>]*>)([\s\S\n\r]*?)(.)([\s\S\n\r]*?)(?=<\/title>)/g;
 
 // 通过 react-helmet 修改模板
 export default function helmet(content: string, helmetData: HelmetData) {
@@ -29,7 +31,7 @@ export default function helmet(content: string, helmetData: HelmetData) {
 
   // 如果模板中存在 title，且 helmetData title 有内容则做替换
   const existTitle = RE_TITLE.test(content);
-  if (title.trim() && existTitle) {
+  if (RE_TITLE_CONTENT.test(title.trim()) && existTitle) {
     result = result.replace(RE_TITLE, title);
   }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
the `<title>` tag in html template will replace by empty content, when deveploper open ssr.

## Description

<!--- Describe your changes in detail -->
plugin-ssr

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
