### PR TITLE
fix: compatibility issues of dev server in iOS 10

### DIFF
--- a/.changeset/quiet-horses-rhyme.md
+++ b/.changeset/quiet-horses-rhyme.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/prod-server': patch
+'@modern-js/utils': patch
+---
+
+fix: compatibility issues of dev server in iOS 10
+
+fix: 修复 dev server 代码在 iOS 10 下的兼容性问题

--- a/packages/server/prod-server/tests/format.test.ts
+++ b/packages/server/prod-server/tests/format.test.ts
@@ -1,4 +1,4 @@
-import { formatProxyOptions } from '../src/format';
+import { formatProxyOptions } from '../src/libs/proxy';
 
 describe('test format', () => {
   it('should format correctly use simply options', async () => {

--- a/packages/toolkit/utils/src/format.ts
+++ b/packages/toolkit/utils/src/format.ts
@@ -10,7 +10,6 @@
 
 import type webpack from 'webpack';
 import type { StatsCompilation } from 'webpack';
-import type { ProxyDetail, BffProxyOptions } from '@modern-js/types';
 
 const friendlySyntaxErrorLabel = 'SyntaxError:';
 
@@ -123,40 +122,3 @@ function formatWebpackMessages(json: StatsCompilation): {
 }
 
 export { formatWebpackMessages };
-
-function formatProxyOptions(proxyOptions: BffProxyOptions) {
-  const formattedProxy: ProxyDetail[] = [];
-
-  if (!Array.isArray(proxyOptions)) {
-    if ('target' in proxyOptions) {
-      formattedProxy.push(proxyOptions);
-    } else {
-      Array.prototype.push.apply(
-        formattedProxy,
-        Object.keys(proxyOptions).reduce(
-          (total: ProxyDetail[], source: string) => {
-            const option = (
-              proxyOptions as
-                | Record<string, string>
-                | Record<string, ProxyDetail>
-            )[source];
-
-            total.push({
-              context: source,
-              changeOrigin: true,
-              logLevel: 'warn',
-              ...(typeof option === 'string' ? { target: option } : option),
-            });
-            return total;
-          },
-          [],
-        ),
-      );
-    }
-  } else {
-    formattedProxy.push(...proxyOptions);
-  }
-  return formattedProxy;
-}
-
-export { formatProxyOptions };


### PR DESCRIPTION
# PR Details

## Description

The `formatProxyOptions` method is only used in server codes, so we can move it to `prod-server` to fix the compatibility issues in iOS 10.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
