### PR TITLE
feat(builder): add inline chunk plugin

### DIFF
--- a/packages/builder/webpack-builder/src/core/createBuilder.ts
+++ b/packages/builder/webpack-builder/src/core/createBuilder.ts
@@ -148,6 +148,7 @@ async function addDefaultPlugins(pluginStore: PluginStore) {
   const { PluginInspector } = await import('../plugins/inspector');
   const { PluginSRI } = await import('../plugins/sri');
   const { PluginStartUrl } = await import('../plugins/startUrl');
+  const { PluginInlineChunk } = await import('../plugins/inlineChunk');
 
   pluginStore.addPlugins([
     // Plugins that provide basic webpack config
@@ -194,6 +195,7 @@ async function addDefaultPlugins(pluginStore: PluginStore) {
     PluginInspector(),
     PluginSRI(),
     PluginStartUrl(),
+    PluginInlineChunk(),
 
     // fallback should be the last plugin
     PluginFallback(),

--- a/packages/builder/webpack-builder/src/plugins/inlineChunk.ts
+++ b/packages/builder/webpack-builder/src/plugins/inlineChunk.ts
@@ -1,0 +1,36 @@
+import type { BuilderPlugin } from '../types';
+import { RUNTIME_CHUNK_NAME } from '../shared';
+
+export const PluginInlineChunk = (): BuilderPlugin => ({
+  name: 'webpack-builder-plugin-inline-chunk',
+
+  setup(api) {
+    api.modifyWebpackChain(async (chain, { CHAIN_ID }) => {
+      const { default: HtmlWebpackPlugin } = await import(
+        'html-webpack-plugin'
+      );
+      const { InlineChunkHtmlPlugin } = await import(
+        '../webpackPlugins/InlineChunkHtmlPlugin'
+      );
+
+      const config = api.getBuilderConfig();
+      const {
+        disableInlineRuntimeChunk,
+        enableInlineStyles,
+        enableInlineScripts,
+      } = config.output || {};
+
+      chain.plugin(CHAIN_ID.PLUGIN.INLINE_HTML).use(InlineChunkHtmlPlugin, [
+        HtmlWebpackPlugin,
+        [
+          enableInlineScripts && /\.js$/,
+          enableInlineStyles && /\.css$/,
+          !disableInlineRuntimeChunk &&
+            // RegExp like /builder-runtime([.].+)?\.js$/
+            // matches builder-runtime.js and builder-runtime.123456.js
+            new RegExp(`${RUNTIME_CHUNK_NAME}([.].+)?\\.js$`),
+        ].filter(Boolean) as RegExp[],
+      ]);
+    });
+  },
+});

--- a/packages/builder/webpack-builder/src/plugins/splitChunks.ts
+++ b/packages/builder/webpack-builder/src/plugins/splitChunks.ts
@@ -6,7 +6,7 @@ import type {
 } from '../types/config/performance';
 import assert from 'assert';
 import type { Module } from 'webpack';
-import { getPackageNameFromModulePath } from '../shared';
+import { getPackageNameFromModulePath, RUNTIME_CHUNK_NAME } from '../shared';
 
 // We expose the three-layer to specify webpack chunk-split ability:
 // 1. By strategy.There some best pratice integrated in our internal strategy.
@@ -215,7 +215,9 @@ export function PluginSplitChunks(): BuilderPlugin {
           userDefinedCacheGroups,
           builderConfig: chunkSplit,
         });
-        chain.optimization.splitChunks(splitChunksOptions);
+        chain.optimization.splitChunks(splitChunksOptions).runtimeChunk({
+          name: RUNTIME_CHUNK_NAME,
+        });
       });
     },
   };

--- a/packages/builder/webpack-builder/src/shared/constants.ts
+++ b/packages/builder/webpack-builder/src/shared/constants.ts
@@ -34,3 +34,5 @@ export const MEDIA_EXTENSIONS = [
   'aac',
   'mov',
 ];
+
+export const RUNTIME_CHUNK_NAME = 'builder-runtime';

--- a/packages/builder/webpack-builder/src/types/config/output.ts
+++ b/packages/builder/webpack-builder/src/types/config/output.ts
@@ -39,10 +39,13 @@ export interface OutputConfig {
   disableMinimize?: boolean;
   disableSourceMap?: boolean;
   disableFilenameHash?: boolean;
+  disableInlineRuntimeChunk?: boolean;
   enableAssetManifest?: boolean;
   enableAssetFallback?: boolean;
   enableLatestDecorators?: boolean;
   enableCssModuleTSDeclaration?: boolean;
+  enableInlineScripts?: boolean;
+  enableInlineStyles?: boolean;
   overrideBrowserslist?: string[];
   svgDefaultExport?: 'component' | 'url';
 }

--- a/packages/builder/webpack-builder/src/webpackPlugins/InlineChunkHtmlPlugin.ts
+++ b/packages/builder/webpack-builder/src/webpackPlugins/InlineChunkHtmlPlugin.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * modified from https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/InlineChunkHtmlPlugin.js
+ */
+import type HtmlWebpackPlugin from 'html-webpack-plugin';
+import type { HtmlTagObject } from 'html-webpack-plugin';
+import { Compiler, Compilation } from 'webpack';
+import { isString } from '@modern-js/utils';
+
+export class InlineChunkHtmlPlugin {
+  htmlWebpackPlugin: typeof HtmlWebpackPlugin;
+
+  tests: RegExp[];
+
+  constructor(htmlWebpackPlugin: typeof HtmlWebpackPlugin, tests: RegExp[]) {
+    this.htmlWebpackPlugin = htmlWebpackPlugin;
+    this.tests = tests;
+  }
+
+  getInlinedScriptTag(
+    publicPath: string,
+    assets: Compilation['assets'],
+    tag: HtmlTagObject,
+  ) {
+    if (!(tag?.attributes.src && isString(tag.attributes.src))) {
+      return tag;
+    }
+    const scriptName = publicPath
+      ? tag.attributes.src.replace(publicPath, '')
+      : tag.attributes.src;
+
+    if (!this.tests.some(test => test.exec(scriptName))) {
+      return tag;
+    }
+    const asset = assets[scriptName];
+    if (asset == null) {
+      return tag;
+    }
+    const ret = {
+      tagName: 'script',
+      innerHTML: asset.source(),
+      closeTag: true,
+    };
+    return ret;
+  }
+
+  getInlinedCSSTag(
+    publicPath: string,
+    assets: Compilation['assets'],
+    tag: HtmlTagObject,
+  ) {
+    if (!(tag.attributes.href && isString(tag.attributes.href))) {
+      return tag;
+    }
+
+    const linkName = publicPath
+      ? tag.attributes.href.replace(publicPath, '')
+      : tag.attributes.href;
+
+    if (!this.tests.some(test => test.exec(linkName))) {
+      return tag;
+    }
+    const asset = assets[linkName];
+    return {
+      tagName: 'style',
+      innerHTML: asset.source(),
+      closeTag: true,
+    };
+  }
+
+  getInlinedTag(
+    publicPath: string,
+    assets: Compilation['assets'],
+    tag: HtmlTagObject,
+  ) {
+    if (tag.tagName === 'script') {
+      return this.getInlinedScriptTag(publicPath, assets, tag) as HtmlTagObject;
+    }
+
+    if (
+      tag.tagName === 'link' &&
+      tag.attributes &&
+      tag.attributes.rel === 'stylesheet'
+    ) {
+      return this.getInlinedCSSTag(publicPath, assets, tag) as HtmlTagObject;
+    }
+
+    return tag;
+  }
+
+  apply(compiler: Compiler) {
+    let publicPath = compiler.options.output.publicPath || '';
+    if (publicPath && !(publicPath as string).endsWith('/')) {
+      publicPath += '/';
+    }
+
+    compiler.hooks.compilation.tap(
+      'InlineChunkHtmlPlugin',
+      (compilation: Compilation) => {
+        const tagFunction = (tag: HtmlTagObject) =>
+          this.getInlinedTag(publicPath as string, compilation.assets, tag);
+
+        const hooks = this.htmlWebpackPlugin.getHooks(compilation);
+
+        hooks.alterAssetTagGroups.tap('InlineChunkHtmlPlugin', assets => {
+          const deferScriptTags = [];
+
+          for (const headTag of assets.headTags) {
+            if (headTag.tagName === 'script') {
+              const { attributes } = headTag;
+              if (attributes && attributes.defer === true) {
+                deferScriptTags.push(headTag);
+                assets.headTags.splice(assets.headTags.indexOf(headTag), 1);
+              }
+            }
+          }
+
+          assets.bodyTags = assets.bodyTags.concat(deferScriptTags);
+
+          assets.headTags = assets.headTags.map(tagFunction);
+          assets.bodyTags = assets.bodyTags.map(tagFunction);
+          return assets;
+        });
+      },
+    );
+  }
+}

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/chunkSplit.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/chunkSplit.test.ts.snap
@@ -3,6 +3,9 @@
 exports[`plugins/splitChunks > should set custom config 1`] = `
 {
   "optimization": {
+    "runtimeChunk": {
+      "name": "builder-runtime",
+    },
     "splitChunks": {
       "cacheGroups": {
         "User_Force_Split_Group_0": {
@@ -22,6 +25,9 @@ exports[`plugins/splitChunks > should set custom config 1`] = `
 exports[`plugins/splitChunks > should set single-size config 1`] = `
 {
   "optimization": {
+    "runtimeChunk": {
+      "name": "builder-runtime",
+    },
     "splitChunks": {
       "cacheGroups": {},
       "chunks": "all",
@@ -36,6 +42,9 @@ exports[`plugins/splitChunks > should set single-size config 1`] = `
 exports[`plugins/splitChunks > should set single-vendor config 1`] = `
 {
   "optimization": {
+    "runtimeChunk": {
+      "name": "builder-runtime",
+    },
     "splitChunks": {
       "cacheGroups": {},
       "chunks": "all",
@@ -48,6 +57,9 @@ exports[`plugins/splitChunks > should set single-vendor config 1`] = `
 exports[`plugins/splitChunks > should set split-by-experience config 1`] = `
 {
   "optimization": {
+    "runtimeChunk": {
+      "name": "builder-runtime",
+    },
     "splitChunks": {
       "cacheGroups": {
         "pre-defined-chunk-0": {
@@ -115,6 +127,9 @@ exports[`plugins/splitChunks > should set split-by-experience config 1`] = `
 exports[`plugins/splitChunks > should set split-by-module config 1`] = `
 {
   "optimization": {
+    "runtimeChunk": {
+      "name": "builder-runtime",
+    },
     "splitChunks": {
       "cacheGroups": {
         "vendors": {

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/inlineChunk.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/inlineChunk.test.ts.snap
@@ -1,0 +1,129 @@
+// Vitest Snapshot v1
+
+exports[`plugins/inlineChunk > should add InlineChunkHtmlPlugin properly by default 1`] = `
+{
+  "entry": {
+    "main": [
+      "src/main.ts",
+    ],
+  },
+  "plugins": [
+    HtmlWebpackPlugin {
+      "userOptions": {
+        "chunks": [
+          "main",
+        ],
+        "favicon": undefined,
+        "filename": "html/main/index.html",
+        "inject": true,
+        "minify": false,
+        "template": "<ROOT>/packages/builder/webpack-builder/static/template.html",
+        "templateParameters": [Function],
+      },
+      "version": 5,
+    },
+    InlineChunkHtmlPlugin {
+      "htmlWebpackPlugin": [Function],
+      "tests": [
+        /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
+      ],
+    },
+  ],
+}
+`;
+
+exports[`plugins/inlineChunk > should use proper plugin options when disableInlineRuntimeChunk is true 1`] = `
+{
+  "entry": {
+    "main": [
+      "src/main.ts",
+    ],
+  },
+  "plugins": [
+    HtmlWebpackPlugin {
+      "userOptions": {
+        "chunks": [
+          "main",
+        ],
+        "favicon": undefined,
+        "filename": "html/main/index.html",
+        "inject": true,
+        "minify": false,
+        "template": "<ROOT>/packages/builder/webpack-builder/static/template.html",
+        "templateParameters": [Function],
+      },
+      "version": 5,
+    },
+    InlineChunkHtmlPlugin {
+      "htmlWebpackPlugin": [Function],
+      "tests": [],
+    },
+  ],
+}
+`;
+
+exports[`plugins/inlineChunk > should use proper plugin options when enableInlineScripts is true 1`] = `
+{
+  "entry": {
+    "main": [
+      "src/main.ts",
+    ],
+  },
+  "plugins": [
+    HtmlWebpackPlugin {
+      "userOptions": {
+        "chunks": [
+          "main",
+        ],
+        "favicon": undefined,
+        "filename": "html/main/index.html",
+        "inject": true,
+        "minify": false,
+        "template": "<ROOT>/packages/builder/webpack-builder/static/template.html",
+        "templateParameters": [Function],
+      },
+      "version": 5,
+    },
+    InlineChunkHtmlPlugin {
+      "htmlWebpackPlugin": [Function],
+      "tests": [
+        /\\\\\\.js\\$/,
+        /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
+      ],
+    },
+  ],
+}
+`;
+
+exports[`plugins/inlineChunk > should use proper plugin options when enableInlineStyles is true 1`] = `
+{
+  "entry": {
+    "main": [
+      "src/main.ts",
+    ],
+  },
+  "plugins": [
+    HtmlWebpackPlugin {
+      "userOptions": {
+        "chunks": [
+          "main",
+        ],
+        "favicon": undefined,
+        "filename": "html/main/index.html",
+        "inject": true,
+        "minify": false,
+        "template": "<ROOT>/packages/builder/webpack-builder/static/template.html",
+        "templateParameters": [Function],
+      },
+      "version": 5,
+    },
+    InlineChunkHtmlPlugin {
+      "htmlWebpackPlugin": [Function],
+      "tests": [
+        /\\\\\\.css\\$/,
+        /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
+      ],
+    },
+  ],
+}
+`;

--- a/packages/builder/webpack-builder/tests/plugins/inlineChunk.test.ts
+++ b/packages/builder/webpack-builder/tests/plugins/inlineChunk.test.ts
@@ -1,0 +1,70 @@
+import { expect, describe, it } from 'vitest';
+import { PluginEntry } from '../../src/plugins/entry';
+import { PluginHtml } from '../../src/plugins/html';
+import { PluginInlineChunk } from '../../src/plugins/inlineChunk';
+import { createStubBuilder } from '../../src/stub';
+
+describe('plugins/inlineChunk', () => {
+  it('should add InlineChunkHtmlPlugin properly by default', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginEntry(), PluginHtml(), PluginInlineChunk()],
+      entry: {
+        main: './src/main.ts',
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
+
+  it('should use proper plugin options when enableInlineScripts is true', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginEntry(), PluginHtml(), PluginInlineChunk()],
+      entry: {
+        main: './src/main.ts',
+      },
+      builderConfig: {
+        output: {
+          enableInlineScripts: true,
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
+
+  it('should use proper plugin options when enableInlineStyles is true', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginEntry(), PluginHtml(), PluginInlineChunk()],
+      entry: {
+        main: './src/main.ts',
+      },
+      builderConfig: {
+        output: {
+          enableInlineStyles: true,
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
+
+  it('should use proper plugin options when disableInlineRuntimeChunk is true', async () => {
+    const builder = createStubBuilder({
+      plugins: [PluginEntry(), PluginHtml(), PluginInlineChunk()],
+      entry: {
+        main: './src/main.ts',
+      },
+      builderConfig: {
+        output: {
+          disableInlineRuntimeChunk: true,
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

- add PluginInlineChunk
  - add webpack plugin InlineChunkHtmlPlugin into builder
  - register InlineChunkHtmlPlugin in PluginInlineChunk and enable inline base on options in `output`
- change PluginEntry
  - add entries defined by source.vendorEntry into webpack-chain entry
- change PluginHtml
  - filter out vendorEntry before register html plugin, because they don't need a html file
  - add all vendorEntry to existing html plugin chunks option
- change PluginSplitChunk
  - set runtimeChunk to `single` mode (with name `builder-runtime`) because there could be more than one entries in a html

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
