### PR TITLE
fix: url parsed cursh should be catched

### DIFF
--- a/packages/server/prod-server/src/libs/context/context.ts
+++ b/packages/server/prod-server/src/libs/context/context.ts
@@ -171,7 +171,7 @@ export class ModernServerContext implements ModernServerContextInterface {
     this.logger.error(
       `Web Server Error - ${dig}, error = %s, req.url = %s, req.headers = %o`,
       e instanceof Error ? e.stack || e.message : e,
-      this.path,
+      this.req.url,
       this.headers,
     );
   }


### PR DESCRIPTION
解决如：http://localhost:8080//
这种 URL 解析会失败的 case。
### 原因
1. error 打印日志的时候，引用了 this.url 导致报错