### PR TITLE
fix(builder): not apply style-loader or extract css when target is node

### DIFF
--- a/.changeset/warm-keys-hammer.md
+++ b/.changeset/warm-keys-hammer.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): not apply style-loader or extract css when target is node
+
+fix(builder): 修复 CSS 构建时注册了 style-loader 或 extract css 导致报错的问题

--- a/packages/builder/builder-webpack-provider/src/plugins/css.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/css.ts
@@ -114,30 +114,34 @@ export async function applyBaseCSSRule(
 
   // 3. Create webpack rule
   // Order: style-loader/mini-css-extract -> css-loader -> postcss-loader
-  rule
-    .when(
-      enableExtractCSS,
-      // use mini-css-extract-plugin loader
-      c => {
-        c.use(CHAIN_ID.USE.MINI_CSS_EXTRACT)
-          .loader(require('mini-css-extract-plugin').loader)
-          .options(extractLoaderOptions)
-          .end();
-      },
-      // or use style-loader
-      c => {
-        c.use(CHAIN_ID.USE.STYLE)
-          .loader(require.resolve('style-loader'))
-          .options(styleLoaderOptions)
-          .end();
-      },
-    )
+  if (!isServer) {
+    // use mini-css-extract-plugin loader
+    if (enableExtractCSS) {
+      rule
+        .use(CHAIN_ID.USE.MINI_CSS_EXTRACT)
+        .loader(require('mini-css-extract-plugin').loader)
+        .options(extractLoaderOptions)
+        .end();
+    }
+    // use style-loader
+    else {
+      rule
+        .use(CHAIN_ID.USE.STYLE)
+        .loader(require.resolve('style-loader'))
+        .options(styleLoaderOptions)
+        .end();
+    }
+
     // use css-modules-typescript-loader
-    .when(enableCSSModuleTS, c => {
-      c.use(CHAIN_ID.USE.CSS_MODULES_TS)
+    if (enableCSSModuleTS) {
+      rule
+        .use(CHAIN_ID.USE.CSS_MODULES_TS)
         .loader(getCompiledPath('css-modules-typescript-loader'))
         .end();
-    })
+    }
+  }
+
+  rule
     .use(CHAIN_ID.USE.CSS)
     .loader(getCompiledPath('css-loader'))
     .options(cssLoaderOptions)

--- a/packages/builder/builder-webpack-provider/tests/plugins/css.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/css.test.ts
@@ -87,4 +87,38 @@ describe('plugins/css', () => {
 
     expect(config).toMatchSnapshot();
   });
+
+  it('should not apply mini-css-extract-plugin when target is node', async () => {
+    const builder = await createStubBuilder({
+      target: ['node'],
+      plugins: [PluginCss()],
+      builderConfig: {},
+    });
+
+    const includeMiniCssExtractLoader = await builder.matchWebpackLoader(
+      'mini-css-extract-plugin',
+      'index.css',
+    );
+
+    expect(includeMiniCssExtractLoader).toBe(false);
+  });
+
+  it('should not apply style-loader when target is node', async () => {
+    const builder = await createStubBuilder({
+      target: ['node'],
+      plugins: [PluginCss()],
+      builderConfig: {
+        tools: {
+          styleLoader: {},
+        },
+      },
+    });
+
+    const includeStyleLoader = await builder.matchWebpackLoader(
+      'style-loader',
+      'index.css',
+    );
+
+    expect(includeStyleLoader).toBe(false);
+  });
 });


### PR DESCRIPTION
# PR Details

## Description

Should not apply style-loader or extract css when target is node, otherwise there will be compile error or runtime error.

<img width="1054" alt="截屏2022-10-13 15 56 58" src="https://user-images.githubusercontent.com/7237365/195537716-b13122d4-0bb5-412b-a6b6-50d2e099cd93.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
