### PR TITLE
perf(builder): disable output.pathinfo to improve performance

### DIFF
--- a/packages/builder/webpack-builder/src/plugins/output.ts
+++ b/packages/builder/webpack-builder/src/plugins/output.ts
@@ -61,6 +61,10 @@ export const PluginOutput = (): BuilderPlugin => ({
         .filename(`${jsPath}/${jsFilename}`)
         .chunkFilename(`${jsPath}/async/${jsFilename}`)
         .publicPath(publicPath)
+        // disable pathinfo to improve compile performance
+        // the path info is useless in most cases
+        // see: https://webpack.js.org/guides/build-performance/#output-without-path-info
+        .pathinfo(false)
         // since webpack v5.54.0+, hashFunction supports xxhash64 as a faster algorithm
         // which will be used as default when experiments.futureDefaults is enabled.
         .hashFunction('xxhash64');

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/output.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/output.test.ts.snap
@@ -7,6 +7,7 @@ exports[`plugins/output > should allow to use filename.js to modify filename 1`]
     "filename": "static/js/foo.js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/packages/builder/webpack-builder/dist",
+    "pathinfo": false,
     "publicPath": "/",
   },
   "plugins": [
@@ -36,6 +37,7 @@ exports[`plugins/output > should set output correctly 1`] = `
     "filename": "static/js/[name].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/packages/builder/webpack-builder/dist",
+    "pathinfo": false,
     "publicPath": "/",
   },
   "plugins": [


### PR DESCRIPTION
# PR Details

## Description

Disable pathinfo to improve compile performance, the path info is useless in most cases, see: https://webpack.js.org/guides/build-performance/#output-without-path-info

![Ls13lowSjX](https://user-images.githubusercontent.com/7237365/190957285-32f285a6-1680-464c-bfc2-f0b45edc7790.jpg)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
