### PR TITLE
chore(web-builder): add type utils to improve tools typing

### DIFF
--- a/packages/builder/web-builder/src/types/config/source.ts
+++ b/packages/builder/web-builder/src/types/config/source.ts
@@ -1,8 +1,8 @@
-import type { JSONValue } from '../utils';
+import type { ChainedConfig, JSONValue } from '../utils';
 import type { WebpackAlias } from '../thirdParty';
 
 export interface SourceConfig {
-  alias?: WebpackAlias | ((alias: WebpackAlias) => WebpackAlias | void);
+  alias?: ChainedConfig<WebpackAlias>;
   preEntry?: string | string[];
   globalVars?: Record<string, JSONValue>;
   resolveExtensionPrefix?: string;

--- a/packages/builder/web-builder/src/types/config/tools.ts
+++ b/packages/builder/web-builder/src/types/config/tools.ts
@@ -16,107 +16,82 @@ import type {
   SassLoaderOptions,
   HTMLPluginOptions,
 } from '../thirdParty';
+import type { ChainedConfig } from '../utils';
 
-export type ToolsTerserConfig =
-  | TerserPluginOptions
-  | ((options: TerserPluginOptions) => TerserPluginOptions | void);
+export type ToolsTerserConfig = ChainedConfig<TerserPluginOptions>;
 
-export type ToolsMinifyCssConfig =
-  | CssMinimizerPluginOptions
-  | ((options: CssMinimizerPluginOptions) => CssMinimizerPluginOptions | void);
+export type ToolsMinifyCssConfig = ChainedConfig<CssMinimizerPluginOptions>;
 
-export type ToolsBabelConfig =
-  | BabelTransformOptions
-  | ((
-      options: BabelTransformOptions,
-      utils: BabelConfigUtils,
-    ) => BabelTransformOptions);
+export type ToolsBabelConfig = ChainedConfig<
+  BabelTransformOptions,
+  BabelConfigUtils
+>;
 
-export type ToolsTSLoaderOptions =
-  | TSLoaderOptions
-  | ((
-      options: TSLoaderOptions,
-      utils: {
-        addIncludes: (items: string | RegExp | (string | RegExp)[]) => void;
-        addExcludes: (items: string | RegExp | (string | RegExp)[]) => void;
-      },
-    ) => TSLoaderOptions | void);
+export type ToolsTSLoaderConfig = ChainedConfig<
+  TSLoaderOptions,
+  {
+    addIncludes: (items: string | RegExp | (string | RegExp)[]) => void;
+    addExcludes: (items: string | RegExp | (string | RegExp)[]) => void;
+  }
+>;
 
-export type ToolsForkTSCheckerConfig =
-  | ForkTSCheckerOptions
-  | ((options: ForkTSCheckerOptions) => ForkTSCheckerOptions | void);
+export type ToolsStyledComponentConfig = ChainedConfig<IStyledComponentOptions>;
 
-export type ToolsStyledComponentConfig =
-  | IStyledComponentOptions
-  | ((options: IStyledComponentOptions) => IStyledComponentOptions | void);
+export type ToolsCSSLoaderConfig = ChainedConfig<CSSLoaderOptions>;
 
-export type ToolsCSSLoaderConfig =
-  | CSSLoaderOptions
-  | ((options: CSSLoaderOptions) => CSSLoaderOptions | void);
-
-export type ToolsStyleLoaderConfig =
-  | StyleLoaderOptions
-  | ((options: StyleLoaderOptions) => StyleLoaderOptions | void);
+export type ToolsStyleLoaderConfig = ChainedConfig<StyleLoaderOptions>;
 
 export type ToolsCssExtractConfig =
   | CssExtractOptions
   | ((options: CssExtractOptions) => CssExtractOptions | void);
 
-export type ToolsAutoprefixerConfig =
-  | AutoprefixerOptions
-  | ((options: AutoprefixerOptions) => AutoprefixerOptions | void);
+export type ToolsAutoprefixerConfig = ChainedConfig<AutoprefixerOptions>;
 
-export type ToolsPostCSSLoaderConfig =
-  | PostCSSLoaderOptions
-  | ((
-      options: PostCSSLoaderOptions,
-      utils: {
-        addPlugins: (plugins: PostCSSPlugin | PostCSSPlugin[]) => void;
-      },
-    ) => PostCSSLoaderOptions | void);
+export type ToolsPostCSSLoaderConfig = ChainedConfig<
+  PostCSSLoaderOptions,
+  {
+    addPlugins: (plugins: PostCSSPlugin | PostCSSPlugin[]) => void;
+  }
+>;
 
-export type ToolsLessConfig =
-  | LessLoaderOptions
-  | ((
-      options: LessLoaderOptions,
-      utils: { addExcludes: (excludes: RegExp | RegExp[]) => void },
-    ) => LessLoaderOptions | void);
+export type ToolsLessConfig = ChainedConfig<
+  LessLoaderOptions,
+  { addExcludes: (excludes: RegExp | RegExp[]) => void }
+>;
 
-export type ToolsSassConfig =
-  | SassLoaderOptions
-  | ((
-      options: SassLoaderOptions,
-      utils: { addExcludes: (excludes: RegExp | RegExp[]) => void },
-    ) => SassLoaderOptions | void);
+export type ToolsSassConfig = ChainedConfig<
+  SassLoaderOptions,
+  { addExcludes: (excludes: RegExp | RegExp[]) => void }
+>;
 
-export type HtmlPluginConfig =
-  | HTMLPluginOptions
-  | ((
-      options: HTMLPluginOptions,
-      utils: {
-        entryName: string;
-        entryValue: string[];
-      },
-    ) => HTMLPluginOptions | void);
+export type ToolsTSCheckerConfig = ChainedConfig<ForkTSCheckerOptions>;
+
+export type ToolsHtmlPluginConfig = ChainedConfig<
+  HTMLPluginOptions,
+  {
+    entryName: string;
+    entryValue: string[];
+  }
+>;
 
 export type DevServerConfig = {
   hot?: boolean;
 };
 
 export interface ToolsConfig {
-  sass?: SassLoaderOptions;
-  less?: LessLoaderOptions;
+  sass?: ToolsSassConfig;
+  less?: ToolsLessConfig;
   babel?: ToolsBabelConfig;
   terser?: ToolsTerserConfig;
-  tsLoader?: ToolsTSLoaderOptions;
-  tsChecker?: false | ForkTSCheckerOptions;
+  tsLoader?: ToolsTSLoaderConfig;
+  tsChecker?: false | ToolsTSCheckerConfig;
   devServer?: DevServerConfig;
   minifyCss?: ToolsMinifyCssConfig;
-  htmlPlugin?: HtmlPluginConfig;
-  styledComponents?: IStyledComponentOptions;
-  cssLoader?: CSSLoaderOptions;
-  styleLoader?: StyleLoaderOptions;
+  htmlPlugin?: ToolsHtmlPluginConfig;
+  styledComponents?: ToolsStyledComponentConfig;
+  cssLoader?: ToolsCSSLoaderConfig;
+  styleLoader?: ToolsStyleLoaderConfig;
   cssExtract?: CssExtractOptions;
-  postcss?: PostCSSLoaderOptions;
-  autoprefixer?: AutoprefixerOptions;
+  postcss?: ToolsPostCSSLoaderConfig;
+  autoprefixer?: ToolsAutoprefixerConfig;
 }

--- a/packages/builder/web-builder/src/types/utils.ts
+++ b/packages/builder/web-builder/src/types/utils.ts
@@ -5,3 +5,11 @@ export type JSONArray = Array<JSONValue>;
 export type JSONObject = { [key: string]: JSONValue };
 
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
+
+export type ArrayOrNot<T> = T | T[];
+
+export type ChainedConfig<Config, Utils = unknown> = ArrayOrNot<
+  Config | keyof Utils extends never
+    ? (config: Config) => Config | void
+    : (config: Config, utils: Utils) => Config | void
+>;


### PR DESCRIPTION
# PR Details

## Description

Added a `ChainedConfig` utils type to improve `tools.xxx` typing.

The `tools.xxx` can be `Object` `Function` or `Array`:

- Object: such as `{ foo: 1  }`
- Function: such as `(config) => { config.foo = 2; }`
- Array: A group of objects and functions, such as `[{ foo: 1 }, (config) => { config.foo = 2; }]`, this is useful for the framework to merge several configs and passing to the web builder.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
