### PR TITLE
feat(builder): support using svg as assets in CSS files

### DIFF
--- a/.changeset/shiny-wolves-work.md
+++ b/.changeset/shiny-wolves-work.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/utils': patch
+---
+
+feat(utils): add SVG_ASSET to CHAIN_ID
+
+feat(utils): CHAIN_ID 常量新增 SVG_ASSET 值

--- a/packages/builder/webpack-builder/package.json
+++ b/packages/builder/webpack-builder/package.json
@@ -41,9 +41,15 @@
   },
   "typesVersions": {
     "*": {
-      "webpack": ["./dist/exports/webpack.d.ts"],
-      "html-webpack-plugin": ["./dist/exports/HtmlWebpackPlugin.d.ts"],
-      "stub": ["./dist/stub/index.d.ts"]
+      "webpack": [
+        "./dist/exports/webpack.d.ts"
+      ],
+      "html-webpack-plugin": [
+        "./dist/exports/HtmlWebpackPlugin.d.ts"
+      ],
+      "stub": [
+        "./dist/stub/index.d.ts"
+      ]
     }
   },
   "scripts": {

--- a/packages/builder/webpack-builder/src/core/createBuilder.ts
+++ b/packages/builder/webpack-builder/src/core/createBuilder.ts
@@ -81,6 +81,7 @@ export async function createBuilder(options?: BuilderOptions) {
 
 async function addDefaultPlugins(pluginStore: PluginStore) {
   const { PluginHMR } = await import('../plugins/hmr');
+  const { PluginSvg } = await import('../plugins/svg');
   const { PluginPug } = await import('../plugins/pug');
   const { PluginCopy } = await import('../plugins/copy');
   const { PluginFont } = await import('../plugins/font');
@@ -126,6 +127,7 @@ async function addDefaultPlugins(pluginStore: PluginStore) {
 
     // Plugins that provide basic features
     PluginHMR(),
+    PluginSvg(),
     PluginPug(),
     PluginCopy(),
     PluginFont(),

--- a/packages/builder/webpack-builder/src/index.ts
+++ b/packages/builder/webpack-builder/src/index.ts
@@ -1,11 +1,31 @@
 export { createBuilder } from './core/createBuilder';
 
-// Types
 export type {
-  WebpackChain,
-  WebpackConfig,
-  BuilderConfig,
+  // Plugin Types
   BuilderPlugin,
   BuilderContext,
   BuilderPluginAPI,
+
+  // Config Types
+  DevConfig,
+  HtmlConfig,
+  OutputConfig,
+  SourceConfig,
+  BuilderConfig,
+  SecurityConfig,
+  PerformanceConfig,
+  ExperimentsConfig,
+
+  // Third Party Types
+  WebpackChain,
+  WebpackConfig,
+  CSSLoaderOptions,
+  CssExtractOptions,
+  LessLoaderOptions,
+  SassLoaderOptions,
+  HTMLPluginOptions,
+  StyleLoaderOptions,
+  AutoprefixerOptions,
+  TerserPluginOptions,
+  PostCSSLoaderOptions,
 } from './types';

--- a/packages/builder/webpack-builder/src/shared/fs.ts
+++ b/packages/builder/webpack-builder/src/shared/fs.ts
@@ -65,7 +65,7 @@ export const getFilename = (
     case 'css':
       return filename.css ?? `[name]${hash}.css`;
     case 'svg':
-      return filename.svg ?? `[name]${hash}.[ext]`;
+      return filename.svg ?? `[name]${hash}.svg`;
     case 'font':
       return filename.font ?? `[name]${hash}[ext]`;
     case 'image':

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/svg.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/svg.test.ts.snap
@@ -5,68 +5,73 @@ exports[`plugins/svg > export default Component 1`] = `
   "module": {
     "rules": [
       {
-        "issuer": [
-          /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
-          /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        "oneOf": [
+          {
+            "generator": {
+              "filename": "static/svg/[name].svg",
+            },
+            "issuer": {
+              "not": [
+                /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
+                /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+              ],
+            },
+            "parser": {
+              "dataUrlCondition": [Function],
+            },
+            "type": "asset",
+          },
+          {
+            "resourceQuery": /inline/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": Infinity,
+                  "name": "static/svg/[name].svg",
+                },
+              },
+            ],
+          },
+          {
+            "resourceQuery": /url/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": false,
+                  "name": "static/svg/[name].svg",
+                },
+              },
+            ],
+          },
+          {
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+            ],
+          },
         ],
-        "resourceQuery": /inline/,
         "test": /\\\\\\.svg\\$/,
-        "type": "javascript/auto",
-        "use": [
-          {
-            "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
-            "options": {
-              "svgo": false,
-            },
-          },
-          {
-            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
-            "options": {
-              "limit": Infinity,
-              "name": "assets/[name].[contenthash:8].[ext]",
-            },
-          },
-        ],
-      },
-      {
-        "issuer": [
-          /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
-          /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
-        ],
-        "resourceQuery": /url/,
-        "test": /\\\\\\.svg\\$/,
-        "type": "javascript/auto",
-        "use": [
-          {
-            "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
-            "options": {
-              "svgo": false,
-            },
-          },
-          {
-            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
-            "options": {
-              "limit": false,
-              "name": "assets/[name].[contenthash:8].[ext]",
-            },
-          },
-        ],
-      },
-      {
-        "issuer": [
-          /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
-          /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
-        ],
-        "test": /\\\\\\.svg\\$/,
-        "type": "javascript/auto",
-        "use": [
-          {
-            "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
-            "options": {
-              "svgo": false,
-            },
-          },
-        ],
       },
     ],
   },
@@ -78,75 +83,250 @@ exports[`plugins/svg > export default url 1`] = `
   "module": {
     "rules": [
       {
-        "issuer": [
-          /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
-          /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        "oneOf": [
+          {
+            "generator": {
+              "filename": "static/svg/[name].svg",
+            },
+            "issuer": {
+              "not": [
+                /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
+                /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+              ],
+            },
+            "parser": {
+              "dataUrlCondition": [Function],
+            },
+            "type": "asset",
+          },
+          {
+            "resourceQuery": /inline/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": Infinity,
+                  "name": "static/svg/[name].svg",
+                },
+              },
+            ],
+          },
+          {
+            "resourceQuery": /url/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": false,
+                  "name": "static/svg/[name].svg",
+                },
+              },
+            ],
+          },
+          {
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": 10000,
+                  "name": "static/svg/[name].svg",
+                },
+              },
+            ],
+          },
         ],
-        "resourceQuery": /inline/,
         "test": /\\\\\\.svg\\$/,
-        "type": "javascript/auto",
-        "use": [
-          {
-            "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
-            "options": {
-              "svgo": false,
-            },
-          },
-          {
-            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
-            "options": {
-              "limit": Infinity,
-              "name": "assets/[name].[contenthash:8].[ext]",
-            },
-          },
-        ],
       },
+    ],
+  },
+}
+`;
+
+exports[`plugins/svg > should allow to use distPath.svg to modify dist path 1`] = `
+{
+  "module": {
+    "rules": [
       {
-        "issuer": [
-          /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
-          /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        "oneOf": [
+          {
+            "generator": {
+              "filename": "foo/[name].svg",
+            },
+            "issuer": {
+              "not": [
+                /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
+                /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+              ],
+            },
+            "parser": {
+              "dataUrlCondition": [Function],
+            },
+            "type": "asset",
+          },
+          {
+            "resourceQuery": /inline/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": Infinity,
+                  "name": "foo/[name].svg",
+                },
+              },
+            ],
+          },
+          {
+            "resourceQuery": /url/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": false,
+                  "name": "foo/[name].svg",
+                },
+              },
+            ],
+          },
+          {
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": 10000,
+                  "name": "foo/[name].svg",
+                },
+              },
+            ],
+          },
         ],
-        "resourceQuery": /url/,
         "test": /\\\\\\.svg\\$/,
-        "type": "javascript/auto",
-        "use": [
-          {
-            "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
-            "options": {
-              "svgo": false,
-            },
-          },
-          {
-            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
-            "options": {
-              "limit": false,
-              "name": "assets/[name].[contenthash:8].[ext]",
-            },
-          },
-        ],
       },
+    ],
+  },
+}
+`;
+
+exports[`plugins/svg > should allow to use filename.svg to modify filename 1`] = `
+{
+  "module": {
+    "rules": [
       {
-        "issuer": [
-          /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
-          /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        "oneOf": [
+          {
+            "generator": {
+              "filename": "static/svg/foo.svg",
+            },
+            "issuer": {
+              "not": [
+                /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
+                /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+              ],
+            },
+            "parser": {
+              "dataUrlCondition": [Function],
+            },
+            "type": "asset",
+          },
+          {
+            "resourceQuery": /inline/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": Infinity,
+                  "name": "static/svg/foo.svg",
+                },
+              },
+            ],
+          },
+          {
+            "resourceQuery": /url/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": false,
+                  "name": "static/svg/foo.svg",
+                },
+              },
+            ],
+          },
+          {
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": 10000,
+                  "name": "static/svg/foo.svg",
+                },
+              },
+            ],
+          },
         ],
         "test": /\\\\\\.svg\\$/,
-        "type": "javascript/auto",
-        "use": [
-          {
-            "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
-            "options": {
-              "svgo": false,
-            },
-          },
-          {
-            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
-            "options": {
-              "limit": 10000,
-              "name": "assets/[name].[contenthash:8].[ext]",
-            },
-          },
-        ],
       },
     ],
   },
@@ -158,75 +338,80 @@ exports[`plugins/svg > should allow using output.dataUriLimit.svg to custom data
   "module": {
     "rules": [
       {
-        "issuer": [
-          /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
-          /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        "oneOf": [
+          {
+            "generator": {
+              "filename": "static/svg/[name].svg",
+            },
+            "issuer": {
+              "not": [
+                /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
+                /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+              ],
+            },
+            "parser": {
+              "dataUrlCondition": [Function],
+            },
+            "type": "asset",
+          },
+          {
+            "resourceQuery": /inline/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": Infinity,
+                  "name": "static/svg/[name].svg",
+                },
+              },
+            ],
+          },
+          {
+            "resourceQuery": /url/,
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": false,
+                  "name": "static/svg/[name].svg",
+                },
+              },
+            ],
+          },
+          {
+            "type": "javascript/auto",
+            "use": [
+              {
+                "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
+                "options": {
+                  "svgo": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
+                "options": {
+                  "limit": 666,
+                  "name": "static/svg/[name].svg",
+                },
+              },
+            ],
+          },
         ],
-        "resourceQuery": /inline/,
         "test": /\\\\\\.svg\\$/,
-        "type": "javascript/auto",
-        "use": [
-          {
-            "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
-            "options": {
-              "svgo": false,
-            },
-          },
-          {
-            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
-            "options": {
-              "limit": Infinity,
-              "name": "assets/[name].[contenthash:8].[ext]",
-            },
-          },
-        ],
-      },
-      {
-        "issuer": [
-          /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
-          /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
-        ],
-        "resourceQuery": /url/,
-        "test": /\\\\\\.svg\\$/,
-        "type": "javascript/auto",
-        "use": [
-          {
-            "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
-            "options": {
-              "svgo": false,
-            },
-          },
-          {
-            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
-            "options": {
-              "limit": false,
-              "name": "assets/[name].[contenthash:8].[ext]",
-            },
-          },
-        ],
-      },
-      {
-        "issuer": [
-          /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
-          /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
-        ],
-        "test": /\\\\\\.svg\\$/,
-        "type": "javascript/auto",
-        "use": [
-          {
-            "loader": "<NODE_MODULES>/@svgr/webpack/dist/index.js",
-            "options": {
-              "svgo": false,
-            },
-          },
-          {
-            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/url-loader",
-            "options": {
-              "limit": 666,
-              "name": "assets/[name].[contenthash:8].[ext]",
-            },
-          },
-        ],
       },
     ],
   },

--- a/packages/builder/webpack-builder/tests/plugins/svg.test.ts
+++ b/packages/builder/webpack-builder/tests/plugins/svg.test.ts
@@ -41,4 +41,36 @@ describe('plugins/svg', () => {
 
     expect(config).toMatchSnapshot();
   });
+
+  it('should allow to use distPath.svg to modify dist path', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginSvg()],
+      builderConfig: {
+        output: {
+          distPath: {
+            svg: 'foo',
+          },
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
+
+  it('should allow to use filename.svg to modify filename', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginSvg()],
+      builderConfig: {
+        output: {
+          filename: {
+            svg: 'foo.svg',
+          },
+        },
+      },
+    });
+
+    const config = await builder.unwrapWebpackConfig();
+    expect(config).toMatchSnapshot();
+  });
 });

--- a/packages/toolkit/utils/src/chainId.ts
+++ b/packages/toolkit/utils/src/chainId.ts
@@ -23,8 +23,6 @@ export const CHAIN_ID = {
     SASS: 'sass',
     /** Rule for svg */
     SVG: 'svg',
-    SVG_INLINE: 'svg-inline',
-    SVG_URL: 'svg-url',
     /** Rule for pug */
     PUG: 'pug',
     /** Rule for toml */
@@ -49,6 +47,7 @@ export const CHAIN_ID = {
     SASS_MODULES: 'sass-modules',
     SVG: 'svg',
     SVG_URL: 'svg-url',
+    SVG_ASSET: 'svg-asset',
     SVG_INLINE: 'svg-inline',
     ASSETS: 'assets',
     ASSETS_URL: 'assets-url',


### PR DESCRIPTION
# PR Details

## Description

- Support using svg as assets in CSS files.
- Using `oneOf` to define svg rules.
- Fix svg plugin is not registered by default.
- Export some types from webpack builder entry.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
