### PR TITLE
fix: the SERVER_DATA inject twice

### DIFF
--- a/.changeset/moody-tomatoes-wonder.md
+++ b/.changeset/moody-tomatoes-wonder.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix: the \_SERVER_DATA injection twice causes the prod-server route error.
+fix: \_SERVER_DATA 二次注入，导致服务器路由错误

--- a/packages/server/prod-server/src/server/modern-server.ts
+++ b/packages/server/prod-server/src/server/modern-server.ts
@@ -454,7 +454,11 @@ export class ModernServer implements ModernServerInterface {
       const templateAPI = createTemplateAPI(file.content.toString());
       await this.emitRouteHook('afterRender', { context, templateAPI });
       await this.injectMicroFE(context, templateAPI);
-      templateAPI.appendHead(
+      // It will inject _SERVER_DATA twice, when SSG mode.
+      // The first time was in ssg html created, the seoncd time was in prod-server start.
+      // but the second wound causes route error.
+      // To ensure that the second injection fails, the _SERVER_DATA inject at the front of head,
+      templateAPI.prependHead(
         `<script>window._SERVER_DATA=${JSON.stringify(
           context.serverData,
         )}</script>`,


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
_SERVER_DATA 二次注入，导致服务器路由错误

## Description

<!--- Describe your changes in detail -->
packages/server/prod-server/src/server/modern-server.ts

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
