### PR TITLE
feat(builder): support compile js data URI

### DIFF
--- a/.changeset/small-icons-talk.md
+++ b/.changeset/small-icons-talk.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/utils': patch
+---
+
+chore(utils): add RULE.JS_DATA_URI to CHAIN_ID
+
+chore(utils): CHAIN_ID 增加 RULE.JS_DATA_URI 值

--- a/packages/builder/builder-doc/en/config/source/compileJsDataURI.md
+++ b/packages/builder/builder-doc/en/config/source/compileJsDataURI.md
@@ -1,0 +1,24 @@
+- Type: `boolean`
+- Default: `false`
+
+Whether to compile JavaScript code imported via Data URI.
+
+Such as:
+
+```js
+import x from 'data:text/javascript,export default 1;';
+
+import 'data:text/javascript;charset=utf-8;base64,Y29uc29sZS5sb2coJ2lubGluZSAxJyk7';
+```
+
+#### Example
+
+Add the following config to enable:
+
+```js
+export default {
+  source: {
+    compileJsDataURI: true,
+  },
+};
+```

--- a/packages/builder/builder-doc/zh/config/source/compileJsDataURI.md
+++ b/packages/builder/builder-doc/zh/config/source/compileJsDataURI.md
@@ -1,7 +1,7 @@
 - Type: `boolean`
 - Default: `false`
 
-是否使用 babel 编译通过 import Data URI 引入的 JavaScript 代码。
+对于使用 Data URI 引入的 JavaScript 代码，是否采用 babel 进行编译。
 
 比如以下代码：
 

--- a/packages/builder/builder-doc/zh/config/source/compileJsDataURI.md
+++ b/packages/builder/builder-doc/zh/config/source/compileJsDataURI.md
@@ -1,0 +1,24 @@
+- Type: `boolean`
+- Default: `false`
+
+是否通过 babel 编译通过 import Data URI 引入的 JavaScript 代码。
+
+比如以下代码：
+
+```js
+import x from 'data:text/javascript,export default 1;';
+
+import 'data:text/javascript;charset=utf-8;base64,Y29uc29sZS5sb2coJ2lubGluZSAxJyk7';
+```
+
+#### 示例
+
+添加以下配置来开启：
+
+```js
+export default {
+  source: {
+    compileJsDataURI: true,
+  },
+};
+```

--- a/packages/builder/builder-doc/zh/config/source/compileJsDataURI.md
+++ b/packages/builder/builder-doc/zh/config/source/compileJsDataURI.md
@@ -1,7 +1,7 @@
 - Type: `boolean`
 - Default: `false`
 
-是否通过 babel 编译通过 import Data URI 引入的 JavaScript 代码。
+是否使用 babel 编译通过 import Data URI 引入的 JavaScript 代码。
 
 比如以下代码：
 

--- a/packages/builder/webpack-builder/src/config/defaults.ts
+++ b/packages/builder/webpack-builder/src/config/defaults.ts
@@ -23,7 +23,9 @@ export const createDefaultConfig = (): BuilderConfig => ({
   tools: {
     tsChecker: {},
   },
-  source: {},
+  source: {
+    compileJsDataURI: false,
+  },
   output: {
     filename: {},
     distPath: {

--- a/packages/builder/webpack-builder/src/plugins/babel.ts
+++ b/packages/builder/webpack-builder/src/plugins/babel.ts
@@ -149,6 +149,23 @@ export const PluginBabel = (): BuilderPlugin => ({
         .loader(getCompiledPath('babel-loader'))
         .options(babelOptions);
 
+      /**
+       * If the script is imported with data URI, it should be compiled by babel too.
+       * This is used by some frameworks to create virtual entry.
+       * https://webpack.js.org/api/module-methods/#import
+       * @example: import x from 'data:text/javascript,export default 1;';
+       */
+      if (config.source?.compileJsDataURI) {
+        chain.module
+          .rule(CHAIN_ID.RULE.JS_DATA_URI)
+          .mimetype({
+            or: ['text/javascript', 'application/javascript'],
+          })
+          .use(CHAIN_ID.USE.BABEL)
+          .loader(getCompiledPath('babel-loader'))
+          .options(babelOptions);
+      }
+
       addCoreJsEntry({ chain, config });
     });
   },

--- a/packages/builder/webpack-builder/src/plugins/babel.ts
+++ b/packages/builder/webpack-builder/src/plugins/babel.ts
@@ -150,7 +150,7 @@ export const PluginBabel = (): BuilderPlugin => ({
         .options(babelOptions);
 
       /**
-       * If the script is imported with data URI, it should be compiled by babel too.
+       * If a script is imported with data URI, it can be compiled by babel too.
        * This is used by some frameworks to create virtual entry.
        * https://webpack.js.org/api/module-methods/#import
        * @example: import x from 'data:text/javascript,export default 1;';

--- a/packages/builder/webpack-builder/src/types/config/source.ts
+++ b/packages/builder/webpack-builder/src/types/config/source.ts
@@ -8,6 +8,7 @@ export interface SourceConfig {
   preEntry?: string | string[];
   globalVars?: Record<string, JSONValue>;
   moduleScopes?: ChainedConfig<ModuleScopes>;
+  compileJsDataURI?: boolean;
   resolveExtensionPrefix?: string;
 }
 

--- a/packages/builder/webpack-builder/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/builder/webpack-builder/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -9,6 +9,315 @@ exports[`plugins/babel > should add core-js-entry when output.polyfill is entry 
 }
 `;
 
+exports[`plugins/babel > should add rule to compile Data URI when enable source.compileJsDataURI 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "include": [
+          {
+            "and": [
+              "<ROOT>/packages/builder/webpack-builder",
+              {
+                "not": /node_modules/,
+              },
+            ],
+          },
+          "<ROOT>/packages/builder/webpack-builder/src/runtime/core-js-entry.js",
+        ],
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$\\|\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/babel-loader",
+            "options": {
+              "babelrc": false,
+              "compact": false,
+              "configFile": false,
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-destructuring/lib/index.js",
+                  {
+                    "loose": false,
+                    "selectiveLoose": [
+                      "useState",
+                      "useEffect",
+                      "useContext",
+                      "useReducer",
+                      "useCallback",
+                      "useMemo",
+                      "useRef",
+                      "useImperativeHandle",
+                      "useLayoutEffect",
+                      "useDebugValue",
+                    ],
+                  },
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-app/src/built-in/babel-plugin-lock-corejs-version",
+                  {
+                    "metaName": "modern-js",
+                  },
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-app/src/built-in/babel-plugin-ssr-loader-id",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-macros/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "libraryDirectory": "es",
+                    "libraryName": "antd",
+                    "style": true,
+                  },
+                  "import-antd",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
+                  {},
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-decorators/index.js",
+                  {
+                    "legacy": true,
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+                  {
+                    "helpers": false,
+                    "regenerator": true,
+                    "useESModules": true,
+                    "version": "7.18.6",
+                  },
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-function-bind/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-export-default-from/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-pipeline-operator/index.js",
+                  {
+                    "proposal": "minimal",
+                  },
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-partial-application/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-styled-components/index.js",
+                  {
+                    "displayName": true,
+                    "pure": true,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                  "styled-components",
+                ],
+              ],
+              "presets": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+                  {
+                    "bugfixes": false,
+                    "corejs": {
+                      "proposals": true,
+                      "version": "3.25",
+                    },
+                    "exclude": [
+                      "transform-typeof-symbol",
+                    ],
+                    "modules": false,
+                    "shippedProposals": false,
+                    "targets": [
+                      "> 0.01%",
+                      "not dead",
+                      "not op_mini all",
+                    ],
+                    "useBuiltIns": "entry",
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-react/lib/index.js",
+                  {
+                    "development": true,
+                    "runtime": "classic",
+                    "useBuiltIns": true,
+                    "useSpread": false,
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "mimetype": {
+          "or": [
+            "text/javascript",
+            "application/javascript",
+          ],
+        },
+        "use": [
+          {
+            "loader": "<ROOT>/packages/builder/webpack-builder/compiled/babel-loader",
+            "options": {
+              "babelrc": false,
+              "compact": false,
+              "configFile": false,
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-destructuring/lib/index.js",
+                  {
+                    "loose": false,
+                    "selectiveLoose": [
+                      "useState",
+                      "useEffect",
+                      "useContext",
+                      "useReducer",
+                      "useCallback",
+                      "useMemo",
+                      "useRef",
+                      "useImperativeHandle",
+                      "useLayoutEffect",
+                      "useDebugValue",
+                    ],
+                  },
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-app/src/built-in/babel-plugin-lock-corejs-version",
+                  {
+                    "metaName": "modern-js",
+                  },
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-app/src/built-in/babel-plugin-ssr-loader-id",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-macros/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "libraryDirectory": "es",
+                    "libraryName": "antd",
+                    "style": true,
+                  },
+                  "import-antd",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
+                  {},
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-decorators/index.js",
+                  {
+                    "legacy": true,
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+                  {
+                    "helpers": false,
+                    "regenerator": true,
+                    "useESModules": true,
+                    "version": "7.18.6",
+                  },
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-function-bind/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-export-default-from/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-pipeline-operator/index.js",
+                  {
+                    "proposal": "minimal",
+                  },
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-partial-application/index.js",
+                ],
+                [
+                  "<ROOT>/packages/cli/babel-preset-base/compiled/babel-plugin-styled-components/index.js",
+                  {
+                    "displayName": true,
+                    "pure": true,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                  "styled-components",
+                ],
+              ],
+              "presets": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+                  {
+                    "bugfixes": false,
+                    "corejs": {
+                      "proposals": true,
+                      "version": "3.25",
+                    },
+                    "exclude": [
+                      "transform-typeof-symbol",
+                    ],
+                    "modules": false,
+                    "shippedProposals": false,
+                    "targets": [
+                      "> 0.01%",
+                      "not dead",
+                      "not op_mini all",
+                    ],
+                    "useBuiltIns": "entry",
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-react/lib/index.js",
+                  {
+                    "development": true,
+                    "runtime": "classic",
+                    "useBuiltIns": true,
+                    "useSpread": false,
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
 exports[`plugins/babel > should not add core-js-entry when output.polyfill is usage 1`] = `
 {
   "main": [

--- a/packages/builder/webpack-builder/tests/plugins/babel.test.ts
+++ b/packages/builder/webpack-builder/tests/plugins/babel.test.ts
@@ -84,4 +84,18 @@ describe('plugins/babel', () => {
 
     expect(config).toMatchSnapshot();
   });
+
+  it('should add rule to compile Data URI when enable source.compileJsDataURI', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginBabel()],
+      builderConfig: {
+        source: {
+          compileJsDataURI: true,
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
 });

--- a/packages/toolkit/utils/src/chainId.ts
+++ b/packages/toolkit/utils/src/chainId.ts
@@ -13,6 +13,8 @@ export const CHAIN_ID = {
     MEDIA: 'media',
     /** Rule for js */
     JS: 'js',
+    /** Rule for data uri encoded javascript */
+    JS_DATA_URI: 'js-data-uri',
     /** Rule for ts */
     TS: 'ts',
     /** Rule for css */

--- a/website/builder/src/en/api/config-source.md
+++ b/website/builder/src/en/api/config-source.md
@@ -6,6 +6,10 @@ This section describes some source code related configurations in Modern.js Buil
 
 !!!include(node_modules/@modern-js/builder-doc/en/config/source/alias.md)!!!
 
+## source.compileJsDataURI
+
+!!!include(node_modules/@modern-js/builder-doc/en/config/source/compileJsDataURI.md)!!!
+
 ## source.globalVars
 
 !!!include(node_modules/@modern-js/builder-doc/en/config/source/globalVars.md)!!!

--- a/website/builder/src/zh/api/config-source.md
+++ b/website/builder/src/zh/api/config-source.md
@@ -6,6 +6,10 @@
 
 !!!include(node_modules/@modern-js/builder-doc/zh/config/source/alias.md)!!!
 
+## source.compileJsDataURI
+
+!!!include(node_modules/@modern-js/builder-doc/zh/config/source/compileJsDataURI.md)!!!
+
 ## source.globalVars
 
 !!!include(node_modules/@modern-js/builder-doc/zh/config/source/globalVars.md)!!!


### PR DESCRIPTION
# PR Details

## Description

Added a new `source.compileJsDataURI` config. 

If this option is enabled, when a script is imported with data URI, it can be compiled by babel too.

This is used by some frameworks such as PIA to create virtual entry.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
