### PR TITLE
feat(builder): auto inspect configs in debug mode

### DIFF
--- a/packages/builder/webpack-builder/src/core/initConfigs.ts
+++ b/packages/builder/webpack-builder/src/core/initConfigs.ts
@@ -63,6 +63,8 @@ export async function initConfigs({
         webpackConfigs,
       });
     };
+
+    // run inspect later to avoid cleaned by cleanOutput plugin
     context.hooks.onBeforeBuildHook.tap(inspect);
     context.hooks.onBeforeStartDevServerHooks.tap(inspect);
   }

--- a/packages/builder/webpack-builder/src/core/initConfigs.ts
+++ b/packages/builder/webpack-builder/src/core/initConfigs.ts
@@ -3,7 +3,12 @@ import { initPlugins } from './initPlugins';
 import { generateWebpackConfig } from './webpackConfig';
 import { stringifyBuilderConfig } from './inspectBuilderConfig';
 import { stringifyWebpackConfig } from './inspectWebpackConfig';
-import type { Context, PluginStore, BuilderOptions } from '../types';
+import type {
+  Context,
+  PluginStore,
+  BuilderOptions,
+  InspectOptions,
+} from '../types';
 
 async function modifyBuilderConfig(context: Context) {
   debug('modify builder config');
@@ -43,7 +48,7 @@ export async function initConfigs({
   // write builder config and webpack config to disk in debug mode
   if (isDebug()) {
     const inspect = () => {
-      const inspectOptions = {
+      const inspectOptions: InspectOptions = {
         verbose: true,
         writeToDisk: true,
       };

--- a/packages/builder/webpack-builder/src/core/inspectBuilderConfig.ts
+++ b/packages/builder/webpack-builder/src/core/inspectBuilderConfig.ts
@@ -24,10 +24,33 @@ async function writeConfigFile({
   await fs.outputFile(filePath, `module.exports = ${config}`);
 
   info(
-    `Inspect builder config succeed, you can open following files to view the content:\n  - ${chalk.yellow(
+    `Inspect builder config succeed, open following files to view the content:\n\n  - ${chalk.yellow(
       filePath,
     )}\n`,
   );
+}
+
+export async function stringifyBuilderConfig({
+  context,
+  inspectOptions,
+}: {
+  context: Context;
+  inspectOptions: InspectOptions;
+}) {
+  const formattedBuilderConfig = await stringifyConfig(
+    context.config,
+    inspectOptions.verbose,
+  );
+
+  if (inspectOptions.writeToDisk) {
+    await writeConfigFile({
+      config: formattedBuilderConfig,
+      context,
+      inspectOptions,
+    });
+  }
+
+  return formattedBuilderConfig;
 }
 
 export async function inspectBuilderConfig({
@@ -46,18 +69,8 @@ export async function inspectBuilderConfig({
     builderOptions,
   });
 
-  const formattedBuilderConfig = await stringifyConfig(
-    context.config,
-    inspectOptions.verbose,
-  );
-
-  if (inspectOptions.writeToDisk) {
-    await writeConfigFile({
-      config: formattedBuilderConfig,
-      context,
-      inspectOptions,
-    });
-  }
-
-  return formattedBuilderConfig;
+  return stringifyBuilderConfig({
+    context,
+    inspectOptions,
+  });
 }

--- a/packages/builder/webpack-builder/src/plugins/cleanOutput.ts
+++ b/packages/builder/webpack-builder/src/plugins/cleanOutput.ts
@@ -11,6 +11,6 @@ export const PluginCleanOutput = (): BuilderPlugin => ({
     };
 
     api.onBeforeBuild(clean);
-    api.onBeforeCreateCompiler(clean);
+    api.onBeforeStartDevServer(clean);
   },
 });

--- a/packages/builder/webpack-builder/src/shared/logger.ts
+++ b/packages/builder/webpack-builder/src/shared/logger.ts
@@ -1,5 +1,7 @@
 import chalk from '@modern-js/utils/chalk';
 
+export const isDebug = () => process.env.DEBUG === 'builder';
+
 export const log = (message = '') => {
   // eslint-disable-next-line no-console
   console.log(message);
@@ -19,7 +21,7 @@ export const error = (message: string | Error) => {
 };
 
 export const debug = (message: string | (() => string)) => {
-  if (process.env.DEBUG === 'builder') {
+  if (isDebug()) {
     const { performance } = require('perf_hooks');
     const result = typeof message === 'string' ? message : message();
     const time = chalk.gray(`[${performance.now().toFixed(2)} ms]`);


### PR DESCRIPTION
# PR Details

## Description

Automatically write builder config and webpack config to disk in debug mode.

![image](https://user-images.githubusercontent.com/7237365/188847227-a991b581-bbe8-4214-b560-a9ef69ce8bf4.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
