### PR TITLE
fix: upgrade command ignore electron, codesmith, reduck packages

### DIFF
--- a/.changeset/witty-berries-jump.md
+++ b/.changeset/witty-berries-jump.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/upgrade-generator': patch
+---
+
+fix: upgrade command ignore electron, codesmith, reduck packages
+
+fix: 升级工具支持忽略 electron、codesmith、reduck 相关包

--- a/packages/generator/generators/upgrade-generator/src/index.ts
+++ b/packages/generator/generators/upgrade-generator/src/index.ts
@@ -62,6 +62,9 @@ export const handleTemplateFile = async (
       .filter(
         dep => dep.startsWith('@modern-js') || dep.startsWith('@modern-js-app'),
       )
+      .filter(dep => !dep.includes('electron'))
+      .filter(dep => !dep.includes('codesmith') && !dep.includes('easy-form'))
+      .filter(dep => !dep.startsWith('@modern-js-reduck'))
       .every(dep => deps[dep] === modernVersion)
   ) {
     generator.logger.info(


### PR DESCRIPTION
# PR Details

执行 npx @modern-js/upgrade 命令时，默认会统一升级 Modern.js 相关包，由于 electron、codesmith、reduck 相关包不在 Modern.js 仓库，版本号不会和 Modern.js 依赖保持一致，因此升级时需要忽略这些包。

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
