### PR TITLE
fix(core): cli -c option not work

### DIFF
--- a/.changeset/three-pianos-reply.md
+++ b/.changeset/three-pianos-reply.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/core': patch
+---
+
+fix(core): cli -c option not work
+
+fix(core): 修复命令行中 -c 选项不生效的问题

--- a/packages/cli/core/src/bin.ts
+++ b/packages/cli/core/src/bin.ts
@@ -21,7 +21,11 @@ if (!process.env.NODE_ENV) {
 
 const { version } = require('../package.json');
 
-const cliParams = minimist(process.argv.slice(2));
+const cliParams = minimist<{
+  c?: string;
+  config?: string;
+}>(process.argv.slice(2));
+
 const runOptions: CoreOptions = {
   version,
 };
@@ -37,8 +41,11 @@ const SUPPORT_CONFIG_PARAM_COMMANDS = [
   'start',
   'inspect',
 ];
-if (SUPPORT_CONFIG_PARAM_COMMANDS.includes(command) && cliParams.config) {
-  runOptions.configFile = cliParams.config;
+
+const customConfigFile = cliParams.config || cliParams.c;
+
+if (SUPPORT_CONFIG_PARAM_COMMANDS.includes(command) && customConfigFile) {
+  runOptions.configFile = customConfigFile;
 }
 
 cli.run(process.argv.slice(2), runOptions);


### PR DESCRIPTION
# PR Details

## Description

Fix cli -c option not work, such as `modern build -c ./xxx.config.ts`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
