### PR TITLE
fix(builder): enable css extract by default

### DIFF
--- a/packages/builder/webpack-builder/src/core/inspectWebpackConfig.ts
+++ b/packages/builder/webpack-builder/src/core/inspectWebpackConfig.ts
@@ -71,7 +71,9 @@ export async function inspectWebpackConfig({
   builderOptions,
   inspectOptions,
 }: InitConfigsOptions & { inspectOptions: InspectOptions }) {
-  process.env.NODE_ENV = inspectOptions.env;
+  if (inspectOptions.env) {
+    process.env.NODE_ENV = inspectOptions.env;
+  }
 
   const { webpackConfigs } = await initConfigs({
     context,

--- a/packages/builder/webpack-builder/src/plugins/css.ts
+++ b/packages/builder/webpack-builder/src/plugins/css.ts
@@ -77,7 +77,7 @@ export async function applyBaseCSSRule(
   };
 
   // 1. Check user config
-  const enableExtractCSS = Boolean(config.tools?.cssExtract);
+  const enableExtractCSS = !config.tools?.styleLoader;
   const enableCSSModuleTS = Boolean(
     config.output?.enableCssModuleTSDeclaration,
   );

--- a/packages/builder/webpack-builder/src/plugins/css.ts
+++ b/packages/builder/webpack-builder/src/plugins/css.ts
@@ -1,4 +1,4 @@
-import { CSS_REGEX } from '../shared';
+import { CSS_REGEX, getBrowserslistWithDefault } from '../shared';
 import {
   BuilderConfig,
   BuilderContext,
@@ -19,9 +19,8 @@ export async function applyBaseCSSRule(
   utils: ModifyWebpackUtils,
 ) {
   const { isServer, isProd, CHAIN_ID, getCompiledPath } = utils;
-  const { applyOptionsChain, getBrowserslist } = await import(
-    '@modern-js/utils'
-  );
+  const { applyOptionsChain } = await import('@modern-js/utils');
+  const browserslist = await getBrowserslistWithDefault(context.rootPath);
 
   const getPostcssConfig = () => {
     const extraPlugins: AcceptedPlugin[] = [];
@@ -53,7 +52,7 @@ export async function applyBaseCSSRule(
               applyOptionsChain(
                 {
                   flexbox: 'no-2009',
-                  overrideBrowserslist: getBrowserslist(context.rootPath),
+                  overrideBrowserslist: browserslist,
                 },
                 config.tools?.autoprefixer,
               ),

--- a/packages/builder/webpack-builder/src/plugins/output.ts
+++ b/packages/builder/webpack-builder/src/plugins/output.ts
@@ -52,7 +52,7 @@ export const PluginOutput = (): BuilderPlugin => ({
         isProd,
         context: api.context,
       });
-      const enableExtractCSS = Boolean(config.tools?.cssExtract);
+      const enableExtractCSS = !config.tools?.styleLoader;
 
       // js output
       const jsFilename = getFilename(config, 'js', isProd);

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/compatModern.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/compatModern.test.ts.snap
@@ -34,6 +34,21 @@ exports[`plugins/compatModern > should apply compatible webpack configs correctl
     "publicPath": "/",
   },
   "plugins": [
+    MiniCssExtractPlugin {
+      "_sortedModulesCache": WeakMap {},
+      "options": {
+        "chunkFilename": "static/css/[name].css",
+        "experimentalUseImportModule": undefined,
+        "filename": "static/css/[name].css",
+        "ignoreOrder": true,
+        "runtime": true,
+      },
+      "runtimeOptions": {
+        "attributes": undefined,
+        "insert": undefined,
+        "linkType": "text/css",
+      },
+    },
     IgnorePlugin {
       "checkIgnore": [Function],
       "options": {

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/output.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/output.test.ts.snap
@@ -9,6 +9,23 @@ exports[`plugins/output > should allow to use filename.js to modify filename 1`]
     "path": "<ROOT>/packages/builder/webpack-builder/dist",
     "publicPath": "/",
   },
+  "plugins": [
+    MiniCssExtractPlugin {
+      "_sortedModulesCache": WeakMap {},
+      "options": {
+        "chunkFilename": "static/css/[name].css",
+        "experimentalUseImportModule": undefined,
+        "filename": "static/css/[name].css",
+        "ignoreOrder": true,
+        "runtime": true,
+      },
+      "runtimeOptions": {
+        "attributes": undefined,
+        "insert": undefined,
+        "linkType": "text/css",
+      },
+    },
+  ],
 }
 `;
 
@@ -21,5 +38,22 @@ exports[`plugins/output > should set output correctly 1`] = `
     "path": "<ROOT>/packages/builder/webpack-builder/dist",
     "publicPath": "/",
   },
+  "plugins": [
+    MiniCssExtractPlugin {
+      "_sortedModulesCache": WeakMap {},
+      "options": {
+        "chunkFilename": "static/css/[name].css",
+        "experimentalUseImportModule": undefined,
+        "filename": "static/css/[name].css",
+        "ignoreOrder": true,
+        "runtime": true,
+      },
+      "runtimeOptions": {
+        "attributes": undefined,
+        "insert": undefined,
+        "linkType": "text/css",
+      },
+    },
+  ],
 }
 `;

--- a/packages/builder/webpack-builder/tests/plugins/css.test.ts
+++ b/packages/builder/webpack-builder/tests/plugins/css.test.ts
@@ -9,7 +9,9 @@ describe('plugins/css', () => {
     const builder = createStubBuilder({
       plugins: [PluginCss()],
       builderConfig: {
-        tools: {},
+        tools: {
+          styleLoader: {},
+        },
       },
     });
     const includeStyleLoader = await builder.matchWebpackLoader({
@@ -23,11 +25,7 @@ describe('plugins/css', () => {
   it('should set css config with mini-css-extract-plugin', async () => {
     const builder = createStubBuilder({
       plugins: [PluginCss()],
-      builderConfig: {
-        tools: {
-          cssExtract: {},
-        },
-      },
+      builderConfig: {},
     });
 
     const includeMiniCssExtractLoader = await builder.matchWebpackLoader({

--- a/tests/integration/webpack-builder/tsconfig.json
+++ b/tests/integration/webpack-builder/tsconfig.json
@@ -10,5 +10,5 @@
       "@shared/*": ["./shared/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "scripts"]
 }


### PR DESCRIPTION
# PR Details

## Description

Enable css extract by default, keep the behavior same as before.

| framework | dev | build |
|---|---|---|
| modern.js | css-extract | css-extract |
| eden | style-loader | css-extract |
| next.js | style-loader | css-extract |
| umi.js | css-extract | css-extract |

Other changes:

- Fix incorrect node env when inspect webpack config.
- Using the `getBrowserslistWithDefault` utils from webpack builder.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
