### PR TITLE
fix: mergeBuilderConfig sideEffect

### DIFF
--- a/packages/builder/builder-doc/en/config/tools/inspector.md
+++ b/packages/builder/builder-doc/en/config/tools/inspector.md
@@ -5,9 +5,9 @@ You can enable or configure the [Webpack Inspector](https://github.com/modern-js
 
   When the configuration is not `undefined`, it means that `webpack-inspector` is enabled, and the type of `tools.inspector` can be `Object` or `Function`.
 
-## Type
+### Type
 
-### Object
+#### Object
 
 When `tools.inspector` is configured with type `Object`, it is merged with the default configuration via Object.assign.  For example:
 
@@ -22,7 +22,7 @@ export default {
 };
 ```
 
-### Function
+#### Function
 
 When `tools.inspector` is of Function type, the default configuration is passed as the first parameter and can be directly modified or returned as the final result.  For example:
 

--- a/packages/builder/webpack-builder/src/shared/utils.ts
+++ b/packages/builder/webpack-builder/src/shared/utils.ts
@@ -198,11 +198,12 @@ export function getPackageNameFromModulePath(modulePath: string) {
   return packageName;
 }
 
-export const mergeBuilderConfig = <T>(...configs: T[]): T =>
-  _.mergeWith({}, ...configs, (target: unknown, source: unknown) => {
+export const mergeBuilderConfig = <T>(config: T, ...sources: T[]): T =>
+  _.mergeWith(config, ...sources, (target: unknown, source: unknown) => {
     const pair = [target, source];
     if (pair.some(_.isUndefined)) {
-      return pair.find(_.negate(_.isUndefined));
+      // fallback to lodash default merge behavior
+      return undefined;
     }
     if (pair.some(_.isArray)) {
       return [..._.castArray(target), ..._.castArray(source)];

--- a/packages/builder/webpack-builder/tests/mergeConfig.test.ts
+++ b/packages/builder/webpack-builder/tests/mergeConfig.test.ts
@@ -132,4 +132,49 @@ describe('mergeBuilderConfig', () => {
       },
     });
   });
+
+  it('should not effect source params', () => {
+    const obj = { a: [1], b: [2], c: { test: [2] } };
+    const other = { a: [3], b: [4], c: { test: [2] }, d: { test: [1] } };
+    const other1 = { a: [4], b: [5], c: { test: [3] }, d: { test: [2] } };
+
+    const res = mergeBuilderConfig<Record<string, any>>({}, obj, other, other1);
+
+    expect(res).toEqual({
+      a: [1, 3, 4],
+      b: [2, 4, 5],
+      c: { test: [2, 2, 3] },
+      d: { test: [1, 2] },
+    });
+    expect(obj).toEqual({ a: [1], b: [2], c: { test: [2] } });
+    expect(other).toEqual({
+      a: [3],
+      b: [4],
+      c: { test: [2] },
+      d: { test: [1] },
+    });
+    expect(other1).toEqual({
+      a: [4],
+      b: [5],
+      c: { test: [3] },
+      d: { test: [2] },
+    });
+
+    const res1 = mergeBuilderConfig<Record<string, any>>(obj, other, other1);
+
+    expect(res1).toEqual(res);
+    expect(obj).toEqual(res);
+    expect(other).toEqual({
+      a: [3],
+      b: [4],
+      c: { test: [2] },
+      d: { test: [1] },
+    });
+    expect(other1).toEqual({
+      a: [4],
+      b: [5],
+      c: { test: [3] },
+      d: { test: [2] },
+    });
+  });
 });


### PR DESCRIPTION
# PR Details

mergeBuilderConfig api should not effect source params when some property is undefined
## Description

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
