### PR TITLE
feat(builder): add output.overrideBrowserslist config

### DIFF
--- a/.changeset/thick-bees-give.md
+++ b/.changeset/thick-bees-give.md
@@ -4,3 +4,5 @@
 ---
 
 feat: add overrideBrowserslist option
+
+feat: 新增 overrideBrowserslist 选项

--- a/.changeset/thick-bees-give.md
+++ b/.changeset/thick-bees-give.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/babel-preset-app': patch
+'@modern-js/babel-preset-base': patch
+---
+
+feat: add overrideBrowserslist option

--- a/packages/builder/webpack-builder/src/core/createBuilder.ts
+++ b/packages/builder/webpack-builder/src/core/createBuilder.ts
@@ -158,6 +158,12 @@ async function addDefaultPlugins(pluginStore: PluginStore) {
     PluginDevtool(),
     PluginResolve(),
 
+    // fileSize plugin will read the previous dist files.
+    // So we should register fileSize plugin before cleanOutput plugin.
+    // And cleanOutput plugin should be registered before other plugins.
+    PluginFileSize(),
+    PluginCleanOutput(),
+
     // Plugins that provide basic features
     PluginHMR(),
     PluginSvg(),
@@ -172,10 +178,6 @@ async function addDefaultPlugins(pluginStore: PluginStore) {
     PluginProgress(),
     PluginMinimize(),
     PluginManifest(),
-    // fileSize plugin will read the previous dist files.
-    // So we should register fileSize plugin before cleanOutput plugin.
-    PluginFileSize(),
-    PluginCleanOutput(),
     PluginModuleScopes(),
     PluginTsLoader(),
     PluginBabel(),

--- a/packages/builder/webpack-builder/src/index.ts
+++ b/packages/builder/webpack-builder/src/index.ts
@@ -19,6 +19,7 @@ export type {
   ExperimentsConfig,
 
   // Third Party Types
+  webpack,
   WebpackChain,
   WebpackConfig,
   CSSLoaderOptions,

--- a/packages/builder/webpack-builder/src/plugins/babel.ts
+++ b/packages/builder/webpack-builder/src/plugins/babel.ts
@@ -4,7 +4,12 @@ import {
   createBabelChain,
   BabelOptions,
 } from '@modern-js/babel-preset-app';
-import { JS_REGEX, TS_REGEX, mergeRegex } from '../shared';
+import {
+  JS_REGEX,
+  TS_REGEX,
+  mergeRegex,
+  getBrowserslistWithDefault,
+} from '../shared';
 
 import type {
   WebpackChain,
@@ -59,6 +64,12 @@ export const PluginBabel = (): BuilderPlugin => ({
         '@modern-js/utils'
       );
 
+      const config = api.getBuilderConfig();
+      const browserslist = await getBrowserslistWithDefault(
+        api.context.rootPath,
+        config,
+      );
+
       const getBabelOptions = (
         framework: string,
         appDirectory: string,
@@ -110,6 +121,7 @@ export const PluginBabel = (): BuilderPlugin => ({
             styledComponents: styledComponentsOptions,
             userBabelConfig: config.tools?.babel,
             userBabelConfigUtils: babelUtils,
+            overrideBrowserslist: browserslist,
           }),
         };
 
@@ -119,7 +131,7 @@ export const PluginBabel = (): BuilderPlugin => ({
           excludes,
         };
       };
-      const config = api.getBuilderConfig();
+
       const { rootPath, framework } = api.context;
       const { babelOptions, includes, excludes } = getBabelOptions(
         framework,
@@ -128,6 +140,7 @@ export const PluginBabel = (): BuilderPlugin => ({
       );
       const useTsLoader = Boolean(config.tools?.tsLoader);
       const rule = chain.module.rule(CHAIN_ID.RULE.JS);
+
       applyScriptCondition(rule, config, api.context, includes, excludes);
 
       rule

--- a/packages/builder/webpack-builder/src/plugins/css.ts
+++ b/packages/builder/webpack-builder/src/plugins/css.ts
@@ -20,7 +20,10 @@ export async function applyBaseCSSRule(
 ) {
   const { isServer, isProd, CHAIN_ID, getCompiledPath } = utils;
   const { applyOptionsChain } = await import('@modern-js/utils');
-  const browserslist = await getBrowserslistWithDefault(context.rootPath);
+  const browserslist = await getBrowserslistWithDefault(
+    context.rootPath,
+    config,
+  );
 
   const getPostcssConfig = () => {
     const extraPlugins: AcceptedPlugin[] = [];

--- a/packages/builder/webpack-builder/src/shared/browserslist.ts
+++ b/packages/builder/webpack-builder/src/shared/browserslist.ts
@@ -1,3 +1,5 @@
+import type { BuilderConfig } from '../types';
+
 export const DEFAULT_BROWSERSLIST = ['> 0.01%', 'not dead', 'not op_mini all'];
 
 // using cache to avoid multiple calls to loadConfig
@@ -21,7 +23,14 @@ export async function getBrowserslist(path: string) {
   return null;
 }
 
-export async function getBrowserslistWithDefault(path: string) {
+export async function getBrowserslistWithDefault(
+  path: string,
+  config: BuilderConfig,
+) {
+  if (config?.output?.overrideBrowserslist) {
+    return config.output.overrideBrowserslist;
+  }
+
   const result = await getBrowserslist(path);
   return result || DEFAULT_BROWSERSLIST;
 }

--- a/packages/builder/webpack-builder/src/types/config/output.ts
+++ b/packages/builder/webpack-builder/src/types/config/output.ts
@@ -43,5 +43,6 @@ export interface OutputConfig {
   enableAssetFallback?: boolean;
   enableLatestDecorators?: boolean;
   enableCssModuleTSDeclaration?: boolean;
+  overrideBrowserslist?: string[];
   svgDefaultExport?: 'component' | 'url';
 }

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -17,6 +17,166 @@ exports[`plugins/babel > should not add core-js-entry when output.polyfill is us
 }
 `;
 
+exports[`plugins/babel > should override targets of babel-preset-env when using output.overrideBrowserslist config 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "include": [
+          {
+            "and": [
+              "<ROOT>/packages/builder/webpack-builder",
+              {
+                "not": /node_modules/,
+              },
+            ],
+          },
+          "<ROOT>/packages/builder/webpack-builder/src/runtime/core-js-entry.js",
+        ],
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$\\|\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/babel-loader",
+            "options": {
+              "babelrc": false,
+              "compact": false,
+              "configFile": false,
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-destructuring/lib/index.js",
+                  {
+                    "loose": false,
+                    "selectiveLoose": [
+                      "useState",
+                      "useEffect",
+                      "useContext",
+                      "useReducer",
+                      "useCallback",
+                      "useMemo",
+                      "useRef",
+                      "useImperativeHandle",
+                      "useLayoutEffect",
+                      "useDebugValue",
+                    ],
+                  },
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-app/src/built-in/babel-plugin-lock-corejs-version",
+                  {
+                    "metaName": "modern-js",
+                  },
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-app/src/built-in/babel-plugin-ssr-loader-id",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-macros/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "libraryDirectory": "es",
+                    "libraryName": "antd",
+                    "style": true,
+                  },
+                  "import-antd",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
+                  {},
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-decorators/index.js",
+                  {
+                    "legacy": true,
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+                  {
+                    "helpers": false,
+                    "regenerator": true,
+                    "useESModules": true,
+                    "version": "7.18.6",
+                  },
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-function-bind/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-export-default-from/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-pipeline-operator/index.js",
+                  {
+                    "proposal": "minimal",
+                  },
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-partial-application/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-styled-components/index.js",
+                  {
+                    "displayName": true,
+                    "pure": true,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                  "styled-components",
+                ],
+              ],
+              "presets": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+                  {
+                    "bugfixes": false,
+                    "corejs": {
+                      "proposals": true,
+                      "version": "3.25",
+                    },
+                    "exclude": [
+                      "transform-typeof-symbol",
+                    ],
+                    "modules": false,
+                    "shippedProposals": false,
+                    "targets": [
+                      "Chrome 80",
+                    ],
+                    "useBuiltIns": "entry",
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-react/lib/index.js",
+                  {
+                    "development": true,
+                    "runtime": "classic",
+                    "useBuiltIns": true,
+                    "useSpread": false,
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
 exports[`plugins/babel > should set babel-loader 1`] = `
 {
   "module": {
@@ -143,9 +303,11 @@ exports[`plugins/babel > should set babel-loader 1`] = `
                     ],
                     "modules": false,
                     "shippedProposals": false,
-                    "targets": {
-                      "node": "12",
-                    },
+                    "targets": [
+                      "> 0.01%",
+                      "not dead",
+                      "not op_mini all",
+                    ],
                     "useBuiltIns": "entry",
                   },
                 ],
@@ -307,9 +469,11 @@ exports[`plugins/babel > should set include/exclude 1`] = `
                     ],
                     "modules": false,
                     "shippedProposals": false,
-                    "targets": {
-                      "node": "12",
-                    },
+                    "targets": [
+                      "> 0.01%",
+                      "not dead",
+                      "not op_mini all",
+                    ],
                     "useBuiltIns": "entry",
                   },
                 ],

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/css.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/css.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1
+
+exports[`plugins/css > should override browserslist of autoprefixer when using output.overrideBrowserslist config 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/node_modules/<PNPM_INNER>/mini-css-extract-plugin/dist/loader.js",
+          },
+          {
+            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/css-loader",
+            "options": {
+              "importLoaders": 1,
+              "modules": {
+                "auto": true,
+                "exportLocalsConvention": "camelCase",
+                "exportOnlyLocals": false,
+                "localIdentName": "[path][name]__[local]--[hash:base64:5]",
+              },
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/postcss-loader",
+            "options": {
+              "postcssOptions": {
+                "plugins": [
+                  [Function],
+                  [Function],
+                  [Function],
+                  [Function],
+                  [Function],
+                  [Function],
+                  [Function],
+                  {
+                    "browsers": [
+                      "Chrome 80",
+                    ],
+                    "info": [Function],
+                    "options": {
+                      "flexbox": "no-2009",
+                      "overrideBrowserslist": [
+                        "Chrome 80",
+                      ],
+                    },
+                    "postcssPlugin": "autoprefixer",
+                    "prepare": [Function],
+                  },
+                ],
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/react.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/react.test.ts.snap
@@ -127,9 +127,11 @@ exports[`plugins/react > should work with babel-loader 1`] = `
                     ],
                     "modules": false,
                     "shippedProposals": false,
-                    "targets": {
-                      "node": "12",
-                    },
+                    "targets": [
+                      "> 0.01%",
+                      "not dead",
+                      "not op_mini all",
+                    ],
                     "useBuiltIns": "entry",
                   },
                 ],

--- a/packages/builder/webpack-builder/tests/plugins/babel.test.ts
+++ b/packages/builder/webpack-builder/tests/plugins/babel.test.ts
@@ -70,4 +70,18 @@ describe('plugins/babel', () => {
     const config = await builder.unwrapWebpackConfig();
     expect(config.entry).toMatchSnapshot();
   });
+
+  it('should override targets of babel-preset-env when using output.overrideBrowserslist config', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginBabel()],
+      builderConfig: {
+        output: {
+          overrideBrowserslist: ['Chrome 80'],
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
 });

--- a/packages/builder/webpack-builder/tests/plugins/css.test.ts
+++ b/packages/builder/webpack-builder/tests/plugins/css.test.ts
@@ -72,4 +72,18 @@ describe('plugins/css', () => {
 
     expect(includeLessLoader).toBe(true);
   });
+
+  it('should override browserslist of autoprefixer when using output.overrideBrowserslist config', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginCss()],
+      builderConfig: {
+        output: {
+          overrideBrowserslist: ['Chrome 80'],
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
 });

--- a/packages/cli/babel-preset-app/src/common.ts
+++ b/packages/cli/babel-preset-app/src/common.ts
@@ -42,6 +42,7 @@ export const genCommon = (options: Options): BabelChain => {
     modules,
     styledComponents,
     useTsLoader,
+    overrideBrowserslist,
   } = options;
 
   const useSSR = target === 'server';
@@ -97,6 +98,7 @@ export const genCommon = (options: Options): BabelChain => {
     },
     syntax: 'es5',
     useLegacyDecorators,
+    overrideBrowserslist,
   });
 
   chain

--- a/packages/cli/babel-preset-app/src/type.ts
+++ b/packages/cli/babel-preset-app/src/type.ts
@@ -24,4 +24,5 @@ export type Options = {
   metaName?: string;
   userBabelConfig?: BabelConfig | BabelConfig[];
   userBabelConfigUtils?: Partial<BabelConfigUtils>;
+  overrideBrowserslist?: string[];
 };

--- a/packages/cli/babel-preset-base/src/index.ts
+++ b/packages/cli/babel-preset-base/src/index.ts
@@ -32,6 +32,7 @@ export interface IBaseBabelConfigOption {
   runEnvironments?: 'node' | 'browsers';
   jsxTransformRuntime?: 'automatic' | 'classic';
   useTsLoader?: boolean;
+  overrideBrowserslist?: string[];
 }
 
 export const getBaseBabelChain = (option: IBaseBabelConfigOption) => {

--- a/packages/cli/babel-preset-base/src/presets.ts
+++ b/packages/cli/babel-preset-base/src/presets.ts
@@ -22,6 +22,7 @@ export const getPresetChain = (option: IBaseBabelConfigOption) => {
     runEnvironments = 'browsers',
     jsxTransformRuntime = 'automatic',
     useTsLoader = false,
+    overrideBrowserslist,
   } = option;
   const chain = createBabelChain();
   // set envOptions = false
@@ -34,13 +35,15 @@ export const getPresetChain = (option: IBaseBabelConfigOption) => {
       syntax === 'es5' ? getBrowserslist(appDirectory) : es6BrowserList;
     const targets =
       runEnvironments === 'node' ? { node: '12' } : browsersTargets;
+
     const presetEnvOptions = {
-      targets,
+      targets: overrideBrowserslist || targets,
       modules: type === 'commonjs' ? 'commonjs' : false,
       bugfixes: runEnvironments !== 'node',
       shippedProposals: type === 'module' && syntax === 'es6+',
       ...getPresetOptions(envOptions),
     };
+
     chain
       .preset('@babel/preset-env')
       .use(require.resolve('@babel/preset-env'), [presetEnvOptions]);


### PR DESCRIPTION
# PR Details

## Description

- Add `output.overrideBrowserslist` config for webpack builder, this allows user to override the browserslist of `@babel/preset-env` and `autoprefixer`.
- Export `webpack` type.
- Fix cleanOutput plugin register order, should register before other plugins.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
