### PR TITLE
fix(builder): adjust async css chunk output path

### DIFF
--- a/packages/builder/webpack-builder/src/plugins/output.ts
+++ b/packages/builder/webpack-builder/src/plugins/output.ts
@@ -77,14 +77,13 @@ export const PluginOutput = (): BuilderPlugin => ({
         >({}, config.tools?.cssExtract?.pluginOptions || {});
 
         const cssFilename = getFilename(config, 'css', isProd);
-        const cssChunkName = `${cssPath}/${cssFilename}`;
 
         chain
           .plugin(CHAIN_ID.PLUGIN.MINI_CSS_EXTRACT)
           .use(MiniCssExtractPlugin, [
             {
-              filename: cssChunkName,
-              chunkFilename: cssChunkName,
+              filename: `${cssPath}/${cssFilename}`,
+              chunkFilename: `${cssPath}/async/${cssFilename}`,
               ignoreOrder: true,
               ...extractPluginOptions,
             },

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/output.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/output.test.ts.snap
@@ -13,7 +13,7 @@ exports[`plugins/output > should allow to use filename.js to modify filename 1`]
     MiniCssExtractPlugin {
       "_sortedModulesCache": WeakMap {},
       "options": {
-        "chunkFilename": "static/css/[name].css",
+        "chunkFilename": "static/css/async/[name].css",
         "experimentalUseImportModule": undefined,
         "filename": "static/css/[name].css",
         "ignoreOrder": true,
@@ -42,7 +42,7 @@ exports[`plugins/output > should set output correctly 1`] = `
     MiniCssExtractPlugin {
       "_sortedModulesCache": WeakMap {},
       "options": {
-        "chunkFilename": "static/css/[name].css",
+        "chunkFilename": "static/css/async/[name].css",
         "experimentalUseImportModule": undefined,
         "filename": "static/css/[name].css",
         "ignoreOrder": true,


### PR DESCRIPTION
# PR Details

## Description

Fix the async css chunk output path, should be `static/css/async/[name].css` instead of `static/css/[name].css`, so the js output files and css output files have the same directory structure.
