### PR TITLE
feat: support package in load config

### DIFF
--- a/.changeset/angry-poems-rest.md
+++ b/.changeset/angry-poems-rest.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/core': patch
+'@modern-js/node-bundle-require': patch
+---
+
+support package in load config

--- a/packages/cli/core/src/load-configs/index.ts
+++ b/packages/cli/core/src/load-configs/index.ts
@@ -91,6 +91,7 @@ const bundleRequireWithCatch = async (
   try {
     const mod = await bundleRequire(configFile, {
       autoClear: false,
+      root: appDirectory,
       getOutputFile: async (filePath: string) => {
         const defaultOutputFileName = path.basename(
           await defaultGetOutputFile(filePath),

--- a/packages/toolkit/node-bundle-require/src/bundle.ts
+++ b/packages/toolkit/node-bundle-require/src/bundle.ts
@@ -43,6 +43,11 @@ export interface Options {
    * auto clear bundle file
    */
   autoClear?: boolean;
+
+  /**
+   * root path
+   */
+  root: string;
 }
 
 export const defaultGetOutputFile = async (filepath: string) =>
@@ -140,6 +145,14 @@ export async function bundle(filepath: string, options?: Options) {
         setup(_build) {
           _build.onResolve({ filter: EXTERNAL_REGEXP }, args => {
             let external = true;
+            const root = options?.root ?? path.dirname(filepath);
+            const realPath = require.resolve(args.path, {
+              paths: [args.importer || root],
+            });
+            // if the real path is a package, don't external
+            if (!realPath.includes('node_modules/')) {
+              external = false;
+            }
             // FIXME: windows external entrypoint
             if (args.kind === 'entry-point') {
               external = false;


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

When i load modern config, if it imports some other packages, it will cause error because package will be external. This PR is to support package, and only external node_modules
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
support package in load config

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
it can be tested in  @modern-js/node-bundle-require

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
