### PR TITLE
fix(webpack): react-refresh-webpack-plugin cause rebuild slow

### DIFF
--- a/.changeset/twelve-spoons-burn.md
+++ b/.changeset/twelve-spoons-burn.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/webpack': patch
+---
+
+fix(webpack): react-refresh-webpack-plugin cause rebuild slow
+
+fix(webpack): 修复 react-refresh-webpack-plugin 导致重新编译慢的问题

--- a/packages/builder/webpack-builder/package.json
+++ b/packages/builder/webpack-builder/package.json
@@ -78,7 +78,7 @@
     "@modern-js/server": "workspace:*",
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "@pmmmwh/react-refresh-webpack-plugin": "0.5.5",
+    "@modern-js/react-refresh-webpack-plugin": "0.5.8",
     "@svgr/webpack": "6.2.1",
     "@types/mini-css-extract-plugin": "2.2.0",
     "caniuse-lite": "^1.0.30001332",

--- a/packages/builder/webpack-builder/src/plugins/react.ts
+++ b/packages/builder/webpack-builder/src/plugins/react.ts
@@ -9,7 +9,7 @@ export const PluginReact = (): BuilderPlugin => ({
         return;
       }
       const { default: ReactFastRefreshPlugin } = await import(
-        '@pmmmwh/react-refresh-webpack-plugin'
+        '@modern-js/react-refresh-webpack-plugin'
       );
       const config = api.getBuilderConfig();
       const useTsLoader = Boolean(config.tools?.tsLoader);

--- a/packages/cli/webpack/package.json
+++ b/packages/cli/webpack/package.json
@@ -48,7 +48,7 @@
     "@modern-js/babel-preset-app": "workspace:*",
     "@modern-js/css-config": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.5",
+    "@modern-js/react-refresh-webpack-plugin": "0.5.8",
     "@svgr/webpack": "^6.2.1",
     "core-js": "^3.25.0",
     "css-minimizer-webpack-plugin": "^3.0.2",

--- a/packages/cli/webpack/src/config/features/react-refresh.ts
+++ b/packages/cli/webpack/src/config/features/react-refresh.ts
@@ -2,7 +2,7 @@ import { CHAIN_ID } from '@modern-js/utils';
 import type { ChainUtils } from '../shared';
 
 export function applyReactRefreshPlugin({ chain }: ChainUtils) {
-  const ReactFastRefreshPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+  const ReactFastRefreshPlugin = require('@modern-js/react-refresh-webpack-plugin');
 
   chain.plugin(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH).use(ReactFastRefreshPlugin, [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,10 +104,10 @@ importers:
       '@modern-js/babel-preset-app': workspace:*
       '@modern-js/e2e': workspace:*
       '@modern-js/inspector-webpack-plugin': 1.0.3
+      '@modern-js/react-refresh-webpack-plugin': 0.5.8
       '@modern-js/server': workspace:*
       '@modern-js/types': workspace:*
       '@modern-js/utils': workspace:*
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.5
       '@scripts/vitest-config': workspace:*
       '@svgr/webpack': 6.2.1
       '@types/babel__core': ^7.1.19
@@ -135,10 +135,10 @@ importers:
     dependencies:
       '@modern-js/babel-preset-app': link:../../cli/babel-preset-app
       '@modern-js/inspector-webpack-plugin': 1.0.3
+      '@modern-js/react-refresh-webpack-plugin': 0.5.8_mrng46iweft73kaoehgasn3du4
       '@modern-js/server': link:../../server/server
       '@modern-js/types': link:../../toolkit/types
       '@modern-js/utils': link:../../toolkit/utils
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.5_mrng46iweft73kaoehgasn3du4
       '@svgr/webpack': 6.2.1
       '@types/mini-css-extract-plugin': 2.2.0
       caniuse-lite: 1.0.30001375
@@ -808,9 +808,9 @@ importers:
       '@modern-js/babel-preset-app': workspace:*
       '@modern-js/core': workspace:*
       '@modern-js/css-config': workspace:*
+      '@modern-js/react-refresh-webpack-plugin': 0.5.8
       '@modern-js/types': workspace:*
       '@modern-js/utils': workspace:*
-      '@pmmmwh/react-refresh-webpack-plugin': ^0.5.5
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@svgr/webpack': ^6.2.1
@@ -840,8 +840,8 @@ importers:
       '@babel/core': 7.18.6
       '@modern-js/babel-preset-app': link:../babel-preset-app
       '@modern-js/css-config': link:../css-config
+      '@modern-js/react-refresh-webpack-plugin': 0.5.8_mrng46iweft73kaoehgasn3du4
       '@modern-js/utils': link:../../toolkit/utils
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.7_mrng46iweft73kaoehgasn3du4
       '@svgr/webpack': 6.2.1
       core-js: 3.25.0
       css-minimizer-webpack-plugin: 3.4.1_webpack@5.73.0
@@ -9330,6 +9330,45 @@ packages:
       - supports-color
     dev: false
 
+  /@modern-js/react-refresh-webpack-plugin/0.5.8_mrng46iweft73kaoehgasn3du4:
+    resolution: {integrity: sha512-bdhpVaQb1qZwZ1FTAp6oQfWhQkQj6UNk1R6tV7CgsqUEUmHQv3muV63WDzZ/2aAIJZ9x3DY+wXqyKD62SKVKbw==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      '@types/webpack': 4.x || 5.x
+      react-refresh: '>=0.10.0 <1.0.0'
+      sockjs-client: ^1.4.0
+      type-fest: '>=0.17.0 <4.0.0'
+      webpack: '>=4.43.0 <6.0.0'
+      webpack-dev-server: 3.x || 4.x
+      webpack-hot-middleware: 2.x
+      webpack-plugin-serve: 0.x || 1.x
+    peerDependenciesMeta:
+      '@types/webpack':
+        optional: true
+      sockjs-client:
+        optional: true
+      type-fest:
+        optional: true
+      webpack-dev-server:
+        optional: true
+      webpack-hot-middleware:
+        optional: true
+      webpack-plugin-serve:
+        optional: true
+    dependencies:
+      ansi-html-community: 0.0.8
+      common-path-prefix: 3.0.0
+      core-js-pure: 3.23.3
+      error-stack-parser: 2.1.4
+      find-up: 5.0.0
+      html-entities: 2.3.3
+      loader-utils: 2.0.2
+      react-refresh: 0.12.0
+      schema-utils: 3.1.1
+      source-map: 0.7.4
+      webpack: 5.73.0
+    dev: false
+
   /@modern-js/utils/1.16.0:
     resolution: {integrity: sha512-ELiw1wX+L+wImU+uSqT7zHSqyeAmVKxxSEciCSfo3+neyyw/TwlD3IAHnjsgUb+Qi4VUX5MH6znixVscSGvD8A==}
     dependencies:
@@ -9609,45 +9648,6 @@ packages:
       playwright-core: 1.25.1
     dev: false
 
-  /@pmmmwh/react-refresh-webpack-plugin/0.5.5_mrng46iweft73kaoehgasn3du4:
-    resolution: {integrity: sha512-RbG7h6TuP6nFFYKJwbcToA1rjC1FyPg25NR2noAZ0vKI+la01KTSRPkuVPE+U88jXv7javx2JHglUcL1MHcshQ==}
-    engines: {node: '>= 10.13'}
-    peerDependencies:
-      '@types/webpack': 4.x || 5.x
-      react-refresh: '>=0.10.0 <1.0.0'
-      sockjs-client: ^1.4.0
-      type-fest: '>=0.17.0 <3.0.0'
-      webpack: '>=4.43.0 <6.0.0'
-      webpack-dev-server: 3.x || 4.x
-      webpack-hot-middleware: 2.x
-      webpack-plugin-serve: 0.x || 1.x
-    peerDependenciesMeta:
-      '@types/webpack':
-        optional: true
-      sockjs-client:
-        optional: true
-      type-fest:
-        optional: true
-      webpack-dev-server:
-        optional: true
-      webpack-hot-middleware:
-        optional: true
-      webpack-plugin-serve:
-        optional: true
-    dependencies:
-      ansi-html-community: 0.0.8
-      common-path-prefix: 3.0.0
-      core-js-pure: 3.23.3
-      error-stack-parser: 2.1.4
-      find-up: 5.0.0
-      html-entities: 2.3.3
-      loader-utils: 2.0.2
-      react-refresh: 0.12.0
-      schema-utils: 3.1.1
-      source-map: 0.7.4
-      webpack: 5.73.0
-    dev: false
-
   /@pmmmwh/react-refresh-webpack-plugin/0.5.7_aumhct55s6lhceplyc622fxoum:
     resolution: {integrity: sha512-bcKCAzF0DV2IIROp9ZHkRJa6O4jy7NlnHdWL3GmcUxYWNjLXkK5kfELELwEfSP5hXPfVL/qOGMAROuMQb9GG8Q==}
     engines: {node: '>= 10.13'}
@@ -9685,45 +9685,6 @@ packages:
       schema-utils: 3.1.1
       source-map: 0.7.4
       webpack: 5.73.0_esbuild@0.14.47
-    dev: false
-
-  /@pmmmwh/react-refresh-webpack-plugin/0.5.7_mrng46iweft73kaoehgasn3du4:
-    resolution: {integrity: sha512-bcKCAzF0DV2IIROp9ZHkRJa6O4jy7NlnHdWL3GmcUxYWNjLXkK5kfELELwEfSP5hXPfVL/qOGMAROuMQb9GG8Q==}
-    engines: {node: '>= 10.13'}
-    peerDependencies:
-      '@types/webpack': 4.x || 5.x
-      react-refresh: '>=0.10.0 <1.0.0'
-      sockjs-client: ^1.4.0
-      type-fest: '>=0.17.0 <3.0.0'
-      webpack: '>=4.43.0 <6.0.0'
-      webpack-dev-server: 3.x || 4.x
-      webpack-hot-middleware: 2.x
-      webpack-plugin-serve: 0.x || 1.x
-    peerDependenciesMeta:
-      '@types/webpack':
-        optional: true
-      sockjs-client:
-        optional: true
-      type-fest:
-        optional: true
-      webpack-dev-server:
-        optional: true
-      webpack-hot-middleware:
-        optional: true
-      webpack-plugin-serve:
-        optional: true
-    dependencies:
-      ansi-html-community: 0.0.8
-      common-path-prefix: 3.0.0
-      core-js-pure: 3.23.3
-      error-stack-parser: 2.1.4
-      find-up: 5.0.0
-      html-entities: 2.3.3
-      loader-utils: 2.0.2
-      react-refresh: 0.12.0
-      schema-utils: 3.1.1
-      source-map: 0.7.4
-      webpack: 5.73.0
     dev: false
 
   /@polka/url/1.0.0-next.21:


### PR DESCRIPTION
# PR Details

## Description

This PR using the forked `@modern-js/react-refresh-webpack-plugin` package to replace `@pmmmwh/react-refresh-webpack-plugin`, the forked package is under https://github.com/modern-js-dev/react-refresh-webpack-plugin.

### Why fork this package?

The react-refresh-webpack-plugin has a performance issue and will cause webpack rebuild much more slower, see:https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/669

This performance issue has been fixed, but react-refresh-webpack-plugin has not released a new version for a long time, so we forked the package and released a new version to fix the performance issue.

Once react-refresh-webpack-plugin released a new version, we will switch back to the official package.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
