### PR TITLE
fix(builder): webpack cache conflict of different targets

### DIFF
--- a/packages/builder/webpack-builder/src/plugins/cache.ts
+++ b/packages/builder/webpack-builder/src/plugins/cache.ts
@@ -30,6 +30,8 @@ export const PluginCache = (): BuilderPlugin => ({
       }
 
       chain.cache({
+        // The default cache name of webpack is '${name}-${env}', and the `name` is `default` by default.
+        // We set cache name to avoid cache conflicts of different targets.
         name: `${target}-${env}`,
         type: 'filesystem',
         cacheDirectory,

--- a/packages/builder/webpack-builder/src/plugins/cache.ts
+++ b/packages/builder/webpack-builder/src/plugins/cache.ts
@@ -6,7 +6,7 @@ export const PluginCache = (): BuilderPlugin => ({
   name: 'webpack-builder-plugin-cache',
 
   setup(api) {
-    api.modifyWebpackChain(async chain => {
+    api.modifyWebpackChain(async (chain, { target, env }) => {
       const { context } = api;
       const cacheDirectory = join(context.cachePath, 'webpack');
       const rootPackageJson = join(context.rootPath, 'package.json');
@@ -30,6 +30,7 @@ export const PluginCache = (): BuilderPlugin => ({
       }
 
       chain.cache({
+        name: `${target}-${env}`,
         type: 'filesystem',
         cacheDirectory,
         buildDependencies,

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/cache.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/cache.test.ts.snap
@@ -9,6 +9,7 @@ exports[`plugins/cache > should add cache config correctly 1`] = `
       ],
     },
     "cacheDirectory": "<ROOT>/packages/builder/webpack-builder/node_modules/.cache/webpack",
+    "name": "web-test",
     "type": "filesystem",
   },
 }
@@ -26,6 +27,7 @@ exports[`plugins/cache > should watch framework config change 1`] = `
       ],
     },
     "cacheDirectory": "<ROOT>/packages/builder/webpack-builder/node_modules/.cache/webpack",
+    "name": "web-test",
     "type": "filesystem",
   },
 }
@@ -43,6 +45,7 @@ exports[`plugins/cache > should watch tsconfig change 1`] = `
       ],
     },
     "cacheDirectory": "<ROOT>/packages/builder/webpack-builder/node_modules/.cache/webpack",
+    "name": "web-test",
     "type": "filesystem",
   },
 }


### PR DESCRIPTION
# PR Details

## Description

The default cache name of webpack is '${name}-${env}', and the `name` is `default` by default.

We set cache name to avoid cache conflicts of different targets.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
