### PR TITLE
fix(app-tools): should not modify entry when using disableDefaultEntries

### DIFF
--- a/.changeset/brave-olives-think.md
+++ b/.changeset/brave-olives-think.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix(app-tools): should not modify entry when using disableDefaultEntries
+
+fix(app-tools): 修复开启 disableDefaultEntries 后 entry 名称被修改的问题

--- a/packages/solutions/app-tools/src/analyze/getBundleEntry.ts
+++ b/packages/solutions/app-tools/src/analyze/getBundleEntry.ts
@@ -84,13 +84,15 @@ export const getBundleEntry = (
     });
   }
 
-  // find main entry point which server route is '/'.
-  const entriesDirAbs = ensureAbsolutePath(appDirectory, entriesDir!);
-  const found = defaults.find(
-    ({ entryName, entry }) =>
-      entryName === packageName || path.dirname(entry) === entriesDirAbs,
-  );
-  found && (found.entryName = MAIN_ENTRY_NAME);
+  if (!disableDefaultEntries) {
+    // find main entry point which server route is '/'.
+    const entriesDirAbs = ensureAbsolutePath(appDirectory, entriesDir!);
+    const found = defaults.find(
+      ({ entryName, entry }) =>
+        entryName === packageName || path.dirname(entry) === entriesDirAbs,
+    );
+    found && (found.entryName = MAIN_ENTRY_NAME);
+  }
 
   return defaults;
 };


### PR DESCRIPTION
# PR Details

## Description

Should not modify entry name when user want to custom entries, keep the logic same as jupiter v4.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
