### PR TITLE
feat(builder): allow set dataUriLimit by file type

### DIFF
--- a/packages/builder/webpack-builder/src/plugins/font.ts
+++ b/packages/builder/webpack-builder/src/plugins/font.ts
@@ -24,7 +24,7 @@ export const PluginFont = (): BuilderPlugin => ({
         // @ts-expect-error webpack-chain has incorrect type for `rule.type`
         .type('asset')
         .parser({
-          dataUrlCondition: getDataUrlCondition(config.output?.dataUriLimit),
+          dataUrlCondition: getDataUrlCondition(config, 'font'),
         })
         .set('generator', {
           filename: join(distDir, filename),

--- a/packages/builder/webpack-builder/src/plugins/image.ts
+++ b/packages/builder/webpack-builder/src/plugins/image.ts
@@ -24,7 +24,7 @@ export const PluginImage = (): BuilderPlugin => ({
         // @ts-expect-error webpack-chain has incorrect type for `rule.type`
         .type('asset')
         .parser({
-          dataUrlCondition: getDataUrlCondition(config.output?.dataUriLimit),
+          dataUrlCondition: getDataUrlCondition(config, 'image'),
         })
         .set('generator', {
           filename: join(distDir, filename),

--- a/packages/builder/webpack-builder/src/plugins/media.ts
+++ b/packages/builder/webpack-builder/src/plugins/media.ts
@@ -25,7 +25,7 @@ export const PluginMedia = (): BuilderPlugin => ({
         // @ts-expect-error webpack-chain has incorrect type for `rule.type`
         .type('asset')
         .parser({
-          dataUrlCondition: getDataUrlCondition(config.output?.dataUriLimit),
+          dataUrlCondition: getDataUrlCondition(config, 'media'),
         })
         .set('generator', {
           filename: join(distDir, filename),

--- a/packages/builder/webpack-builder/src/plugins/svg.ts
+++ b/packages/builder/webpack-builder/src/plugins/svg.ts
@@ -1,5 +1,5 @@
-import { JS_REGEX, SVG_REGEX, TS_REGEX } from '../shared';
-import { BuilderPlugin } from '../types';
+import { getDataUrlLimit, JS_REGEX, SVG_REGEX, TS_REGEX } from '../shared';
+import type { BuilderPlugin } from '../types';
 
 export const PluginSvg = (): BuilderPlugin => {
   return {
@@ -58,7 +58,7 @@ export const PluginSvg = (): BuilderPlugin => {
               .use(CHAIN_ID.USE.URL)
               .loader(getCompiledPath('url-loader'))
               .options({
-                limit: config.output?.dataUriLimit || 4096,
+                limit: getDataUrlLimit(config, 'svg'),
                 name: `assets/[name].[contenthash:8].[ext]`,
               }),
           );

--- a/packages/builder/webpack-builder/src/shared/fs.ts
+++ b/packages/builder/webpack-builder/src/shared/fs.ts
@@ -30,21 +30,21 @@ export const getDistPath = (
 
   switch (type) {
     case 'js':
-      return distPath.js || JS_DIST_DIR;
+      return distPath.js ?? JS_DIST_DIR;
     case 'css':
-      return distPath.css || CSS_DIST_DIR;
+      return distPath.css ?? CSS_DIST_DIR;
     case 'svg':
-      return distPath.svg || SVG_DIST_DIR;
+      return distPath.svg ?? SVG_DIST_DIR;
     case 'font':
-      return distPath.font || FONT_DIST_DIR;
+      return distPath.font ?? FONT_DIST_DIR;
     case 'html':
-      return distPath.html || HTML_DIST_DIR;
+      return distPath.html ?? HTML_DIST_DIR;
     case 'media':
-      return distPath.media || MEDIA_DIST_DIR;
+      return distPath.media ?? MEDIA_DIST_DIR;
     case 'root':
-      return distPath.root || ROOT_DIST_DIR;
+      return distPath.root ?? ROOT_DIST_DIR;
     case 'image':
-      return distPath.image || IMAGE_DIST_DIR;
+      return distPath.image ?? IMAGE_DIST_DIR;
     default:
       throw new Error(`unknown key ${type} in "output.distPath"`);
   }
@@ -61,17 +61,17 @@ export const getFilename = (
 
   switch (type) {
     case 'js':
-      return filename.js || `[name]${hash}.js`;
+      return filename.js ?? `[name]${hash}.js`;
     case 'css':
-      return filename.css || `[name]${hash}.css`;
+      return filename.css ?? `[name]${hash}.css`;
     case 'svg':
-      return filename.svg || `[name]${hash}.[ext]`;
+      return filename.svg ?? `[name]${hash}.[ext]`;
     case 'font':
-      return filename.font || `[name]${hash}[ext]`;
+      return filename.font ?? `[name]${hash}[ext]`;
     case 'image':
-      return filename.image || `[name]${hash}[ext]`;
+      return filename.image ?? `[name]${hash}[ext]`;
     case 'media':
-      return filename.media || `[name]${hash}[ext]`;
+      return filename.media ?? `[name]${hash}[ext]`;
     default:
       throw new Error(`unknown key ${type} in "output.filename"`);
   }

--- a/packages/builder/webpack-builder/src/types/config/output.ts
+++ b/packages/builder/webpack-builder/src/types/config/output.ts
@@ -20,6 +20,13 @@ export type FilenameConfig = {
   media?: string;
 };
 
+export type DataUriLimit = {
+  svg?: number;
+  font?: number;
+  image?: number;
+  media?: number;
+};
+
 export type Polyfill = 'usage' | 'entry' | 'ua' | 'off';
 
 export interface OutputConfig {
@@ -28,7 +35,7 @@ export interface OutputConfig {
   filename?: FilenameConfig;
   polyfill?: Polyfill;
   assetPrefix?: string;
-  dataUriLimit?: number;
+  dataUriLimit?: number | DataUriLimit;
   disableMinimize?: boolean;
   disableSourceMap?: boolean;
   disableFilenameHash?: boolean;

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/font.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/font.test.ts.snap
@@ -19,6 +19,25 @@ exports[`plugins/font > should add font rules correctly 1`] = `
 }
 `;
 
+exports[`plugins/font > should allow to use distPath.font to be empty string 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "generator": {
+          "filename": "[name][ext]",
+        },
+        "parser": {
+          "dataUrlCondition": [Function],
+        },
+        "test": /\\\\\\.\\(woff\\|woff2\\|eot\\|ttf\\|otf\\|ttc\\)\\$/i,
+        "type": "asset",
+      },
+    ],
+  },
+}
+`;
+
 exports[`plugins/font > should allow to use distPath.font to modify dist path 1`] = `
 {
   "module": {

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/image.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/image.test.ts.snap
@@ -19,6 +19,25 @@ exports[`plugins/image > should add image rules correctly 1`] = `
 }
 `;
 
+exports[`plugins/image > should allow to use distPath.image to be empty string 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "generator": {
+          "filename": "[name][ext]",
+        },
+        "parser": {
+          "dataUrlCondition": [Function],
+        },
+        "test": /\\\\\\.\\(png\\|jpg\\|jpeg\\|gif\\|bmp\\|webp\\|ico\\|apng\\|avif\\|tiff\\)\\$/i,
+        "type": "asset",
+      },
+    ],
+  },
+}
+`;
+
 exports[`plugins/image > should allow to use distPath.image to modify dist path 1`] = `
 {
   "module": {

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/media.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/media.test.ts.snap
@@ -19,6 +19,25 @@ exports[`plugins/media > should add media rules correctly 1`] = `
 }
 `;
 
+exports[`plugins/media > should allow to use distPath.media to be empty string 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "generator": {
+          "filename": "[name][ext]",
+        },
+        "parser": {
+          "dataUrlCondition": [Function],
+        },
+        "test": /\\\\\\.\\(mp4\\|webm\\|ogg\\|mp3\\|wav\\|flac\\|aac\\|mov\\)\\$/i,
+        "type": "asset",
+      },
+    ],
+  },
+}
+`;
+
 exports[`plugins/media > should allow to use distPath.media to modify dist path 1`] = `
 {
   "module": {

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/svg.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/svg.test.ts.snap
@@ -142,7 +142,87 @@ exports[`plugins/svg > export default url 1`] = `
           {
             "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
             "options": {
-              "limit": 4096,
+              "limit": 10000,
+              "name": "assets/[name].[contenthash:8].[ext]",
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`plugins/svg > should allow using output.dataUriLimit.svg to custom data uri limit 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "issuer": [
+          /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
+          /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        ],
+        "resourceQuery": /inline/,
+        "test": /\\\\\\.svg\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+            "options": {
+              "svgo": false,
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+            "options": {
+              "limit": Infinity,
+              "name": "assets/[name].[contenthash:8].[ext]",
+            },
+          },
+        ],
+      },
+      {
+        "issuer": [
+          /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
+          /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        ],
+        "resourceQuery": /url/,
+        "test": /\\\\\\.svg\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+            "options": {
+              "svgo": false,
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+            "options": {
+              "limit": false,
+              "name": "assets/[name].[contenthash:8].[ext]",
+            },
+          },
+        ],
+      },
+      {
+        "issuer": [
+          /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
+          /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        ],
+        "test": /\\\\\\.svg\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+            "options": {
+              "svgo": false,
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+            "options": {
+              "limit": 666,
               "name": "assets/[name].[contenthash:8].[ext]",
             },
           },

--- a/packages/builder/webpack-builder/tests/plugins/font.test.ts
+++ b/packages/builder/webpack-builder/tests/plugins/font.test.ts
@@ -7,8 +7,8 @@ describe('plugins/font', () => {
     const builder = createStubBuilder({
       plugins: [PluginFont()],
     });
-    const config = await builder.unwrapWebpackConfig();
 
+    const config = await builder.unwrapWebpackConfig();
     expect(config).toMatchSnapshot();
   });
 
@@ -19,6 +19,22 @@ describe('plugins/font', () => {
         output: {
           distPath: {
             font: 'foo',
+          },
+        },
+      },
+    });
+
+    const config = await builder.unwrapWebpackConfig();
+    expect(config).toMatchSnapshot();
+  });
+
+  it('should allow to use distPath.font to be empty string', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginFont()],
+      builderConfig: {
+        output: {
+          distPath: {
+            font: '',
           },
         },
       },

--- a/packages/builder/webpack-builder/tests/plugins/image.test.ts
+++ b/packages/builder/webpack-builder/tests/plugins/image.test.ts
@@ -28,6 +28,22 @@ describe('plugins/image', () => {
     expect(config).toMatchSnapshot();
   });
 
+  it('should allow to use distPath.image to be empty string', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginImage()],
+      builderConfig: {
+        output: {
+          distPath: {
+            image: '',
+          },
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
+
   it('should allow to use filename.image to modify filename', async () => {
     const builder = createStubBuilder({
       plugins: [PluginImage()],

--- a/packages/builder/webpack-builder/tests/plugins/media.test.ts
+++ b/packages/builder/webpack-builder/tests/plugins/media.test.ts
@@ -23,8 +23,24 @@ describe('plugins/media', () => {
         },
       },
     });
-    const config = await builder.unwrapWebpackConfig();
 
+    const config = await builder.unwrapWebpackConfig();
+    expect(config).toMatchSnapshot();
+  });
+
+  it('should allow to use distPath.media to be empty string', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginMedia()],
+      builderConfig: {
+        output: {
+          distPath: {
+            media: '',
+          },
+        },
+      },
+    });
+
+    const config = await builder.unwrapWebpackConfig();
     expect(config).toMatchSnapshot();
   });
 

--- a/packages/builder/webpack-builder/tests/plugins/svg.test.ts
+++ b/packages/builder/webpack-builder/tests/plugins/svg.test.ts
@@ -25,4 +25,20 @@ describe('plugins/svg', () => {
 
     expect(config).toMatchSnapshot();
   });
+
+  it('should allow using output.dataUriLimit.svg to custom data uri limit', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginSvg()],
+      builderConfig: {
+        output: {
+          dataUriLimit: {
+            svg: 666,
+          },
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
# PR Details

1. Allow set dataUriLimit by file type:

```js
export default {
  output: {
    dataUriLimit: {
      svg: 1024 * 5,
      font: 1024 * 20
    }
  }
}
```

2. Allow `output.distPath.xxx` to be empty string:

```js
export default {
  output: {
    distPath: {
      js: '',
      css: '',
    }
  }
}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
