### PR TITLE
feat(web-builder): support html.appIcon config

### DIFF
--- a/packages/builder/web-builder/src/plugins/html.ts
+++ b/packages/builder/web-builder/src/plugins/html.ts
@@ -171,15 +171,31 @@ export const PluginHtml = (): BuilderPlugin => ({
         }),
       );
 
-      if (config.html?.crossorigin) {
-        const { HtmlCrossOriginPlugin } = await import(
-          '../webpackPlugins/HtmlCrossOriginPlugin'
-        );
-        chain
-          .plugin(CHAIN_ID.PLUGIN.HTML_CROSS_ORIGIN)
-          .use(HtmlCrossOriginPlugin, [
-            { crossOrigin: config.html.crossorigin },
-          ]);
+      if (config.html) {
+        const { appIcon, crossorigin } = config.html;
+
+        if (crossorigin) {
+          const { HtmlCrossOriginPlugin } = await import(
+            '../webpackPlugins/HtmlCrossOriginPlugin'
+          );
+          chain
+            .plugin(CHAIN_ID.PLUGIN.HTML_CROSS_ORIGIN)
+            .use(HtmlCrossOriginPlugin, [{ crossOrigin: crossorigin }]);
+        }
+
+        if (appIcon) {
+          const { HtmlAppIconPlugin } = await import(
+            '../webpackPlugins/HtmlAppIconPlugin'
+          );
+
+          const iconPath = path.isAbsolute(appIcon)
+            ? appIcon
+            : path.join(api.context.rootPath, appIcon);
+
+          chain
+            .plugin(CHAIN_ID.PLUGIN.APP_ICON)
+            .use(HtmlAppIconPlugin, [{ iconPath }]);
+        }
       }
     });
   },

--- a/packages/builder/web-builder/src/types/config/html.ts
+++ b/packages/builder/web-builder/src/types/config/html.ts
@@ -12,6 +12,7 @@ export interface HtmlConfig {
   injectByEntries?: Record<string, HTMLPluginOptions['inject']>;
   favicon?: string;
   faviconByEntries?: Record<string, string | undefined>;
+  appIcon?: string;
   mountId?: string;
   crossorigin?: CrossOrigin;
   disableHtmlFolder?: boolean;

--- a/packages/builder/web-builder/src/webpackPlugins/HtmlAppIconPlugin.ts
+++ b/packages/builder/web-builder/src/webpackPlugins/HtmlAppIconPlugin.ts
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import path from 'path';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import { Compiler, Compilation, sources } from 'webpack';
+
+type AppIconOptions = {
+  iconPath: string;
+};
+
+export class HtmlAppIconPlugin {
+  readonly name: string;
+
+  readonly iconPath: string;
+
+  constructor(options: AppIconOptions) {
+    this.name = 'HtmlAppIconPlugin';
+    this.iconPath = options.iconPath;
+  }
+
+  apply(compiler: Compiler) {
+    const iconName = path.basename(this.iconPath);
+
+    if (!fs.existsSync(this.iconPath)) {
+      throw new Error(
+        `[${this.name}] Can not find the app icon, please check if the '${this.iconPath}' file exists'.`,
+      );
+    }
+
+    // add html asset tags
+    compiler.hooks.compilation.tap(this.name, (compilation: Compilation) => {
+      HtmlWebpackPlugin.getHooks(compilation).alterAssetTagGroups.tap(
+        this.name,
+        data => {
+          const { publicPath } = compiler.options.output;
+
+          data.headTags.unshift({
+            tagName: 'link',
+            voidTag: true,
+            attributes: {
+              rel: 'apple-touch-icon',
+              sizes: '180*180',
+              href: `${publicPath as string}${iconName}`,
+            },
+            meta: {},
+          });
+
+          return data;
+        },
+      );
+    });
+
+    // copy icon to dist
+    compiler.hooks.thisCompilation.tap(
+      this.name,
+      (compilation: Compilation) => {
+        compilation.hooks.processAssets.tap(
+          {
+            name: this.name,
+            stage: Compilation.PROCESS_ASSETS_STAGE_PRE_PROCESS,
+          },
+          assets => {
+            const source = fs.readFileSync(this.iconPath);
+            assets[iconName] = new sources.RawSource(source, false);
+          },
+        );
+      },
+    );
+  }
+}

--- a/packages/builder/web-builder/tests/plugins/html.test.ts
+++ b/packages/builder/web-builder/tests/plugins/html.test.ts
@@ -35,6 +35,23 @@ describe('plugins/html', () => {
     expect(isPluginRegistered(config, 'HtmlCrossOriginPlugin')).toBeTruthy();
   });
 
+  it('should register appIcon plugin when using html.appIcon', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginEntry(), PluginHtml()],
+      entry: {
+        main: './src/main.ts',
+      },
+      builderConfig: {
+        html: {
+          appIcon: './src/assets/icon.png',
+        },
+      },
+    });
+
+    const config = await builder.unwrapWebpackConfig();
+    expect(isPluginRegistered(config, 'HtmlAppIconPlugin')).toBeTruthy();
+  });
+
   it('should allow to set favicon by html.favicon option', async () => {
     const builder = createStubBuilder({
       plugins: [PluginEntry(), PluginHtml()],


### PR DESCRIPTION
# PR Details

## Description

Support `html.appIcon` config in web builder, the HtmlAppIconPlugin is modified from [@modern-js/webpack/plugins/app-icon-plugin.ts](https://github.com/modern-js-dev/modern.js/blob/main/packages/cli/webpack/src/plugins/app-icon-plugin.ts).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
