### PR TITLE
fix(core): should keep single function value after merge config

### DIFF
--- a/.changeset/lovely-oranges-impress.md
+++ b/.changeset/lovely-oranges-impress.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/core': patch
+---
+
+fix(core): should keep single function value after merge config
+
+fix(core): 修复合并配置后，函数类型的配置项变成数组类型的问题

--- a/packages/cli/core/src/config/mergeConfig.ts
+++ b/packages/cli/core/src/config/mergeConfig.ts
@@ -80,10 +80,16 @@ export const mergeConfig = (
       if (Array.isArray(source)) {
         return [...target, ...source];
       } else {
-        return typeof source !== 'undefined' ? [...target, source] : target;
+        return source !== undefined ? [...target, source] : target;
       }
-    } else if (isFunction(source)) {
-      return typeof target !== 'undefined' ? [target, source] : [source];
+    } else if (isFunction(target) || isFunction(source)) {
+      if (source === undefined) {
+        return target;
+      }
+      if (target === undefined) {
+        return source;
+      }
+      return [target, source];
     }
 
     return undefined;

--- a/packages/cli/core/tests/mergeConfig.test.ts
+++ b/packages/cli/core/tests/mergeConfig.test.ts
@@ -50,8 +50,8 @@ describe('merge config', () => {
         app: './App.tsx',
       },
     });
-    expect(Array.isArray(config.tools.webpack)).toBe(true);
-    expect((config.tools.webpack as WebpackConfig[]).length).toBe(1);
+    expect(Array.isArray(config.tools.webpack)).toBe(false);
+    expect(typeof (config.tools.webpack as WebpackConfig[])).toBe('function');
   });
 
   test(`should merge array value`, () => {
@@ -77,6 +77,14 @@ describe('merge config', () => {
         },
       },
     });
+  });
+
+  test(`should keep single function value`, () => {
+    const config = mergeConfig([
+      { tools: { webpack: undefined } },
+      { tools: { webpack: () => ({}) } },
+    ]);
+    expect(typeof config.tools.webpack).toEqual('function');
   });
 
   test(`should merge function and object value`, () => {


### PR DESCRIPTION
# PR Details

## Description

The `mergeConfig` function should keep single function value after merge config.

This bug will breaks PostCSS plugins like this:

```ts
export default defineConfig({
  tools: {
    postcss: {
      postcssOptions: {
        plugins: [require('autoprefixer')({ foo: 'bar' })],
      },
    },
  },
});
```
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
