### PR TITLE
feat: support hook、middleware and new context with logger & metrics

### DIFF
--- a/.changeset/six-mirrors-sip.md
+++ b/.changeset/six-mirrors-sip.md
@@ -1,0 +1,16 @@
+---
+'@modern-js/core': patch
+'@modern-js/runtime': patch
+'@modern-js/plugin-egg': patch
+'@modern-js/plugin-express': patch
+'@modern-js/plugin-koa': patch
+'@modern-js/plugin-nest': patch
+'@modern-js/plugin-server': patch
+'@modern-js/prod-server': patch
+'@modern-js/types': patch
+'@modern-js/utils': patch
+---
+
+feat: support Hook、Middleware new API
+feat: 支持 Hook、Middleware 的新 API
+

--- a/packages/cli/core/src/config/schema/server.ts
+++ b/packages/cli/core/src/config/schema/server.ts
@@ -103,6 +103,7 @@ export const server = {
     metrics: { type: ['object', 'boolean'] },
     proxy: { type: 'object' },
     enableMicroFrontendDebug: { type: 'boolean' },
+    disableFrameworkExt: { type: 'boolean' },
     watchOptions: { type: 'object' },
     compiler: { type: 'string' },
   },

--- a/packages/cli/core/src/config/types/index.ts
+++ b/packages/cli/core/src/config/types/index.ts
@@ -176,6 +176,7 @@ export interface ServerConfig {
   enableMicroFrontendDebug?: boolean;
   watchOptions?: WatchOptions;
   compiler?: 'babel' | 'typescript';
+  disableFrameworkExt?: boolean;
 }
 
 export type DevProxyOptions = string | Record<string, string>;

--- a/packages/runtime/plugin-runtime/lib/types.d.ts
+++ b/packages/runtime/plugin-runtime/lib/types.d.ts
@@ -8,3 +8,9 @@ declare module '@modern-js/core' {
       state?: StateConfig | boolean;
     }
   }
+
+declare module 'http' {
+  interface ServerResponse {
+    locals: Record<string, any>
+  }
+}

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -162,7 +162,8 @@
     "@types/react-helmet": "^6.1.2",
     "@types/redux-logger": "^3.0.9",
     "@types/loadable__component": "^5.13.4",
-    "@types/styled-components": "^5.1.14"
+    "@types/styled-components": "^5.1.14",
+    "@modern-js/types": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=18",
@@ -175,7 +176,6 @@
     "typescript": "^4",
     "jest": "^27",
     "@modern-js/core": "workspace:*",
-    "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@types/jest": "^27",
     "@types/node": "^14",

--- a/packages/runtime/plugin-runtime/src/exports/server.ts
+++ b/packages/runtime/plugin-runtime/src/exports/server.ts
@@ -11,7 +11,7 @@ export const hook = (
     afterMatch,
     afterRender,
   }: {
-    addMiddleware: (mid: RequestHndler) => void;
+    addMiddleware: (mid: RequestHandler) => void;
     afterRender: (hook: AfterRenderHook) => void;
     afterMatch: (hook: AfterMatchHook) => void;
   }) => void,
@@ -27,7 +27,7 @@ export type AfterMatchHook = (
   next: NextFunction,
 ) => void;
 
-export type RequestHndler = (
+export type RequestHandler = (
   context: MiddlewareContext,
   next: NextFunction,
 ) => Promise<void> | void;

--- a/packages/runtime/plugin-runtime/src/exports/server.ts
+++ b/packages/runtime/plugin-runtime/src/exports/server.ts
@@ -1,1 +1,33 @@
-export const hook = (attacher: any) => attacher;
+import {
+  AfterMatchContext,
+  AfterRenderContext,
+  MiddlewareContext,
+  NextFunction,
+} from '@modern-js/types';
+
+export const hook = (
+  attacher: ({
+    addMiddleware,
+    afterMatch,
+    afterRender,
+  }: {
+    addMiddleware: (mid: RequestHndler) => void;
+    afterRender: (hook: AfterRenderHook) => void;
+    afterMatch: (hook: AfterMatchHook) => void;
+  }) => void,
+) => attacher;
+
+export type AfterRenderHook = (
+  context: AfterRenderContext,
+  next: NextFunction,
+) => void;
+
+export type AfterMatchHook = (
+  context: AfterMatchContext,
+  next: NextFunction,
+) => void;
+
+export type RequestHndler = (
+  context: MiddlewareContext,
+  next: NextFunction,
+) => Promise<void> | void;

--- a/packages/runtime/plugin-runtime/src/ssr/utils.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/utils.ts
@@ -56,5 +56,6 @@ export const mockResponse = () => {
     status() {
       console.info('status can only be used in the server side');
     },
+    locals: {},
   };
 };

--- a/packages/runtime/plugin-runtime/src/ssr/utils.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/utils.ts
@@ -51,11 +51,14 @@ export const formatClient = (
 export const mockResponse = () => {
   return {
     setHeader() {
-      console.info('setHeader can only be used in the server side');
+      console.warn('response.setHeader() can only be used in the server side');
     },
     status() {
-      console.info('status can only be used in the server side');
+      console.warn('response.status() can only be used in the server side');
     },
-    locals: {},
+    get locals() {
+      console.warn('response.locals can only be used in the server side');
+      return {};
+    },
   };
 };

--- a/packages/server/core/src/plugin.ts
+++ b/packages/server/core/src/plugin.ts
@@ -15,11 +15,12 @@ import {
 import type {
   ModernServerContext,
   BaseSSRServerContext,
-  Metrics,
-  Logger,
-} from '@modern-js/types/server';
+  AfterMatchContext,
+  AfterRenderContext,
+  MiddlewareContext,
+  ISAppContext,
+} from '@modern-js/types';
 import type { NormalizedConfig, UserConfig } from '@modern-js/core';
-import type { ISAppContext } from '@modern-js/types';
 import type { Options } from 'http-proxy-middleware';
 
 // collect all middleware register in server plugins
@@ -28,24 +29,14 @@ const gather = createParallelWorkflow<{
   addAPIMiddleware: (_input: any) => void;
 }>();
 
-type ServerInitInput = {
-  loggerOptions: any;
-  metricsOptions: any;
-};
-
-type InitExtension = {
-  logger: Logger;
-  metrics: Metrics;
-};
-
 // config
 const config = createWaterfall<ServerConfig>();
 
 const prepare = createWaterfall();
 
-const create = createAsyncPipeline<ServerInitInput, InitExtension>();
+export type Adapter = (ctx: MiddlewareContext) => void | Promise<void>;
 
-export type Adapter = (
+export type APIAdapter = (
   req: IncomingMessage,
   res: ServerResponse,
 ) => void | Promise<void>;
@@ -70,7 +61,7 @@ type Change = {
   event: 'add' | 'change' | 'unlink';
 };
 
-const prepareApiServer = createAsyncPipeline<APIServerStartInput, Adapter>();
+const prepareApiServer = createAsyncPipeline<APIServerStartInput, APIAdapter>();
 
 const onApiChange = createWaterfall<Change[]>();
 
@@ -117,10 +108,7 @@ const beforeMatch = createAsyncPipeline<
   any
 >();
 
-const afterMatch = createAsyncPipeline<
-  { context: ModernServerContext; routeAPI: any },
-  any
->();
+const afterMatch = createAsyncPipeline<AfterMatchContext, any>();
 
 // TODO FIXME
 export type SSRServerContext = Record<string, unknown>;
@@ -140,10 +128,7 @@ const beforeRender = createAsyncPipeline<
   any
 >();
 
-const afterRender = createAsyncPipeline<
-  { context: ModernServerContext; templateAPI: any },
-  any
->();
+const afterRender = createAsyncPipeline<AfterRenderContext, any>();
 
 const beforeSend = createAsyncPipeline<ModernServerContext, RequestResult>();
 
@@ -180,7 +165,6 @@ const serverHooks = {
   gather,
   config,
   prepare,
-  create,
   prepareWebServer,
   prepareApiServer,
   onApiChange,

--- a/packages/server/core/src/plugin.ts
+++ b/packages/server/core/src/plugin.ts
@@ -34,9 +34,9 @@ const config = createWaterfall<ServerConfig>();
 
 const prepare = createWaterfall();
 
-export type Adapter = (ctx: MiddlewareContext) => void | Promise<void>;
+export type WebAdapter = (ctx: MiddlewareContext) => void | Promise<void>;
 
-export type APIAdapter = (
+export type Adapter = (
   req: IncomingMessage,
   res: ServerResponse,
 ) => void | Promise<void>;
@@ -46,7 +46,7 @@ export type WebServerStartInput = {
   config: Record<string, any>;
 };
 
-const prepareWebServer = createAsyncPipeline<WebServerStartInput, Adapter>();
+const prepareWebServer = createAsyncPipeline<WebServerStartInput, WebAdapter>();
 
 export type APIServerStartInput = {
   pwd: string;
@@ -61,7 +61,7 @@ type Change = {
   event: 'add' | 'change' | 'unlink';
 };
 
-const prepareApiServer = createAsyncPipeline<APIServerStartInput, APIAdapter>();
+const prepareApiServer = createAsyncPipeline<APIServerStartInput, Adapter>();
 
 const onApiChange = createWaterfall<Change[]>();
 

--- a/packages/server/plugin-egg/src/plugin.ts
+++ b/packages/server/plugin-egg/src/plugin.ts
@@ -226,7 +226,10 @@ export default (): ServerPlugin => ({
 
       initEggConfig(app);
 
-      return (req, res) => {
+      return ctx => {
+        const {
+          source: { res, req },
+        } = ctx;
         app.on('error', err => {
           if (err) {
             throw err;

--- a/packages/server/plugin-egg/tests/webServer.test.ts
+++ b/packages/server/plugin-egg/tests/webServer.test.ts
@@ -1,3 +1,4 @@
+import { IncomingMessage, ServerResponse } from 'http';
 import * as path from 'path';
 import fs from 'fs';
 import request from 'supertest';
@@ -29,7 +30,9 @@ describe('webServer', () => {
       config: { middleware: [middleware] },
     });
 
-    const res = await request(webHandler).get('/');
+    const res = await request((req: IncomingMessage, res: ServerResponse) => {
+      return webHandler({ source: { req, res } });
+    }).get('/');
     expect(res.status).toBe(200);
     expect(res.get('content-type')).toBe('application/json; charset=utf-8');
     expect(res.body).toEqual(foo);
@@ -48,7 +51,9 @@ describe('webServer', () => {
       config: { middleware: [middleware] },
     });
 
-    const res = await request(webHandler).get('/');
+    const res = await request((req: IncomingMessage, res: ServerResponse) => {
+      return webHandler({ source: { req, res } });
+    }).get('/');
     expect(res.status).toBe(200);
     expect(res.get('content-type')).toBe('text/html');
     expect(res.text).toContain(`hello egg plugin`);
@@ -72,7 +77,9 @@ describe('webServer', () => {
       config: { middleware: [middleware1, middleware2] },
     });
 
-    const res = await request(webHandler).get('/');
+    const res = await request((req: IncomingMessage, res: ServerResponse) => {
+      return webHandler({ source: { req, res } });
+    }).get('/');
     expect(res.status).toBe(200);
     expect(res.get('content-type')).toBe('text/html');
     expect(res.text).toContain(`hello egg plugin`);

--- a/packages/server/plugin-express/src/cli/index.ts
+++ b/packages/server/plugin-express/src/cli/index.ts
@@ -30,6 +30,7 @@ export default (): CliPlugin => ({
             source: {
               alias: {
                 '@modern-js/runtime/server': relativeRuntimePath,
+                '@modern-js/runtime/express': relativeRuntimePath,
               },
             },
           };
@@ -38,6 +39,7 @@ export default (): CliPlugin => ({
             source: {
               alias: {
                 '@modern-js/runtime/server': serverRuntimePath,
+                '@modern-js/runtime/express': serverRuntimePath,
               },
             },
           };

--- a/packages/server/plugin-express/tests/webServer.test.ts
+++ b/packages/server/plugin-express/tests/webServer.test.ts
@@ -31,7 +31,9 @@ describe('webServer', () => {
       config: { middleware: [middleware] },
     });
 
-    const res = await request(webHandler).get('/');
+    const res = await request((req: Request, res: Response) => {
+      return webHandler({ source: { req, res } });
+    }).get('/');
     expect(res.status).toBe(200);
     expect(res.get('content-type')).toBe('text/html; charset=utf-8');
     expect(res.text).toContain(name);
@@ -57,7 +59,9 @@ describe('webServer', () => {
       config: { middleware: [middleware1, middleware2] },
     });
 
-    const res = await request(webHandler).get('/');
+    const res = await request((req: Request, res: Response) => {
+      return webHandler({ source: { req, res } });
+    }).get('/');
     expect(res.status).toBe(200);
     expect(res.get('content-type')).toBe('application/json; charset=utf-8');
     expect(res.body).toEqual(foo);
@@ -105,7 +109,7 @@ describe('support as async handler', () => {
     };
 
     const asyncHandler = async (req: Request, res: Response) => {
-      await webHandler(req, res);
+      await webHandler({ source: { req, res } });
       order.push(3);
       serveHandler(req, res);
     };
@@ -144,7 +148,7 @@ describe('support as async handler', () => {
     });
 
     const asyncHandler = async (req: Request, res: Response) => {
-      await webHandler(req, res);
+      await webHandler({ source: { req, res } });
       order.push(3);
     };
     const res = await request(asyncHandler).get('/');

--- a/packages/server/plugin-express/types.d.ts
+++ b/packages/server/plugin-express/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference path="./dist/types/index.d.ts" />
 
-declare module '@modern-js/runtime/server' {
+declare module '@modern-js/runtime/express' {
   import { Request, Response, RequestHandler } from 'express';
 
   type ExpressOptions = {
@@ -17,6 +17,8 @@ declare module '@modern-js/runtime/server' {
   export function useContext(): Context;
 
   export function hook(attacher: ExpressAttacher): ExpressAttacher;
+
+  export type { RequestHandler };
 
   export * from '@modern-js/bff-core';
 }

--- a/packages/server/plugin-koa/package.json
+++ b/packages/server/plugin-koa/package.json
@@ -21,6 +21,7 @@
     "prepare": "pnpm build",
     "prepublishOnly": "only-allow-pnpm && pnpm build -- --platform",
     "new": "modern new",
+    "dev": "modern build --watch",
     "build": "wireit",
     "test": "wireit"
   },

--- a/packages/server/plugin-koa/src/cli/index.ts
+++ b/packages/server/plugin-koa/src/cli/index.ts
@@ -30,6 +30,7 @@ export default (): CliPlugin => ({
             source: {
               alias: {
                 '@modern-js/runtime/server': relativeRuntimePath,
+                '@modern-js/runtime/koa': relativeRuntimePath,
               },
             },
           };
@@ -38,6 +39,7 @@ export default (): CliPlugin => ({
             source: {
               alias: {
                 '@modern-js/runtime/server': serverRuntimePath,
+                '@modern-js/runtime/koa': serverRuntimePath,
               },
             },
           };

--- a/packages/server/plugin-koa/src/plugin.ts
+++ b/packages/server/plugin-koa/src/plugin.ts
@@ -44,6 +44,7 @@ const initMiddlewares = (
 export default (): ServerPlugin => ({
   name: '@modern-js/plugin-koa',
   pre: ['@modern-js/plugin-bff'],
+  post: ['@modern-js/plugin-server'],
   setup: api => ({
     async prepareApiServer({ pwd, config }) {
       let app: Application;
@@ -95,7 +96,11 @@ export default (): ServerPlugin => ({
         return Promise.resolve(app.callback()(req, res));
       };
     },
-    prepareWebServer({ config }) {
+    prepareWebServer({ config }, next) {
+      const userConfig = api.useConfigContext();
+      if (userConfig?.server?.disableFrameworkExt) {
+        return next();
+      }
       const app: Application = new Koa();
 
       app.use(async (ctx, next) => {

--- a/packages/server/plugin-koa/src/plugin.ts
+++ b/packages/server/plugin-koa/src/plugin.ts
@@ -118,7 +118,10 @@ export default (): ServerPlugin => ({
         initMiddlewares(middleware, app);
       }
 
-      return (req, res) => {
+      return ctx => {
+        const {
+          source: { req, res },
+        } = ctx;
         app.on('error', err => {
           if (err) {
             throw err;

--- a/packages/server/plugin-koa/tests/webServer.test.ts
+++ b/packages/server/plugin-koa/tests/webServer.test.ts
@@ -1,3 +1,4 @@
+import { IncomingMessage, ServerResponse } from 'http';
 import * as path from 'path';
 import fs from 'fs';
 import request from 'supertest';
@@ -30,7 +31,9 @@ describe('webServer', () => {
       config: { middleware: [middleware] },
     });
 
-    const res = await request(webHandler).get('/');
+    const res = await request((req: IncomingMessage, res: ServerResponse) => {
+      return webHandler({ source: { req, res } });
+    }).get('/');
     expect(res.status).toBe(200);
     expect(res.get('content-type')).toBe('application/json; charset=utf-8');
     expect(res.body).toEqual(foo);
@@ -49,7 +52,9 @@ describe('webServer', () => {
       config: { middleware: [middleware] },
     });
 
-    const res = await request(webHandler).get('/');
+    const res = await request((req: IncomingMessage, res: ServerResponse) => {
+      return webHandler({ source: { req, res } });
+    }).get('/');
     expect(res.status).toBe(200);
     expect(res.get('content-type')).toBe('text/html');
     expect(res.text).toContain(`hello koa plugin`);
@@ -73,7 +78,9 @@ describe('webServer', () => {
       config: { middleware: [middleware1, middleware2] },
     });
 
-    const res = await request(webHandler).get('/');
+    const res = await request((req: IncomingMessage, res: ServerResponse) => {
+      return webHandler({ source: { req, res } });
+    }).get('/');
     expect(res.status).toBe(200);
     expect(res.get('content-type')).toBe('text/html');
     expect(res.text).toContain(`hello koa plugin`);

--- a/packages/server/plugin-koa/types.d.ts
+++ b/packages/server/plugin-koa/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference path="./dist/types/index.d.ts" />
-declare module '@modern-js/runtime/server' {
+declare module '@modern-js/runtime/koa' {
 
   import { Context, Middleware } from 'koa';
 
@@ -8,6 +8,8 @@ declare module '@modern-js/runtime/server' {
   };
 
   type KoaAttacher = (options: KoaOptions) => void;
+
+  export type { Middleware as RequestHandler };
 
   export function useContext(): Context;
 

--- a/packages/server/plugin-nest/src/server.ts
+++ b/packages/server/plugin-nest/src/server.ts
@@ -123,8 +123,11 @@ export default (): ServerPlugin => ({
 
       await app.init();
 
-      return (req, res) =>
+      return ctx =>
         new Promise((resolve, reject) => {
+          const {
+            source: { req, res },
+          } = ctx;
           const handler = () => {
             if (res.headersSent && res.statusCode !== 200) {
               finalhandler(req, res, {

--- a/packages/server/plugin-server/package.json
+++ b/packages/server/plugin-server/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "prepare": "pnpm build",
     "prepublishOnly": "only-allow-pnpm && modern build --platform",
-    "dev": "modern dev",
+    "dev": "modern build --watch",
     "build": "wireit",
     "new": "modern new",
     "test": "wireit"

--- a/packages/server/plugin-server/src/server.ts
+++ b/packages/server/plugin-server/src/server.ts
@@ -1,15 +1,38 @@
 import path from 'path';
 import type { ServerPlugin } from '@modern-js/server-core';
-import { isProd, requireExistModule, SERVER_DIR } from '@modern-js/utils';
-import type { ModernServerContext } from '@modern-js/types';
+import type {
+  HookContext,
+  MiddlewareContext,
+  NextFunction,
+} from '@modern-js/types';
+import {
+  isProd,
+  logger,
+  requireExistModule,
+  SERVER_DIR,
+} from '@modern-js/utils';
 
 const WEB_APP_NAME = 'index';
 
-type SF = (args: any, next: any) => void;
-class Storage {
-  public middlewares: SF[] = [];
+enum HOOKS {
+  AFTER_MATCH = 'afterMatch',
+  AFTER_RENDER = 'afterRender',
+}
 
-  public hooks: Record<string, SF> = {};
+type Hook = (ctx: HookContext, next: NextFunction) => void;
+type Middleware = (ctx: MiddlewareContext, next: NextFunction) => void;
+
+type ServerMod = {
+  default: (args: any) => void;
+  middleware: Middleware | Middleware[];
+  afterMatch: Hook;
+  afterRender: Hook;
+};
+
+class Storage {
+  public middlewares: Middleware[] = [];
+
+  public hooks: Record<string, Hook> = {};
 
   reset() {
     this.middlewares = [];
@@ -23,15 +46,36 @@ const createTransformAPI = (storage: Storage) =>
     {
       get(target: any, name: string) {
         if (name === 'addMiddleware') {
-          return (fn: SF) => storage.middlewares.push(fn);
+          return (fn: Middleware) => storage.middlewares.push(fn);
         }
-        return (fn: SF) => (storage.hooks[name] = fn);
+        return (fn: Hook) => {
+          logger.warn(
+            'declare hook in default export is to be deprecated, use named export instead',
+          );
+          storage.hooks[name] = fn;
+        };
       },
     },
   );
 
-type AfterMatchContext = ModernServerContext & { router: any };
-type AfterRenderContext = ModernServerContext & { template: any };
+const compose = (middlewares: Middleware[]) => {
+  return (
+    ctx: MiddlewareContext,
+    resolve: (value: void | PromiseLike<void>) => void,
+    reject: (reason?: any) => void,
+  ) => {
+    let i = 0;
+    const dispatch: NextFunction = () => {
+      const handler = middlewares[i++];
+      if (!handler) {
+        return resolve();
+      }
+
+      return (handler(ctx, dispatch) as any)?.catch?.(reject);
+    };
+    return dispatch;
+  };
+};
 
 export default (): ServerPlugin => ({
   name: '@modern-js/plugin-server',
@@ -40,57 +84,78 @@ export default (): ServerPlugin => ({
     const { appDirectory, distDirectory } = api.useAppContext();
     const storage = new Storage();
     const transformAPI = createTransformAPI(storage);
-    let webAppPath = '';
+    const pwd = isProd() ? distDirectory : appDirectory;
+    const webAppPath = path.resolve(pwd, SERVER_DIR, WEB_APP_NAME);
+
+    const loadMod = () => {
+      const mod: ServerMod = requireExistModule(webAppPath, {
+        interop: false,
+      });
+
+      const { default: defaultExports, middleware, ...hooks } = mod;
+
+      if (defaultExports) {
+        defaultExports(transformAPI);
+      }
+
+      // named export hooks will overrides hooks in default export function
+      Object.values(HOOKS).forEach(key => {
+        const fn = hooks[key];
+        if (fn) {
+          storage.hooks[key] = fn;
+        }
+      });
+
+      if (middleware) {
+        storage.middlewares = ([] as Middleware[]).concat(middleware);
+      }
+    };
 
     return {
       prepare() {
-        const pwd = isProd() ? distDirectory : appDirectory;
-
-        const serverPath = path.resolve(pwd, SERVER_DIR);
-        webAppPath = path.resolve(serverPath, WEB_APP_NAME);
-
-        const webMod = requireExistModule(webAppPath);
-        if (webMod) {
-          webMod(transformAPI);
-        }
+        loadMod();
       },
       reset() {
         storage.reset();
-        const newWebModule = requireExistModule(webAppPath);
-        if (newWebModule) {
-          newWebModule(transformAPI);
-        }
+        loadMod();
       },
       gather({ addWebMiddleware }) {
         storage.middlewares.forEach(mid => {
           addWebMiddleware(mid);
         });
       },
-      beforeMatch({ context }, next) {
-        if (!storage.hooks.beforeMatch) {
-          return next();
-        }
-        return storage.hooks.beforeMatch(context, next);
-      },
-      afterMatch({ context, routeAPI }, next) {
+      afterMatch(context, next) {
         if (!storage.hooks.afterMatch) {
           return next();
         }
-        (context as AfterMatchContext).router = routeAPI;
         return storage.hooks.afterMatch(context, next);
       },
-      beforeRender({ context }, next) {
-        if (!storage.hooks.beforeRender) {
-          return next();
-        }
-        return storage.hooks.beforeRender(context, next);
-      },
-      afterRender({ context, templateAPI }, next) {
+      afterRender(context, next) {
         if (!storage.hooks.afterRender) {
           return next();
         }
-        (context as AfterRenderContext).template = templateAPI;
         return storage.hooks.afterRender(context, next);
+      },
+      prepareWebServer({ config }) {
+        const { middleware } = config;
+        const factory = compose(middleware);
+
+        return ctx => {
+          const {
+            source: { res },
+          } = ctx;
+          return new Promise<void>((resolve, reject) => {
+            res.on('finish', (err: Error) => {
+              if (err) {
+                return reject(err);
+              }
+              return resolve();
+            });
+
+            const dispatch = factory(ctx, resolve, reject);
+            dispatch();
+          });
+        };
       },
     };
   },

--- a/packages/server/plugin-server/tests/fixtures/legency/server/index.ts
+++ b/packages/server/plugin-server/tests/fixtures/legency/server/index.ts
@@ -4,18 +4,8 @@ const fn = (sign: Sign) => {
   sign.status += 1;
 };
 
-export default ({
-  addMiddleware,
-  beforeMatch,
-  beforeRender,
-  afterMatch,
-  afterRender,
-}: any) => {
+export default ({ addMiddleware, afterMatch, afterRender }: any) => {
   addMiddleware(fn);
-
-  beforeMatch(fn);
-
-  beforeRender(fn);
 
   afterMatch(fn);
 

--- a/packages/server/plugin-server/tests/fixtures/mix/server/index.ts
+++ b/packages/server/plugin-server/tests/fixtures/mix/server/index.ts
@@ -1,0 +1,23 @@
+type Sign = { status: number };
+
+const fn = (sign: Sign) => {
+  sign.status += 1;
+};
+
+const newfn = (sign: Sign) => {
+  sign.status += 2;
+};
+
+export const afterMatch = newfn;
+
+export const afterRender = newfn;
+
+export const middleware = [newfn, newfn];
+
+export default ({ addMiddleware, afterMatch, afterRender }: any) => {
+  addMiddleware(fn);
+
+  afterMatch(fn);
+
+  afterRender(fn);
+};

--- a/packages/server/plugin-server/tests/fixtures/new/server/index.ts
+++ b/packages/server/plugin-server/tests/fixtures/new/server/index.ts
@@ -1,0 +1,9 @@
+type Sign = { status: number };
+
+const newfn = (sign: Sign) => {
+  sign.status += 2;
+};
+
+export const afterMatch = newfn;
+
+export const afterRender = newfn;

--- a/packages/server/plugin-server/tests/index.test.ts
+++ b/packages/server/plugin-server/tests/index.test.ts
@@ -8,15 +8,14 @@ describe('plugin-server', () => {
     expect(cliPlugin().name).toBe('@modern-js/plugin-server');
   });
 
-  it('server', () => {
+  it('should legency server hook work correctly', () => {
     expect(serverPlugin).toBeDefined();
-
     const plugin = serverPlugin();
     expect(plugin.name).toBe('@modern-js/plugin-server');
 
     const hooks: any = plugin.setup!({
       useAppContext: () => ({
-        appDirectory: path.join(__dirname, './fixtures/foo'),
+        appDirectory: path.join(__dirname, './fixtures/legency'),
       }),
     } as any);
 
@@ -30,12 +29,54 @@ describe('plugin-server', () => {
     });
     expect(sign.status).toBe(1);
 
-    const params = { context: sign };
-    hooks.beforeMatch(params);
-    hooks.afterMatch(params);
-    hooks.beforeRender(params);
-    hooks.afterRender(params);
+    hooks.afterMatch(sign);
+    hooks.afterRender(sign);
     hooks.reset();
-    expect(sign.status).toBe(5);
+    expect(sign.status).toBe(3);
+  });
+
+  it('should new server hook work correctly', () => {
+    expect(serverPlugin).toBeDefined();
+    const plugin = serverPlugin();
+    expect(plugin.name).toBe('@modern-js/plugin-server');
+
+    const hooks: any = plugin.setup!({
+      useAppContext: () => ({
+        appDirectory: path.join(__dirname, './fixtures/new'),
+      }),
+    } as any);
+
+    hooks.prepare();
+    const sign = { status: 0 };
+
+    hooks.afterMatch(sign);
+    hooks.afterRender(sign);
+    hooks.reset();
+    expect(sign.status).toBe(4);
+  });
+
+  it('should mix server hook work correctly', () => {
+    expect(serverPlugin).toBeDefined();
+    const plugin = serverPlugin();
+    expect(plugin.name).toBe('@modern-js/plugin-server');
+
+    const hooks: any = plugin.setup!({
+      useAppContext: () => ({
+        appDirectory: path.join(__dirname, './fixtures/mix'),
+      }),
+    } as any);
+    hooks.prepare();
+
+    const sign = { status: 0 };
+    hooks.gather({
+      addWebMiddleware: (fn: any) => {
+        fn(sign);
+      },
+    });
+    expect(sign.status).toBe(4);
+
+    hooks.afterMatch(sign);
+    hooks.afterRender(sign);
+    expect(sign.status).toBe(8);
   });
 });

--- a/packages/server/prod-server/src/libs/hook-api/route.ts
+++ b/packages/server/prod-server/src/libs/hook-api/route.ts
@@ -1,42 +1,26 @@
-import { RouteMatchManager, RouteMatcher } from '../route';
+export class RouteAPI {
+  public current: string;
 
-class RouteAPI {
-  private readonly router: RouteMatchManager;
+  public status: number;
 
-  private current: RouteMatcher;
+  public url: string;
 
-  private readonly url: string;
+  constructor(entryName: string) {
+    this.current = entryName;
+    this.status = 200;
+    this.url = '';
+  }
 
-  constructor(matched: RouteMatcher, router: RouteMatchManager, url: string) {
-    this.current = matched;
-    this.router = router;
+  public redirect(url: string, status = 302) {
     this.url = url;
+    this.status = status;
   }
 
-  public cur() {
-    return this.current.generate(this.url);
-  }
-
-  public get(entryName: string) {
-    const { router } = this;
-    const matched = router.matchEntry(entryName);
-    return matched ? matched.generate(this.url) : null;
+  public rewrite(entryName: string) {
+    this.current = entryName;
   }
 
   public use(entryName: string) {
-    const { router } = this;
-    const matched = router.matchEntry(entryName);
-    if (matched) {
-      this.current = matched;
-      return true;
-    } else {
-      return false;
-    }
+    this.rewrite(entryName);
   }
 }
-
-export const createRouteAPI = (
-  matched: RouteMatcher,
-  router: RouteMatchManager,
-  url: string,
-) => new RouteAPI(matched, router, url);

--- a/packages/server/prod-server/src/libs/hook-api/template.ts
+++ b/packages/server/prod-server/src/libs/hook-api/template.ts
@@ -9,7 +9,7 @@ const RegList = {
   },
 };
 
-class TemplateAPI {
+export class TemplateAPI {
   private content: string;
 
   constructor(content: string) {
@@ -44,10 +44,7 @@ class TemplateAPI {
     return this.replace(body, `${fragment}${body}`);
   }
 
-  public replace(reg: RegExp | string, text: string) {
+  private replace(reg: RegExp | string, text: string) {
     this.content = this.content.replace(reg, text);
-    return this;
   }
 }
-
-export const createTemplateAPI = (content: string) => new TemplateAPI(content);

--- a/packages/server/prod-server/src/libs/render/measure.ts
+++ b/packages/server/prod-server/src/libs/render/measure.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import { BaseSSRServerContext, Logger, Metrics } from '@modern-js/types';
 import { headersWithoutCookie } from '../../utils';
 
@@ -51,6 +52,11 @@ export const createLogger = (
   };
 
   const error = (message: string, e: Error | string) => {
+    if (!e) {
+      e = message;
+      message = '';
+    }
+
     logger.error(
       `SSR Error - ${message}, error = %s, req.url = %s, req.headers = %o`,
       e instanceof Error ? e.stack || e.message : e,
@@ -65,3 +71,4 @@ export const createLogger = (
     debug,
   };
 };
+/* eslint-enable no-param-reassign */

--- a/packages/server/prod-server/src/libs/render/ssr.ts
+++ b/packages/server/prod-server/src/libs/render/ssr.ts
@@ -41,6 +41,7 @@ export const render = async (
       status: code => {
         ctx.res.statusCode = code;
       },
+      locals: ctx.res?.locals || {},
     },
     redirection: {},
     template,

--- a/packages/server/prod-server/src/server/modern-server-split.ts
+++ b/packages/server/prod-server/src/server/modern-server-split.ts
@@ -9,8 +9,8 @@ class ModernSSRServer extends ModernServer {
     return null as any;
   }
 
-  protected filterRoutes(routes: ModernRouteInterface[]) {
-    return routes.filter(route => !route.isApi);
+  protected async handleAPI(context: ModernServerContext) {
+    return this.render404(context);
   }
 }
 
@@ -19,8 +19,8 @@ class ModernAPIServer extends ModernServer {
     return null as any;
   }
 
-  protected async handleAPI(context: ModernServerContext) {
-    return this.render404(context);
+  protected filterRoutes(routes: ModernRouteInterface[]) {
+    return routes.filter(route => route.isApi);
   }
 }
 

--- a/packages/server/prod-server/src/server/modern-server-split.ts
+++ b/packages/server/prod-server/src/server/modern-server-split.ts
@@ -1,8 +1,7 @@
 import { APIServerStartInput } from '@modern-js/server-core';
 import { ModernRoute, ModernRouteInterface } from '../libs/route';
-import { RUN_MODE } from '../constants';
 import type { ModernServerContext } from '../libs/context';
-import { ModernServerOptions, ModernServerInterface, HookNames } from '../type';
+import { ModernServerOptions, ModernServerInterface } from '../type';
 import { ModernServer } from './modern-server';
 
 class ModernSSRServer extends ModernServer {
@@ -13,18 +12,6 @@ class ModernSSRServer extends ModernServer {
   protected filterRoutes(routes: ModernRouteInterface[]) {
     return routes.filter(route => !route.isApi);
   }
-
-  protected async setupBeforeProdMiddleware() {
-    if (this.runMode === RUN_MODE.FULL) {
-      await super.setupBeforeProdMiddleware();
-    }
-  }
-
-  protected async emitRouteHook(_: HookNames, _input: any) {
-    if (this.runMode === RUN_MODE.FULL) {
-      await super.emitRouteHook(_, _input);
-    }
-  }
 }
 
 class ModernAPIServer extends ModernServer {
@@ -32,18 +19,8 @@ class ModernAPIServer extends ModernServer {
     return null as any;
   }
 
-  protected filterRoutes(routes: ModernRouteInterface[]) {
-    return routes.filter(route => route.isApi);
-  }
-
-  protected async setupBeforeProdMiddleware() {
-    if (this.runMode === RUN_MODE.FULL) {
-      await super.setupBeforeProdMiddleware();
-    }
-  }
-
-  protected async emitRouteHook(_: HookNames, _input: any) {
-    // empty
+  protected async handleAPI(context: ModernServerContext) {
+    return this.render404(context);
   }
 }
 
@@ -53,25 +30,12 @@ class ModernWebServer extends ModernServer {
   }
 
   protected async handleAPI(context: ModernServerContext) {
-    const { proxyTarget } = this;
-
-    if (proxyTarget?.api) {
-      return this.proxy();
-    } else {
-      return this.render404(context);
-    }
+    return this.render404(context);
   }
 
   protected async handleWeb(context: ModernServerContext, route: ModernRoute) {
-    const { proxyTarget } = this;
-
-    if (route.isSSR && proxyTarget?.ssr) {
-      return this.proxy();
-    } else {
-      // if no proxyTarget but access web server, degradation to csr
-      route.isSSR = false;
-      return super.handleWeb(context, route);
-    }
+    route.isSSR = false;
+    return super.handleWeb(context, route);
   }
 }
 

--- a/packages/server/prod-server/src/type.ts
+++ b/packages/server/prod-server/src/type.ts
@@ -25,8 +25,6 @@ export type ModernServerOptions = {
   plugins?: Plugin[];
   routes?: ModernRouteInterface[];
   staticGenerate?: boolean;
-  loggerOptions?: Record<string, string>;
-  metricsOptions?: Record<string, string>;
   logger?: Logger;
   metrics?: Metrics;
   apiOnly?: boolean;
@@ -61,11 +59,7 @@ export type BuildOptions = { routes?: ModernRouteInterface[] };
 
 export type { Metrics, Logger, NextFunction };
 
-export type HookNames =
-  | 'beforeMatch'
-  | 'afterMatch'
-  | 'beforeRender'
-  | 'afterRender';
+export type HookNames = 'afterMatch' | 'afterRender';
 
 export interface ModernServerInterface {
   pwd: string;

--- a/packages/server/prod-server/tests/hook.test.ts
+++ b/packages/server/prod-server/tests/hook.test.ts
@@ -1,44 +1,144 @@
-import { createRouteAPI } from '../src/libs/hook-api/route';
-import { createTemplateAPI } from '../src/libs/hook-api/template';
-import { RouteMatchManager } from '../src/libs/route';
+import EventEmitter from 'events';
+import { Readable } from 'stream';
+import httpMocks from 'node-mocks-http';
+import {
+  base,
+  createAfterMatchContext,
+  createAfterRenderContext,
+  createMiddlewareContext,
+} from '../src/libs/hook-api';
+import { createContext } from '../src/libs/context';
 import { createDoc } from './helper';
-import spec from './fixtures/route-spec/index.json';
 
 describe('test hook api', () => {
-  test('should route api work correctly', () => {
-    const manager = new RouteMatchManager();
-    manager.reset(spec.routes);
-    const matcher = manager.match('/home');
+  test('should base context work correctly', resolve => {
+    const cookie = 'a=b; c=d';
+    const req = httpMocks.createRequest({
+      url: '/home?id=12345',
+      headers: {
+        host: 'modernjs.com',
+        cookie,
+      },
+      eventEmitter: Readable,
+      method: 'GET',
+    });
+    const res = httpMocks.createResponse({ eventEmitter: EventEmitter });
+    const context = base(createContext(req, res));
+    const { request, response } = context;
 
-    const routeAPI = createRouteAPI(matcher!, manager, '');
-    expect(routeAPI.cur().entryName).toBe('home');
-    expect(routeAPI.get('entry')?.entryPath).toBe('html/entry/index.html');
+    // request data
+    expect(request.cookie).toBe(cookie);
+    expect(request.cookies.get('a')).toBe('b');
+    expect(request.headers.host).toBe('modernjs.com');
+    expect(request.pathname).toBe('/home');
+    expect(request.query.id).toBe('12345');
 
-    expect(routeAPI.use('home')).toBeTruthy();
-    expect(routeAPI.cur().entryName).toBe('home');
+    // response data
+    response.cookies.set('name', 'modern');
+    expect(response.cookies.get('name')).toBe('modern');
+    response.cookies.delete('name');
+    expect(response.cookies.get('name')).toBeUndefined();
+    response.cookies.set('name', 'modern');
+    expect(res.getHeader('set-cookie')).toBeUndefined();
+    response.cookies.apply();
+    expect(res.getHeader('set-cookie')).toBe('name=modern');
+    response.cookies.clear();
+    response.cookies.apply();
+    expect(res.getHeader('set-cookie')).toBeUndefined();
+
+    response.set('x-modern-test', 'foo');
+    expect(response.get('x-modern-test')).toBe('foo');
+
+    response.status(404);
+    expect(res.statusCode).toBe(404);
+
+    res.on('finish', () => {
+      expect(res._getData()).toBe('Hello Modern');
+      resolve();
+    });
+    response.raw('Hello Modern', {
+      status: 200,
+      headers: { 'x-modern-test': 'bar' },
+    });
+    expect(res.getHeader('x-modern-test')).toBe('bar');
+    expect(res.statusCode).toBe(200);
   });
 
-  test('should template api work correctly', () => {
+  test('should after match context work correctly', () => {
+    const req = httpMocks.createRequest({
+      url: '/',
+      headers: {
+        host: 'modernjs.com',
+      },
+      eventEmitter: Readable,
+      method: 'GET',
+    });
+    const res = httpMocks.createResponse({ eventEmitter: EventEmitter });
+    const { router } = createAfterMatchContext(createContext(req, res), 'main');
+
+    expect(router.current).toBe('main');
+    router.rewrite('home');
+    expect(router.current).toBe('home');
+    router.use('main');
+    expect(router.current).toBe('main');
+    router.redirect('https://modernjs.com', 301);
+    expect(router.url).toBe('https://modernjs.com');
+    expect(router.status).toBe(301);
+  });
+
+  test('should after render context work correctly', () => {
     const content = createDoc();
-    const templateAPI = createTemplateAPI(content);
+    const req = httpMocks.createRequest({
+      url: '/',
+      headers: {
+        host: 'modernjs.com',
+      },
+      eventEmitter: Readable,
+      method: 'GET',
+    });
+    const res = httpMocks.createResponse({ eventEmitter: EventEmitter });
+    const { template } = createAfterRenderContext(
+      createContext(req, res),
+      content,
+    );
 
-    expect(templateAPI.get()).toMatch(content);
+    expect(template.get()).toMatch(content);
+    template.appendBody('after body');
+    template.prependBody('before body');
+    template.appendHead('after head');
+    template.prependHead('before head');
 
-    templateAPI.replace('mock', 'replace');
-    expect(templateAPI.get()).toMatch('replace');
-
-    templateAPI.appendBody('after body');
-    templateAPI.prependBody('before body');
-    templateAPI.appendHead('after head');
-    templateAPI.prependHead('before head');
-
-    const newContent = templateAPI.get();
+    const newContent = template.get();
     expect(newContent).toMatch('<head>before head');
     expect(newContent).toMatch('<body>before body');
     expect(newContent).toMatch('after head</head>');
     expect(newContent).toMatch('after body</body>');
 
-    templateAPI.set('<div>empty</div>');
-    expect(templateAPI.get()).toBe('<div>empty</div>');
+    template.set('<div>empty</div>');
+    expect(template.get()).toBe('<div>empty</div>');
+  });
+
+  test('should middleware context worke correctly', () => {
+    const req = httpMocks.createRequest({
+      url: '/',
+      headers: {
+        host: 'modernjs.com',
+      },
+      eventEmitter: Readable,
+      method: 'GET',
+    });
+    const res = httpMocks.createResponse({ eventEmitter: EventEmitter });
+    const locals = { name: 'modern' };
+    res.locals = locals;
+    const { source, response } = createMiddlewareContext(
+      createContext(req, res),
+    );
+
+    expect(source.req).toBe(req);
+    expect(source.res).toBe(res);
+    expect(response.locals).toEqual(locals);
+
+    response.locals.foo = 'bar';
+    expect((locals as any).foo).toBe('bar');
   });
 });

--- a/packages/toolkit/types/server/context.d.ts
+++ b/packages/toolkit/types/server/context.d.ts
@@ -6,7 +6,7 @@ import { Metrics, Logger } from './utils';
 export interface ModernServerContext {
   req: IncomingMessage;
 
-  res: ServerResponse;
+  res: ServerResponse & { locals?: Record<string, any> };
 
   params: Record<string, string>;
 
@@ -64,6 +64,7 @@ export type BaseSSRServerContext = {
   response: {
     setHeader: (key: string, value: string) => void;
     status: (code: number) => void;
+    locals: Record<string, any>;
   };
   redirection: { url?: string; status?: number };
   distDir: string;
@@ -89,7 +90,6 @@ export type BaseSSRServerContext = {
   loadableManifest?: string;
   cacheConfig?: any;
 };
-
 export interface ISAppContext {
   appDirectory: string;
   distDirectory: string;

--- a/packages/toolkit/utils/src/compatRequire.ts
+++ b/packages/toolkit/utils/src/compatRequire.ts
@@ -5,23 +5,31 @@ import { findExists } from './findExists';
  * @param filePath - File to required.
  * @returns module export object.
  */
-export const compatRequire = (filePath: string) => {
+export const compatRequire = (filePath: string, interop = true) => {
   const mod = require(filePath);
+  const rtnESMDefault = interop && mod?.__esModule;
 
-  return mod?.__esModule ? mod.default : mod;
+  return rtnESMDefault ? mod.default : mod;
 };
 
 export const requireExistModule = (
   filename: string,
-  extensions = ['.ts', '.js'],
+  opt?: {
+    extensions?: string[];
+    interop?: boolean;
+  },
 ) => {
-  const exist = findExists(extensions.map(ext => `${filename}${ext}`));
-
+  const final = {
+    extensions: ['.ts', '.js'],
+    interop: true,
+    ...opt,
+  };
+  const exist = findExists(final.extensions.map(ext => `${filename}${ext}`));
   if (!exist) {
     return null;
   }
 
-  return compatRequire(exist);
+  return compatRequire(exist, final.interop);
 };
 
 export const cleanRequireCache = (filelist: string[]) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1829,6 +1829,7 @@ importers:
       '@modern-js-reduck/react': 1.0.1_react@18.2.0
       '@modern-js-reduck/store': 1.0.4
       '@modern-js/plugin': link:../../toolkit/plugin
+      '@modern-js/types': link:../../toolkit/types
       '@modern-js/utils': link:../../toolkit/utils
       '@modern-js/webpack': link:../../cli/webpack
       '@types/history': 4.7.11
@@ -1849,7 +1850,6 @@ importers:
       styled-components: 5.3.5_pumtretovylab5lwhztzjp2kuy
     devDependencies:
       '@modern-js/core': link:../../cli/core
-      '@modern-js/types': link:../../toolkit/types
       '@scripts/build': link:../../../scripts/build
       '@scripts/jest-config': link:../../../scripts/jest-config
       '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y


### PR DESCRIPTION
# PR Details

- support hook in `server/index.[jt]s`.
- now web server middleware can work without framework-ext plugin like `@modern-js/plugin-express` or `@modern-js/plugin-koa`.
- add `server.disableFrameworkExt` config. if true, ignore framework-ext plugin.

## Description

### Hook
Modern.js internal logic for handling HTML resources
```ts
// server/index.ts
import type { AfterRenderHook, AfterMatchHook } from '@modern-js/runtime/server';
export const afterRender: AfterRenderHook = async (context, next) => {}
export const afterMatch: AfterMatchHook = async (context, next) => {}
```

**BaseContext**
```ts
type HookContext = {
  response: {
    set: (key: string, value: string) => void;
    status: (code: number) => void;
    cookies: {
      get: (key: string) => string;
      set: (key: string, value: string) => void;
      delete: () => void;
      clear: () => void;
    };
    raw: (
      body: string,
      { status, headers }: { status: number; headers: Record<string, any> },
    ) => void;
  };
  request: {
    host: string;
    pathname: string;
    query: Record<string, any>;
    cookie: string;
    cookies: {
      get: (key: string) => string;
    };
    headers: IncomingHttpHeaders;
  };
  logger?: Logger;
  metrics?: Metrics;
};
```

**AfterMatchContext**
```ts
type AfterMatchContext = HookContext & {
  router: {
    redirect: (url: string, status: number) => void;
    rewrite: (entry: string) => void;
  };
}
```

**AfterRenderContext**
```ts
type AfterRenderContext = {
  template: {
    get: () => string;
    set: (html: string) => void;
    prependHead: (fragment: string) => void;
    appendHead: (fragment: string) => void;
    prependBody: (fragment: string) => void;
    appendBody: (fragment: string) => void;
  };
};
```

### Middleware
```ts
// server/index.ts

// without framework-ext plugin
import type { RequestHandler } from '@modern-js/runtime/server';
export const middleware: RequestHandler = async (context, next) => {}

// with framework-ext plugin，like @modern-js/plugin-express
import type { RequestHandler } from '@modern-js/runtime/express';
export const middleware: RequestHandler[] = [
  async (context, next) => {},
  async (context, next) => {},
]
```

**MiddlewareContext**
```ts
type MiddlewareContext = {
  response: {
    set: (key: string, value: string) => void;
    status: (code: number) => void;
    cookies: {
      get: (key: string) => string;
      set: (key: string, value: string) => void;
      delete: () => void;
      clear: () => void;
      apply: () => void;
    };
    raw: (
      body: string,
      { status, headers }: { status: number; headers: Record<string, any> },
    ) => void;
    locals: Record<string, any>;
  };
  request: {
    host: string;
    pathname: string;
    query: Record<string, any>;
    cookie: string;
    cookies: {
      get: (key: string) => string;
    };
    headers: IncomingHttpHeaders;
  };
  source: {
    req: IncomingMessage;
    res: ServerResponse;
  };
  logger?: Logger;
  metrics?: Metrics;
};
```

### New Config
```ts
{
  server: {
    disableFrameworkExt: true,
  }
}
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
