### PR TITLE
feat(web-builder): add html.crossorigin option

### DIFF
--- a/.changeset/fluffy-tools-camp.md
+++ b/.changeset/fluffy-tools-camp.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/utils': patch
+---
+
+feat(utils): add html-cross-origin to CHAIN_ID
+
+feat(utils): CHAIN_ID 常量新增  html-cross-origin 值

--- a/packages/builder/web-builder/src/plugins/html.ts
+++ b/packages/builder/web-builder/src/plugins/html.ts
@@ -170,6 +170,17 @@ export const PluginHtml = (): BuilderPlugin => ({
             .use(HtmlWebpackPlugin, [finalOptions]);
         }),
       );
+
+      if (config.html?.crossorigin) {
+        const { HtmlCrossOriginPlugin } = await import(
+          '../webpackPlugins/HtmlCrossOriginPlugin'
+        );
+        chain
+          .plugin(CHAIN_ID.PLUGIN.HTML_CROSS_ORIGIN)
+          .use(HtmlCrossOriginPlugin, [
+            { crossOrigin: config.html.crossorigin },
+          ]);
+      }
     });
   },
 });

--- a/packages/builder/web-builder/src/types/config/html.ts
+++ b/packages/builder/web-builder/src/types/config/html.ts
@@ -1,6 +1,8 @@
 import type { MetaOptions } from '@modern-js/utils';
 import type { HTMLPluginOptions } from '../thirdParty';
 
+export type CrossOrigin = boolean | 'anonymous' | 'use-credentials';
+
 export interface HtmlConfig {
   meta?: MetaOptions;
   metaByEntries?: Record<string, MetaOptions>;
@@ -11,6 +13,7 @@ export interface HtmlConfig {
   favicon?: string;
   faviconByEntries?: Record<string, string | undefined>;
   mountId?: string;
+  crossorigin?: CrossOrigin;
   disableHtmlFolder?: boolean;
   templateParameters?: Record<string, unknown>;
   templateParametersByEntries?: Record<

--- a/packages/builder/web-builder/src/webpackPlugins/HtmlCrossOriginPlugin.ts
+++ b/packages/builder/web-builder/src/webpackPlugins/HtmlCrossOriginPlugin.ts
@@ -1,0 +1,45 @@
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import type { CrossOrigin } from '../types';
+import type { Compiler, WebpackPluginInstance } from 'webpack';
+
+type CrossOriginOptions = {
+  crossOrigin: CrossOrigin;
+};
+
+export class HtmlCrossOriginPlugin implements WebpackPluginInstance {
+  readonly name: string;
+
+  readonly crossOrigin: string | false;
+
+  constructor(options: CrossOriginOptions) {
+    const { crossOrigin } = options;
+    this.name = 'HtmlCrossOriginPlugin';
+    this.crossOrigin = crossOrigin === true ? 'anonymous' : crossOrigin;
+  }
+
+  apply(compiler: Compiler): void {
+    if (!this.crossOrigin) {
+      return;
+    }
+
+    compiler.hooks.compilation.tap(this.name, compilation => {
+      HtmlWebpackPlugin.getHooks(compilation).alterAssetTags.tapPromise(
+        this.name,
+        async alterAssetTags => {
+          const {
+            assetTags: { scripts, styles },
+          } = alterAssetTags;
+
+          scripts.forEach(
+            script => (script.attributes.crossorigin = this.crossOrigin),
+          );
+          styles.forEach(
+            style => (style.attributes.crossorigin = this.crossOrigin),
+          );
+
+          return alterAssetTags;
+        },
+      );
+    });
+  }
+}

--- a/packages/builder/web-builder/tests/plugins/html.test.ts
+++ b/packages/builder/web-builder/tests/plugins/html.test.ts
@@ -2,6 +2,7 @@ import { expect, describe, it } from 'vitest';
 import { PluginHtml } from '../../src/plugins/html';
 import { PluginEntry } from '../../src/plugins/entry';
 import { createStubBuilder } from '../utils/builder';
+import { isPluginRegistered } from '../utils/webpack';
 
 describe('plugins/html', () => {
   it('should register html plugin correctly', async () => {
@@ -13,7 +14,25 @@ describe('plugins/html', () => {
     });
     const config = await builder.unwrapWebpackConfig();
 
+    expect(isPluginRegistered(config, 'HtmlWebpackPlugin')).toBeTruthy();
     expect(config).toMatchSnapshot();
+  });
+
+  it('should register crossorigin plugin when using html.crossorigin', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginEntry(), PluginHtml()],
+      entry: {
+        main: './src/main.ts',
+      },
+      builderConfig: {
+        html: {
+          crossorigin: true,
+        },
+      },
+    });
+
+    const config = await builder.unwrapWebpackConfig();
+    expect(isPluginRegistered(config, 'HtmlCrossOriginPlugin')).toBeTruthy();
   });
 
   it('should allow to set favicon by html.favicon option', async () => {

--- a/packages/toolkit/utils/src/chainId.ts
+++ b/packages/toolkit/utils/src/chainId.ts
@@ -109,6 +109,8 @@ export const CHAIN_ID = {
     BUNDLE_ANALYZER: 'bundle-analyze',
     /** BottomTemplatePlugin */
     BOTTOM_TEMPLATE: 'bottom-template',
+    /** HtmlCrossOriginPlugin */
+    HTML_CROSS_ORIGIN: 'html-cross-origin',
     /** MiniCssExtractPlugin */
     MINI_CSS_EXTRACT: 'mini-css-extract',
     /** ReactFastRefreshPlugin */


### PR DESCRIPTION
# PR Details

## Description

Add `html.crossorigin` option to web builder.

This option is used to inject the `crossorigin` attribute into the `<script>` resource tag, passing in true will enable the default value of anonymous.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
