### PR TITLE
Release v1.6.4

### DIFF
--- a/.changeset/blue-dodos-complain.md
+++ b/.changeset/blue-dodos-complain.md
@@ -1,7 +1,0 @@
----
-'@modern-js/plugin-testing': minor
----
-
-chore(testing): merge `@modern-js/testing-plugin-bff` to `@modern-js/plugin-testing`
-
-chore(testing): 合并 `@modern-js/testing-plugin-bff` 到 `@modern-js/plugin-testing`

--- a/.changeset/blue-horses-worry.md
+++ b/.changeset/blue-horses-worry.md
@@ -1,8 +1,0 @@
----
-'@modern-js/plugin-testing': minor
-'@modern-js/plugin-unbundle': minor
----
-
-chore(testing): delete `@modern-js/bff-utils`
-
-chore(testing): 删除 `@modern-js/bff-utils`

--- a/.changeset/cuddly-boxes-carry.md
+++ b/.changeset/cuddly-boxes-carry.md
@@ -1,7 +1,0 @@
----
-'@modern-js/plugin-ssr': patch
----
-
-fix: the `<title>` tag in html template will replace by empty content, when deveploper open ssr.
-
-fix: 当开启SSR时，html 中的 `<title>` 标签将被空白内容替换。

--- a/.changeset/honest-plums-train.md
+++ b/.changeset/honest-plums-train.md
@@ -1,7 +1,0 @@
----
-'@modern-js/plugin-express': patch
-'@modern-js/plugin-koa': patch
----
-
-fix: fix bff hot reload not works when has app.ts
-fix: 修复有 app.ts 的时候， bff 热更新不生效的问题

--- a/.changeset/perfect-birds-judge.md
+++ b/.changeset/perfect-birds-judge.md
@@ -1,7 +1,0 @@
----
-'@modern-js/plugin-testing': minor
----
-
-chore(testing): merge `@modern-js/testing` to `@modern-js/plugin-testing`
-
-chore(testing): 合并 `@modern-js/testing` 到 `@modern-js/plugin-testing`

--- a/.changeset/rich-jobs-bow.md
+++ b/.changeset/rich-jobs-bow.md
@@ -1,7 +1,0 @@
----
-'@modern-js/plugin-storybook': patch
-'@modern-js/module-tools': patch
----
-
-feat: add addRuntimeExports hooks for module-tools
-feat: 为 module-tools 添加 addRuntimeExports 钩子

--- a/.changeset/wise-geckos-train.md
+++ b/.changeset/wise-geckos-train.md
@@ -1,7 +1,0 @@
----
-'@modern-js/bff-core': patch
----
-
-fix: export http status
-
-fix: 暴露 http 状态码

--- a/packages/cli/plugin-ssr/CHANGELOG.md
+++ b/packages/cli/plugin-ssr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/plugin-ssr
 
+## 1.5.1
+
+### Patch Changes
+
+- b5a193c: fix: the `<title>` tag in html template will replace by empty content, when deveploper open ssr.
+
+  fix: 当开启 SSR 时，html 中的 `<title>` 标签将被空白内容替换。
+
 ## 1.5.0
 
 ### Minor Changes

--- a/packages/cli/plugin-ssr/package.json
+++ b/packages/cli/plugin-ssr/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.5.0",
+  "version": "1.5.1",
   "jsnext:source": "./src/index.tsx",
   "types": "./src/index.tsx",
   "main": "./dist/js/node/index.node.js",

--- a/packages/cli/plugin-storybook/CHANGELOG.md
+++ b/packages/cli/plugin-storybook/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/plugin-storybook
 
+## 1.3.18
+
+### Patch Changes
+
+- b2f90f8: feat: add addRuntimeExports hooks for module-tools
+  feat: 为 module-tools 添加 addRuntimeExports 钩子
+
 ## 1.3.17
 
 ### Patch Changes

--- a/packages/cli/plugin-storybook/package.json
+++ b/packages/cli/plugin-storybook/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.3.17",
+  "version": "1.3.18",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-testing/CHANGELOG.md
+++ b/packages/cli/plugin-testing/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @modern-js/plugin-testing
 
+## 1.6.0
+
+### Minor Changes
+
+- 10f4283: chore(testing): merge `@modern-js/testing-plugin-bff` to `@modern-js/plugin-testing`
+
+  chore(testing): 合并 `@modern-js/testing-plugin-bff` 到 `@modern-js/plugin-testing`
+
+- 10f4283: chore(testing): delete `@modern-js/bff-utils`
+
+  chore(testing): 删除 `@modern-js/bff-utils`
+
+- 10f4283: chore(testing): merge `@modern-js/testing` to `@modern-js/plugin-testing`
+
+  chore(testing): 合并 `@modern-js/testing` 到 `@modern-js/plugin-testing`
+
 ## 1.5.7
 
 ### Patch Changes

--- a/packages/cli/plugin-testing/package.json
+++ b/packages/cli/plugin-testing/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.5.7",
+  "version": "1.6.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-unbundle/CHANGELOG.md
+++ b/packages/cli/plugin-unbundle/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/plugin-unbundle
 
+## 1.5.0
+
+### Minor Changes
+
+- 10f4283: chore(testing): delete `@modern-js/bff-utils`
+
+  chore(testing): 删除 `@modern-js/bff-utils`
+
 ## 1.4.5
 
 ### Patch Changes

--- a/packages/cli/plugin-unbundle/package.json
+++ b/packages/cli/plugin-unbundle/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.4.5",
+  "version": "1.5.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/bff-core/package.json
+++ b/packages/server/bff-core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.1.2",
+  "version": "1.1.3",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-express/CHANGELOG.md
+++ b/packages/server/plugin-express/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/plugin-express
 
+## 1.6.1
+
+### Patch Changes
+
+- 74f7fd7: fix: fix bff hot reload not works when has app.ts
+  fix: 修复有 app.ts 的时候， bff 热更新不生效的问题
+- Updated dependencies [74f7fd7]
+  - @modern-js/bff-core@1.1.3
+
 ## 1.6.0
 
 ### Minor Changes

--- a/packages/server/plugin-express/package.json
+++ b/packages/server/plugin-express/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.6.0",
+  "version": "1.6.1",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -42,7 +42,7 @@
   "dependencies": {
     "@babel/runtime": "^7.18.0",
     "@modern-js/adapter-helpers": "workspace:^1.3.0",
-    "@modern-js/bff-core": "workspace:^1.1.2",
+    "@modern-js/bff-core": "workspace:^1.1.3",
     "@modern-js/bff-runtime": "workspace:^1.3.0",
     "@modern-js/types": "workspace:^1.6.0",
     "@modern-js/utils": "workspace:^1.7.12",

--- a/packages/server/plugin-koa/CHANGELOG.md
+++ b/packages/server/plugin-koa/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/plugin-koa
 
+## 1.5.1
+
+### Patch Changes
+
+- 74f7fd7: fix: fix bff hot reload not works when has app.ts
+  fix: 修复有 app.ts 的时候， bff 热更新不生效的问题
+- Updated dependencies [74f7fd7]
+  - @modern-js/bff-core@1.1.3
+
 ## 1.5.0
 
 ### Minor Changes

--- a/packages/server/plugin-koa/package.json
+++ b/packages/server/plugin-koa/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.5.0",
+  "version": "1.5.1",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -42,7 +42,7 @@
   "dependencies": {
     "@babel/runtime": "^7.18.0",
     "@modern-js/adapter-helpers": "workspace:^1.3.0",
-    "@modern-js/bff-core": "workspace:^1.1.2",
+    "@modern-js/bff-core": "workspace:^1.1.3",
     "@modern-js/bff-runtime": "workspace:^1.3.0",
     "@modern-js/utils": "workspace:^1.7.12",
     "koa-body": "^4.2.0",

--- a/packages/solutions/module-tools/CHANGELOG.md
+++ b/packages/solutions/module-tools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/module-tools
 
+## 1.7.1
+
+### Patch Changes
+
+- b2f90f8: feat: add addRuntimeExports hooks for module-tools
+  feat: 为 module-tools 添加 addRuntimeExports 钩子
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.7.0",
+  "version": "1.7.1",
   "bin": {
     "modern": "./bin/modern.js"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2820,7 +2820,7 @@ importers:
     specifiers:
       '@babel/runtime': ^7.18.0
       '@modern-js/adapter-helpers': workspace:^1.3.0
-      '@modern-js/bff-core': workspace:^1.1.2
+      '@modern-js/bff-core': workspace:^1.1.3
       '@modern-js/bff-runtime': workspace:^1.3.0
       '@modern-js/core': workspace:*
       '@modern-js/server-core': workspace:*
@@ -2883,7 +2883,7 @@ importers:
     specifiers:
       '@babel/runtime': ^7.18.0
       '@modern-js/adapter-helpers': workspace:^1.3.0
-      '@modern-js/bff-core': workspace:^1.1.2
+      '@modern-js/bff-core': workspace:^1.1.3
       '@modern-js/bff-runtime': workspace:^1.3.0
       '@modern-js/core': workspace:*
       '@modern-js/server-core': workspace:*


### PR DESCRIPTION

# Release v1.6.4



## Features:

- [#1388](https://github.com/modern-js-dev/modern.js/pull/1388) 

  chore(testing): merge `@modern-js/testing-plugin-bff` to `@modern-js/plugin-testing`

  chore(testing): 合并 `@modern-js/testing-plugin-bff` 到 `@modern-js/plugin-testing`

- [#1388](https://github.com/modern-js-dev/modern.js/pull/1388) 

  chore(testing): delete `@modern-js/bff-utils`

  chore(testing): 删除 `@modern-js/bff-utils`

- [#1388](https://github.com/modern-js-dev/modern.js/pull/1388) 

  chore(testing): merge `@modern-js/testing` to `@modern-js/plugin-testing`

  chore(testing): 合并 `@modern-js/testing` 到 `@modern-js/plugin-testing`

- [#1389](https://github.com/modern-js-dev/modern.js/pull/1389) 

  feat: add addRuntimeExports hooks for module-tools

  feat: 为 module-tools 添加 addRuntimeExports 钩子

## Bug Fix:

- [#1383](https://github.com/modern-js-dev/modern.js/pull/1383) 

  fix: the `<title>` tag in html template will replace by empty content, when deveploper open ssr.

  fix: 当开启SSR时，html 中的 `<title>` 标签将被空白内容替换。

- [#1386](https://github.com/modern-js-dev/modern.js/pull/1386) 

  fix: fix bff hot reload not works when has app.ts

  fix: 修复有 app.ts 的时候， bff 热更新不生效的问题

- [#1386](https://github.com/modern-js-dev/modern.js/pull/1386) 

  fix: export http status

  fix: 暴露 http 状态码

