### PR TITLE
fix(builder): should not apply react refresh when dev.hmr is false

### DIFF
--- a/.changeset/silly-elephants-protect.md
+++ b/.changeset/silly-elephants-protect.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): should not apply react refresh when dev.hmr is false
+
+fix(builder): 修复 dev.hmr 为 false 时仍然会注入 react-refresh 的问题

--- a/packages/builder/builder-webpack-provider/src/plugins/react.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/react.ts
@@ -5,17 +5,20 @@ export const PluginReact = (): BuilderPlugin => ({
 
   setup(api) {
     api.modifyWebpackChain(async (chain, { CHAIN_ID, isProd }) => {
-      if (isProd) {
+      const config = api.getBuilderConfig();
+
+      if (isProd || config.dev?.hmr === false) {
         return;
       }
+
       const { default: ReactFastRefreshPlugin } = await import(
         '@modern-js/react-refresh-webpack-plugin'
       );
-      const config = api.getBuilderConfig();
       const useTsLoader = Boolean(config.tools?.tsLoader);
       const rule = useTsLoader
         ? chain.module.rule(CHAIN_ID.RULE.TS)
         : chain.module.rule(CHAIN_ID.RULE.JS);
+
       rule.use(CHAIN_ID.USE.BABEL).tap(options => ({
         ...options,
         plugins: [

--- a/packages/builder/builder-webpack-provider/tests/plugins/react.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/react.test.ts
@@ -32,4 +32,17 @@ describe('plugins/react', () => {
 
     expect(config).toMatchSnapshot();
   });
+
+  it('should not apply react refresh when dev.hmr is false', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginReact()],
+      builderConfig: {
+        dev: {
+          hmr: false,
+        },
+      },
+    });
+
+    expect(await builder.matchWebpackPlugin('ReactRefreshPlugin')).toBeFalsy();
+  });
 });


### PR DESCRIPTION
# PR Details

## Description

should not apply react refresh when dev.hmr is false.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
