### PR TITLE
doc: avoid prepare failure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@ npm install -g pnpm@6
 ### Set up local Modern.js repository
 
 ```zsh
-pnpm install
+pnpm install --ignore-scripts
+pnpm prepare
 ```
 
 <details>


### PR DESCRIPTION
when running pnpm install, always occur prepare failure which cause application can not work