### PR TITLE
fix(builder): api.onExit hook not work

### DIFF
--- a/.changeset/brown-cobras-reply.md
+++ b/.changeset/brown-cobras-reply.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): api.onExit hook not work
+
+fix(builder): 修复 api.onExit 钩子不生效的问题

--- a/.changeset/twelve-spoons-burn.md
+++ b/.changeset/twelve-spoons-burn.md
@@ -1,6 +1,6 @@
 ---
 '@modern-js/webpack': patch
-'@modern-js/builder-provider-webpack': patch
+'@modern-js/builder-webpack-provider': patch
 ---
 
 fix(webpack): react-refresh-webpack-plugin cause rebuild slow

--- a/packages/builder/builder-shared/src/index.ts
+++ b/packages/builder/builder-shared/src/index.ts
@@ -8,6 +8,7 @@ export * from './fs';
 export * from './getBrowserslist';
 export * from './logger';
 export * from './mergeBuilderConfig';
+export * from './onExitProcess';
 export * from './pick';
 export * from './regexp';
 export * from './types';

--- a/packages/builder/builder-shared/src/onExitProcess.ts
+++ b/packages/builder/builder-shared/src/onExitProcess.ts
@@ -1,0 +1,10 @@
+export function onExitProcess(listener: NodeJS.ExitListener) {
+  process.on('exit', listener);
+
+  // listen to 'SIGINT' and trigger a exit
+  // 'SIGINT' from the terminal is supported on all platforms, and can usually be generated with Ctrl + C
+  process.on('SIGINT', () => {
+    // eslint-disable-next-line no-process-exit
+    process.exit(0);
+  });
+}

--- a/packages/builder/builder-webpack-provider/src/core/initPlugins.ts
+++ b/packages/builder/builder-webpack-provider/src/core/initPlugins.ts
@@ -1,5 +1,6 @@
 import {
   debug,
+  onExitProcess,
   createPublicContext,
   type PluginStore,
 } from '@modern-js/builder-shared';
@@ -40,6 +41,10 @@ export async function initPlugins({
   for (const plugin of pluginStore.plugins) {
     await plugin.setup(pluginAPI);
   }
+
+  onExitProcess(() => {
+    hooks.onExitHook.call();
+  });
 
   debug('init plugins done');
 }

--- a/packages/builder/builder-webpack-provider/tests/__snapshots__/hooks.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/__snapshots__/hooks.test.ts.snap
@@ -1,0 +1,17 @@
+// Vitest Snapshot v1
+
+exports[`initHooks > should init hooks correctly 1`] = `
+[
+  "onExitHook",
+  "onAfterBuildHook",
+  "onBeforeBuildHook",
+  "onDevCompileDoneHook",
+  "modifyWebpackChainHook",
+  "modifyWebpackConfigHook",
+  "modifyBuilderConfigHook",
+  "onAfterCreateCompilerHooks",
+  "onBeforeCreateCompilerHooks",
+  "onAfterStartDevServerHooks",
+  "onBeforeStartDevServerHooks",
+]
+`;

--- a/packages/builder/builder-webpack-provider/tests/createAsyncHook.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/createAsyncHook.test.ts
@@ -1,9 +1,0 @@
-import { describe, expect, test } from 'vitest';
-import { initHooks } from '../src/core/initHooks';
-
-describe('initHooks', () => {
-  test('should init hooks correctly', async () => {
-    const hooks = initHooks();
-    expect(Object.keys(hooks)).toMatchSnapshot();
-  });
-});

--- a/packages/builder/builder-webpack-provider/tests/hooks.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/hooks.test.ts
@@ -1,0 +1,37 @@
+import { vi, describe, expect, test } from 'vitest';
+import { initHooks } from '../src/core/initHooks';
+import { createStubBuilder } from '../src/stub';
+
+describe('initHooks', () => {
+  test('should init hooks correctly', async () => {
+    const hooks = initHooks();
+    expect(Object.keys(hooks)).toMatchSnapshot();
+  });
+});
+
+describe('onExit hook', () => {
+  test('should listen to process exit when calling api.onExit', async () => {
+    const spy = vi.spyOn(process, 'on');
+    spy.mockImplementation((event, cb) => {
+      if (event === 'exit') {
+        cb();
+      }
+      return process;
+    });
+
+    const onExit = vi.fn();
+    const builder = await createStubBuilder({
+      plugins: [
+        {
+          name: 'foo',
+          setup(api) {
+            api.onExit(onExit);
+          },
+        },
+      ],
+    });
+    await builder.unwrapWebpackConfig();
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# PR Details

## Description

- Fix api.onExit hook not work.
- Fix builder package name in changeset.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
