### PR TITLE
fix: missing devServer.proxy.cookieDomainRewrite type

### DIFF
--- a/.changeset/serious-bulldogs-watch.md
+++ b/.changeset/serious-bulldogs-watch.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/types': patch
+---
+
+fix: missing devServer.proxy.cookieDomainRewrite type
+
+fix: 修复 devServer.proxy.cookieDomainRewrite 类型缺失的问题

--- a/packages/toolkit/types/server/utils.d.ts
+++ b/packages/toolkit/types/server/utils.d.ts
@@ -32,6 +32,8 @@ export type ProxyDetail = {
   ) => string | undefined | null | false;
   context?: string | string[];
   changeOrigin?: boolean;
+  /** Rewrites domain of set-cookie headers. */
+  cookieDomainRewrite?: false | string | Record<string, string>;
 };
 
 export type BffProxyOptions =


### PR DESCRIPTION
# PR Details

## Description

Fix missing devServer.proxy.cookieDomainRewrite type.

https://www.npmjs.com/package/http-proxy-middleware

![image](https://user-images.githubusercontent.com/7237365/182759034-5f6c9c50-9cf2-43c8-a38f-0513041c8f24.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
