### PR TITLE
fix: use output.publicPath(default) as webpack-dev-middleware publicPath

### DIFF
--- a/.changeset/young-jobs-press.md
+++ b/.changeset/young-jobs-press.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/server': patch
+---
+
+fix: use output.publicPath(default) as webpack-dev-middleware publicPath
+
+fix: 使用 output.publicPath 作为 webpack-dev-middleware publicPath

--- a/packages/server/server/src/dev-tools/dev-middleware/index.ts
+++ b/packages/server/server/src/dev-tools/dev-middleware/index.ts
@@ -112,7 +112,6 @@ export default class DevMiddleware extends EventEmitter {
         IncomingMessage,
         ServerResponse
       >,
-      publicPath: '/',
       stats: false,
       ...devOptions.devMiddleware,
     });


### PR DESCRIPTION
# PR Details

use output.publicPath(default) as webpack-dev-middleware publicPath

https://github.com/webpack/webpack-dev-middleware#publicpath

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. set dev.assetPrefix in config (https://modernjs.dev/docs/apis/app/config/dev/asset-prefix)
2. run dev 
3. request resource ok

<img width="293" alt="image" src="https://user-images.githubusercontent.com/22373761/191207431-fc29cf6a-f4c0-4680-be11-d359afe4c39e.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
