### PR TITLE
fix(utils): failed to resolve execa

### DIFF
--- a/.changeset/smooth-feet-attend.md
+++ b/.changeset/smooth-feet-attend.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/utils': patch
+---
+
+fix(utils): failed to resolve execa
+
+fix(utils): 修复找不到 execa 模块的问题

--- a/packages/toolkit/utils/src/version.ts
+++ b/packages/toolkit/utils/src/version.ts
@@ -1,6 +1,5 @@
 import path from 'path';
-import execa from 'execa';
-import { fs, semver } from './compiled';
+import { fs, execa, semver } from './compiled';
 
 export async function getPnpmVersion() {
   const { stdout } = await execa('pnpm', ['--version']);


### PR DESCRIPTION
# PR Details

## Description

Fix failed to resolve execa, it is not installed.

```bash
Error: Cannot find module 'execa'
Require stack:
- /Users/Project/demos/demo/node_modules/.pnpm/@modern-js+utils@0.0.0-canary-20221012094820/node_modules/@modern-js/utils/dist/version.js
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
