### PR TITLE
fix(builder): failed to disable tsChecker with modifyBuilderConfig

### DIFF
--- a/packages/builder/builder-webpack-provider/src/plugins/cleanOutput.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/cleanOutput.ts
@@ -4,17 +4,17 @@ export const PluginCleanOutput = (): BuilderPlugin => ({
   name: 'builder-plugin-clean-output',
 
   setup(api) {
-    const config = api.getBuilderConfig();
+    const clean = async () => {
+      const config = api.getBuilderConfig();
 
-    if (config.output?.cleanDistPath) {
-      const clean = async () => {
+      if (config.output?.cleanDistPath) {
         const { emptyDir } = await import('@modern-js/utils');
         const { distPath } = api.context;
         await emptyDir(distPath);
-      };
+      }
+    };
 
-      api.onBeforeBuild(clean);
-      api.onBeforeStartDevServer(clean);
-    }
+    api.onBeforeBuild(clean);
+    api.onBeforeStartDevServer(clean);
   },
 });

--- a/packages/builder/builder-webpack-provider/src/plugins/tsChecker.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/tsChecker.ts
@@ -4,15 +4,15 @@ export const PluginTsChecker = (): BuilderPlugin => {
   return {
     name: 'builder-plugin-ts-checker',
     setup(api) {
-      const config = api.getBuilderConfig();
-      // Use tsChecker if tsChecker is not `false`, So there are two situations for user:
-      // 1. tsLoader + transpileOnly + tschecker
-      // 2. @babel/preset-typescript + tschecker
-      if (config.tools?.tsChecker === false || !api.context.tsconfigPath) {
-        return;
-      }
-
       api.modifyWebpackChain(async chain => {
+        const config = api.getBuilderConfig();
+        // Use tsChecker if tsChecker is not `false`, So there are two situations for user:
+        // 1. tsLoader + transpileOnly + tschecker
+        // 2. @babel/preset-typescript + tschecker
+        if (config.tools?.tsChecker === false || !api.context.tsconfigPath) {
+          return;
+        }
+
         const { default: ForkTsCheckerWebpackPlugin } = await import(
           'fork-ts-checker-webpack-plugin'
         );


### PR DESCRIPTION
# PR Details

## Description

Move `api.getBuilderConfig` inside the `api.modifyWebpackChain` callback, so we can get the correct builder config.

This change allows other plugins to modify builder config to disable the ts checker.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
