### PR TITLE
fix(builder): polyfill entry not work

### DIFF
--- a/packages/builder/webpack-builder/src/plugins/babel.ts
+++ b/packages/builder/webpack-builder/src/plugins/babel.ts
@@ -129,11 +129,14 @@ export const PluginBabel = (): BuilderPlugin => ({
       const useTsLoader = Boolean(config.tools?.tsLoader);
       const rule = chain.module.rule(CHAIN_ID.RULE.JS);
       applyScriptCondition(rule, config, api.context, includes, excludes);
+
       rule
         .test(useTsLoader ? JS_REGEX : mergeRegex(JS_REGEX, TS_REGEX))
         .use(CHAIN_ID.USE.BABEL)
         .loader(getCompiledPath('babel-loader'))
         .options(babelOptions);
+
+      addCoreJsEntry({ chain, config });
     });
   },
 });

--- a/packages/builder/webpack-builder/src/plugins/splitChunks.ts
+++ b/packages/builder/webpack-builder/src/plugins/splitChunks.ts
@@ -65,7 +65,7 @@ function splitByExperience(ctx: SplitChunksContext): SplitChunks {
   ];
 
   SPLIT_EXPERIENCE_LIST.forEach((test: RegExp, index: number) => {
-    const key = `Experience_Defined_Cache_Group_${index}`;
+    const key = `pre-defined-chunk-${index}`;
 
     experienceCacheGroup[key] = {
       test,

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -1,5 +1,22 @@
 // Vitest Snapshot v1
 
+exports[`plugins/babel > should add core-js-entry when output.polyfill is entry 1`] = `
+{
+  "main": [
+    "<ROOT>/packages/builder/webpack-builder/src/runtime/core-js-entry.js",
+    "index.js",
+  ],
+}
+`;
+
+exports[`plugins/babel > should not add core-js-entry when output.polyfill is usage 1`] = `
+{
+  "main": [
+    "index.js",
+  ],
+}
+`;
+
 exports[`plugins/babel > should set babel-loader 1`] = `
 {
   "module": {

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/chunkSplit.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/chunkSplit.test.ts.snap
@@ -50,56 +50,56 @@ exports[`plugins/splitChunks > should set split-by-experience config 1`] = `
   "optimization": {
     "splitChunks": {
       "cacheGroups": {
-        "Experience_Defined_Cache_Group_0": {
-          "name": "Experience_Defined_Cache_Group_0",
+        "pre-defined-chunk-0": {
+          "name": "pre-defined-chunk-0",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]react\\|react-dom\\[\\\\\\\\/\\]/,
         },
-        "Experience_Defined_Cache_Group_1": {
-          "name": "Experience_Defined_Cache_Group_1",
+        "pre-defined-chunk-1": {
+          "name": "pre-defined-chunk-1",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]react-router\\|react-router-dom\\|history\\[\\\\\\\\/\\]/,
         },
-        "Experience_Defined_Cache_Group_2": {
-          "name": "Experience_Defined_Cache_Group_2",
+        "pre-defined-chunk-2": {
+          "name": "pre-defined-chunk-2",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]@ies\\\\/semi\\[\\\\\\\\/\\]/,
         },
-        "Experience_Defined_Cache_Group_3": {
-          "name": "Experience_Defined_Cache_Group_3",
+        "pre-defined-chunk-3": {
+          "name": "pre-defined-chunk-3",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]antd\\[\\\\\\\\/\\]/,
         },
-        "Experience_Defined_Cache_Group_4": {
-          "name": "Experience_Defined_Cache_Group_4",
+        "pre-defined-chunk-4": {
+          "name": "pre-defined-chunk-4",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]@arco-design\\[\\\\\\\\/\\]/,
         },
-        "Experience_Defined_Cache_Group_5": {
-          "name": "Experience_Defined_Cache_Group_5",
+        "pre-defined-chunk-5": {
+          "name": "pre-defined-chunk-5",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]@douyinfe\\\\/semi\\[\\\\\\\\/\\]/,
         },
-        "Experience_Defined_Cache_Group_6": {
-          "name": "Experience_Defined_Cache_Group_6",
+        "pre-defined-chunk-6": {
+          "name": "pre-defined-chunk-6",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]@babel\\\\/runtime\\|@babel\\\\/runtime-corejs2\\|@babel\\\\/runtime-corejs3\\[\\\\\\\\/\\]/,
         },
-        "Experience_Defined_Cache_Group_7": {
-          "name": "Experience_Defined_Cache_Group_7",
+        "pre-defined-chunk-7": {
+          "name": "pre-defined-chunk-7",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]lodash\\|lodash-es\\[\\\\\\\\/\\]/,
         },
-        "Experience_Defined_Cache_Group_8": {
-          "name": "Experience_Defined_Cache_Group_8",
+        "pre-defined-chunk-8": {
+          "name": "pre-defined-chunk-8",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]core-js\\[\\\\\\\\/\\]/,

--- a/packages/builder/webpack-builder/tests/plugins/babel.test.ts
+++ b/packages/builder/webpack-builder/tests/plugins/babel.test.ts
@@ -1,5 +1,6 @@
 import { expect, describe, it } from 'vitest';
 import { PluginBabel } from '../../src/plugins/babel';
+import { PluginEntry } from '../../src/plugins/entry';
 import { createStubBuilder } from '../../src/stub';
 
 describe('plugins/babel', () => {
@@ -36,5 +37,37 @@ describe('plugins/babel', () => {
     const config = await builder.unwrapWebpackConfig();
 
     expect(config).toMatchSnapshot();
+  });
+
+  it('should add core-js-entry when output.polyfill is entry', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginEntry(), PluginBabel()],
+      builderConfig: {
+        output: {
+          polyfill: 'entry',
+        },
+      },
+      entry: {
+        main: './index.js',
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+    expect(config.entry).toMatchSnapshot();
+  });
+
+  it('should not add core-js-entry when output.polyfill is usage', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginEntry(), PluginBabel()],
+      builderConfig: {
+        output: {
+          polyfill: 'usage',
+        },
+      },
+      entry: {
+        main: './index.js',
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+    expect(config.entry).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
# PR Details

## Description

- Fix `polyfill='entry'` not work, the `core-js-entry` is not included.
- Rename experience defined chunk name, `Experience_Defined_Cache_Group_x` -> `pre-defined-chunk-x`, make it shorter and easier to read.

<img width="835" alt="截屏2022-09-07 17 52 25" src="https://user-images.githubusercontent.com/7237365/188849843-9ed3b25c-1629-4a5e-bcb8-197402ef8503.png">

<img width="721" alt="截屏2022-09-07 17 53 49" src="https://user-images.githubusercontent.com/7237365/188849894-367e6cf5-e7b6-4cf8-b204-ecf038bedd4c.png">

