### PR TITLE
feat(builder): support custom dev server options

### DIFF
--- a/.changeset/chatty-horses-vanish.md
+++ b/.changeset/chatty-horses-vanish.md
@@ -3,3 +3,5 @@
 ---
 
 feat: change hmr sock path to /webpack-hmr
+
+feat: 热更新 socket 请求的 path 修改为 /webpack-hmr

--- a/.changeset/chatty-horses-vanish.md
+++ b/.changeset/chatty-horses-vanish.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/utils': patch
+---
+
+feat: change hmr sock path to /webpack-hmr

--- a/.changeset/new-ducks-crash.md
+++ b/.changeset/new-ducks-crash.md
@@ -3,3 +3,5 @@
 ---
 
 chore(server): export DevServerOptions type
+
+chore(server): 导出 DevServerOptions 类型

--- a/.changeset/new-ducks-crash.md
+++ b/.changeset/new-ducks-crash.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/server': patch
+---
+
+chore(server): export DevServerOptions type

--- a/packages/builder/webpack-builder/src/plugins/hmr.ts
+++ b/packages/builder/webpack-builder/src/plugins/hmr.ts
@@ -10,7 +10,7 @@ export const PluginHMR = (): BuilderPlugin => ({
       }
 
       const config = api.getBuilderConfig();
-      const usingHMR = config.tools?.devServer?.hot !== false;
+      const usingHMR = config.dev?.hmr ?? true;
 
       if (usingHMR) {
         chain

--- a/packages/builder/webpack-builder/src/types/config/dev.ts
+++ b/packages/builder/webpack-builder/src/types/config/dev.ts
@@ -1,4 +1,5 @@
 export interface DevConfig {
+  hmr?: boolean;
   port?: number;
   https?: boolean;
   assetPrefix?: string | boolean;

--- a/packages/builder/webpack-builder/src/types/config/tools.ts
+++ b/packages/builder/webpack-builder/src/types/config/tools.ts
@@ -1,3 +1,4 @@
+import type { DevServerOptions } from '@modern-js/server';
 import type { IStyledComponentOptions } from '@modern-js/babel-preset-app';
 import type { ModifyWebpackUtils } from '../hooks';
 import type {
@@ -89,9 +90,7 @@ export type ToolsWebpackChainConfig = ArrayOrNot<
   (chain: WebpackChain, utils: ModifyWebpackUtils) => void
 >;
 
-export type DevServerConfig = {
-  hot?: boolean;
-};
+export type ToolsDevServerConfig = ChainedConfig<DevServerOptions>;
 
 export interface ToolsConfig {
   pug?: ToolsPugConfig;
@@ -101,7 +100,7 @@ export interface ToolsConfig {
   terser?: ToolsTerserConfig;
   tsLoader?: ToolsTSLoaderConfig;
   tsChecker?: false | ToolsTSCheckerConfig;
-  devServer?: DevServerConfig;
+  devServer?: ToolsDevServerConfig;
   minifyCss?: ToolsMinifyCssConfig;
   htmlPlugin?: ToolsHtmlPluginConfig;
   styledComponents?: ToolsStyledComponentConfig;

--- a/packages/server/server/src/index.ts
+++ b/packages/server/server/src/index.ts
@@ -1,8 +1,8 @@
 import { DevServer as Server } from './server';
-import { ModernDevServerOptions } from './types';
+import type { DevServerOptions, ModernDevServerOptions } from './types';
 
 export { Server };
-export type { ModernDevServerOptions };
+export type { DevServerOptions, ModernDevServerOptions };
 
 export default (options: ModernDevServerOptions): Promise<Server> => {
   if (options == null) {

--- a/packages/server/server/tests/index.test.ts
+++ b/packages/server/server/tests/index.test.ts
@@ -8,11 +8,11 @@ describe('formatURL', () => {
     expect(
       formatURL({
         hostname: 'localhost',
-        pathname: '/_modern_js_hmr_ws',
+        pathname: '/webpack-hmr',
         port: '8080',
         protocol: 'ws',
       }),
-    ).toEqual('ws://localhost:8080/_modern_js_hmr_ws');
+    ).toEqual('ws://localhost:8080/webpack-hmr');
   });
 
   test('should return correct URL in legacy browsers', async () => {
@@ -24,11 +24,11 @@ describe('formatURL', () => {
     expect(
       formatURL({
         hostname: 'localhost',
-        pathname: '/_modern_js_hmr_ws',
+        pathname: '/webpack-hmr',
         port: '8080',
         protocol: 'ws',
       }),
-    ).toEqual('ws://localhost:8080/_modern_js_hmr_ws');
+    ).toEqual('ws://localhost:8080/webpack-hmr');
 
     Object.defineProperty(window, 'URL', {
       value: URL,

--- a/packages/toolkit/utils/src/constants.ts
+++ b/packages/toolkit/utils/src/constants.ts
@@ -1,7 +1,7 @@
 /**
  * hmr socket connect path
  */
-export const HMR_SOCK_PATH = '/_modern_js_hmr_ws';
+export const HMR_SOCK_PATH = '/webpack-hmr';
 
 /**
  * route specification file


### PR DESCRIPTION
# PR Details

## Description

- Support using `tools.devServer` to custom dev server options.
- Add new `dev.hmr` option.
- Change hmr sock path to `/webpack-hmr`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
