### PR TITLE
fix(builder): html.crossorigin not work for async chunk

### DIFF
--- a/packages/builder/webpack-builder/src/plugins/html.ts
+++ b/packages/builder/webpack-builder/src/plugins/html.ts
@@ -197,9 +197,17 @@ export const PluginHtml = (): BuilderPlugin => ({
           const { HtmlCrossOriginPlugin } = await import(
             '../webpackPlugins/HtmlCrossOriginPlugin'
           );
+
+          const formattedCrossorigin =
+            crossorigin === true ? 'anonymous' : crossorigin;
+
           chain
             .plugin(CHAIN_ID.PLUGIN.HTML_CROSS_ORIGIN)
-            .use(HtmlCrossOriginPlugin, [{ crossOrigin: crossorigin }]);
+            .use(HtmlCrossOriginPlugin, [
+              { crossOrigin: formattedCrossorigin },
+            ]);
+
+          chain.output.crossOriginLoading(formattedCrossorigin);
         }
 
         if (appIcon) {

--- a/packages/builder/webpack-builder/src/plugins/sri.ts
+++ b/packages/builder/webpack-builder/src/plugins/sri.ts
@@ -3,12 +3,14 @@ import { SubresourceIntegrityPlugin } from '../../compiled/webpack-subresource-i
 
 export const PluginSRI = (): BuilderPlugin => ({
   name: 'webpack-builder-plugin-sri',
+
   setup(api) {
-    const subresourceIntegrityOptions = api.getBuilderConfig().security?.sri;
-    if (!subresourceIntegrityOptions) {
-      return;
-    }
     api.modifyWebpackChain((chain, { CHAIN_ID }) => {
+      const subresourceIntegrityOptions = api.getBuilderConfig().security?.sri;
+      if (!subresourceIntegrityOptions) {
+        return;
+      }
+
       chain.output.crossOriginLoading('anonymous');
       chain
         .plugin(CHAIN_ID.PLUGIN.SUBRESOURCE_INTEGRITY)

--- a/packages/builder/webpack-builder/src/types/config/html.ts
+++ b/packages/builder/webpack-builder/src/types/config/html.ts
@@ -1,7 +1,7 @@
 import type { MetaOptions } from '@modern-js/utils';
 import type { HTMLPluginOptions } from '../thirdParty';
 
-export type CrossOrigin = boolean | 'anonymous' | 'use-credentials';
+export type CrossOrigin = 'anonymous' | 'use-credentials';
 
 export interface HtmlConfig {
   meta?: MetaOptions;
@@ -14,7 +14,7 @@ export interface HtmlConfig {
   faviconByEntries?: Record<string, string | undefined>;
   appIcon?: string;
   mountId?: string;
-  crossorigin?: CrossOrigin;
+  crossorigin?: boolean | CrossOrigin;
   disableHtmlFolder?: boolean;
   templateParameters?: Record<string, unknown>;
   templateParametersByEntries?: Record<

--- a/packages/builder/webpack-builder/src/webpackPlugins/HtmlCrossOriginPlugin.ts
+++ b/packages/builder/webpack-builder/src/webpackPlugins/HtmlCrossOriginPlugin.ts
@@ -9,12 +9,12 @@ type CrossOriginOptions = {
 export class HtmlCrossOriginPlugin implements WebpackPluginInstance {
   readonly name: string;
 
-  readonly crossOrigin: string | false;
+  readonly crossOrigin: CrossOrigin;
 
   constructor(options: CrossOriginOptions) {
     const { crossOrigin } = options;
     this.name = 'HtmlCrossOriginPlugin';
-    this.crossOrigin = crossOrigin === true ? 'anonymous' : crossOrigin;
+    this.crossOrigin = crossOrigin;
   }
 
   apply(compiler: Compiler): void {

--- a/packages/builder/webpack-builder/tests/plugins/html.test.ts
+++ b/packages/builder/webpack-builder/tests/plugins/html.test.ts
@@ -30,9 +30,11 @@ describe('plugins/html', () => {
       },
     });
 
+    const config = await builder.unwrapWebpackConfig();
     expect(
       await builder.matchWebpackPlugin('HtmlCrossOriginPlugin'),
     ).toBeTruthy();
+    expect(config.output?.crossOriginLoading).toEqual('anonymous');
   });
 
   it('should register appIcon plugin when using html.appIcon', async () => {


### PR DESCRIPTION
# PR Details

## Description

Fix `html.crossorigin` config not work for async chunks.

The `HtmlCrossOriginPlugin` can only handle the entry chunks, and we should add the `crossOriginLoading` config to handle async chunks.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
