### PR TITLE
feat(webpack-builder): remove `memfs` and auto set `distPath` by `webpack` option

### DIFF
--- a/packages/builder/webpack-builder/.eslintrc.js
+++ b/packages/builder/webpack-builder/.eslintrc.js
@@ -68,6 +68,7 @@ module.exports = {
         './src/webpackPlugins/**/*',
         '**/*.test.*',
         './src/types/**/*',
+        './src/stub/**/*',
       ],
       rules: {
         '@typescript-eslint/no-restricted-imports': [

--- a/packages/builder/webpack-builder/package.json
+++ b/packages/builder/webpack-builder/package.json
@@ -103,7 +103,6 @@
     "@types/serialize-javascript": "^5.0.1",
     "@vitest/ui": "^0.21.1",
     "autoprefixer": "^10.4.8",
-    "memfs": "^3.3.0",
     "typescript": "^4",
     "vitest": "^0.21.1",
     "@modern-js/e2e": "workspace:*"

--- a/packages/builder/webpack-builder/tests/stub/builder.test.ts
+++ b/packages/builder/webpack-builder/tests/stub/builder.test.ts
@@ -1,6 +1,4 @@
-import path from 'path';
 import { describe, expect, it } from 'vitest';
-import { Volume, createFsFromVolume } from 'memfs';
 import _ from '@modern-js/utils/lodash';
 import { createStubBuilder } from '../../src/stub';
 import { normalizeStubPluginOptions } from '../../src/stub/builder';
@@ -28,20 +26,6 @@ describe('stub-builder', () => {
     expect((builder.build.cache as Map<any, any>).size).toBe(0);
     const newConfig = await builder.unwrapWebpackConfig();
     expect(oldConfig).not.toBe(newConfig);
-  });
-
-  it('should run webpack and output to memfs', async () => {
-    const builder = await createStubBuilder({ webpack: 'in-memory' });
-    builder.hooks.onAfterCreateCompilerHooks.tap(async ({ compiler }) => {
-      const filename = path.resolve('./src/index.js');
-      const vol = Volume.fromJSON({ [filename]: 'console.log(42)' });
-      compiler.inputFileSystem = createFsFromVolume(vol);
-    });
-    expect(await builder.unwrapOutputJSON()).toMatchInlineSnapshot(`
-      {
-        "<ROOT>/packages/builder/webpack-builder/dist/main.js": "console.log(42);",
-      }
-    `);
   });
 });
 

--- a/packages/toolkit/e2e/package.json
+++ b/packages/toolkit/e2e/package.json
@@ -47,8 +47,6 @@
     "@types/serve-static": "^1.13.10",
     "@vitest/ui": "^0.21.1",
     "got": "^11.8.3",
-    "memfs": "^3.4.7",
-    "nanoid": "3.3.4",
     "typescript": "^4",
     "vitest": "^0.21.1"
   },

--- a/packages/toolkit/e2e/src/server/index.ts
+++ b/packages/toolkit/e2e/src/server/index.ts
@@ -1,22 +1,21 @@
-import { Volume } from 'memfs/lib/volume';
 import createServer from 'connect';
 import serveStaticMiddle from './static';
 import getPort from 'get-port';
 
-export interface ServeVolumeOptions {
+export interface StaticServerOptions {
   hostname?: string;
-  volume?: Volume;
+  port?: number;
 }
 
 export async function runStaticServer(
   root: string,
-  options?: ServeVolumeOptions,
+  options?: StaticServerOptions,
 ) {
   const server = createServer();
 
-  server.use(serveStaticMiddle(root, { volume: options?.volume }));
+  server.use(serveStaticMiddle(root));
 
-  const port = await getPort();
+  const port = await getPort({ port: options?.port });
   const hostname = options?.hostname ?? '127.0.0.1';
   server.listen(port, hostname);
 

--- a/packages/toolkit/e2e/src/server/static.ts
+++ b/packages/toolkit/e2e/src/server/static.ts
@@ -1,42 +1,16 @@
-import os from 'os';
 import http from 'http';
-import fs from 'fs';
 import serveStaticImpl from 'serve-static';
-import { Volume } from 'memfs/lib/volume';
-import { nanoid } from 'nanoid';
-import path from 'path';
-import { createFsFromVolume } from 'memfs';
 
 export interface ServeStaticOptions<
   R extends http.ServerResponse = http.ServerResponse,
 > extends serveStaticImpl.ServeStaticOptions<R> {
-  volume?: Volume;
 }
 
 function serveStaticMiddle<R extends http.ServerResponse>(
   root: string,
   options?: ServeStaticOptions<R>,
 ): serveStaticImpl.RequestHandler<R> {
-  const ofs = options?.volume ? createFsFromVolume(options.volume) : fs;
-  let _root = root;
-  if (ofs !== fs) {
-    const tempDir = fs.realpathSync(os.tmpdir());
-    const outputDir = path.resolve(tempDir, 'modern-js-e2e', nanoid());
-    _root = outputDir;
-    if (options?.volume) {
-      const files = options.volume.toJSON(root, undefined, true);
-      for (const [filename, data] of Object.entries(files)) {
-        if (data) {
-          const filepath = path.resolve(outputDir, filename);
-          fs.mkdirSync(path.dirname(filepath), { recursive: true });
-          fs.writeFileSync(filepath, data);
-        }
-      }
-    } else {
-      throw new Error('Unsupported filesystem.');
-    }
-  }
-  return serveStaticImpl(_root, options);
+  return serveStaticImpl(root, options);
 }
 
 export default serveStaticMiddle;

--- a/packages/toolkit/utils/src/path.ts
+++ b/packages/toolkit/utils/src/path.ts
@@ -1,5 +1,7 @@
 import path from 'path';
-import { upath } from './compiled';
+import os from 'os';
+import fs from 'fs';
+import { nanoid, upath } from './compiled';
 
 export const isPathString = (test: string): boolean =>
   path.posix.basename(test) !== test || path.win32.basename(test) !== test;
@@ -12,3 +14,11 @@ export const normalizeToPosixPath = (p: string | undefined) =>
   upath
     .normalizeSafe(path.normalize(p || ''))
     .replace(/^([a-zA-Z]+):/, (_, m: string) => `/${m.toLowerCase()}`);
+
+export const getTemplatePath = (prefix?: string) => {
+  const tmpRoot = fs.realpathSync(os.tmpdir());
+  const parts = [tmpRoot];
+  prefix && parts.push(prefix);
+  parts.push(nanoid());
+  return path.resolve(...parts);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,7 +121,6 @@ importers:
       cssnano: ^5.1.12
       fork-ts-checker-webpack-plugin: 7.2.13
       html-webpack-plugin: 5.5.0
-      memfs: ^3.3.0
       mini-css-extract-plugin: 2.4.5
       postcss: 8.4.16
       react-refresh: 0.12.0
@@ -163,7 +162,6 @@ importers:
       '@types/serialize-javascript': 5.0.2
       '@vitest/ui': 0.21.1
       autoprefixer: 10.4.8_postcss@8.4.16
-      memfs: 3.4.7
       typescript: 4.7.4
       vitest: 0.21.1_@vitest+ui@0.21.1
 
@@ -2831,8 +2829,6 @@ importers:
       connect: ^3.7.0
       get-port: ^5.1.1
       got: ^11.8.3
-      memfs: ^3.4.7
-      nanoid: 3.3.4
       playwright: ^1.25.1
       serve-static: ^1.14.1
       typescript: ^4
@@ -2851,8 +2847,6 @@ importers:
       '@types/serve-static': 1.13.10
       '@vitest/ui': 0.21.1
       got: 11.8.5
-      memfs: 3.4.7
-      nanoid: 3.3.4
       typescript: 4.7.4
       vitest: 0.21.1_@vitest+ui@0.21.1
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

* Remove `memfs` from `@modern-js/webpack-builder` and `@modern-js/e2e`.
* Add new util function `getTemplatePath`.
* Set a string value to the stub builder option `webpack` enable using webpack and specify the `output.distPath`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
