### PR TITLE
fix(builder): inlined assets should be deleted after all html generated

### DIFF
--- a/.changeset/strange-months-guess.md
+++ b/.changeset/strange-months-guess.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@e2e/webpack-builder-inline-chunk': patch
+---
+
+fix(builder): inlined assets should be deleted after all html generated
+
+fix(builder): inline 的资源应该在所有 html 生成后被删除

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/inlineChunk.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/inlineChunk.test.ts.snap
@@ -24,6 +24,7 @@ exports[`plugins/inlineChunk > should add InlineChunkHtmlPlugin properly by defa
     },
     InlineChunkHtmlPlugin {
       "htmlWebpackPlugin": [Function],
+      "inlinedAssets": Set {},
       "tests": [
         /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
       ],
@@ -56,6 +57,7 @@ exports[`plugins/inlineChunk > should use proper plugin options when disableInli
     },
     InlineChunkHtmlPlugin {
       "htmlWebpackPlugin": [Function],
+      "inlinedAssets": Set {},
       "tests": [],
     },
   ],
@@ -86,6 +88,7 @@ exports[`plugins/inlineChunk > should use proper plugin options when enableInlin
     },
     InlineChunkHtmlPlugin {
       "htmlWebpackPlugin": [Function],
+      "inlinedAssets": Set {},
       "tests": [
         /\\\\\\.js\\$/,
         /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
@@ -119,6 +122,7 @@ exports[`plugins/inlineChunk > should use proper plugin options when enableInlin
     },
     InlineChunkHtmlPlugin {
       "htmlWebpackPlugin": [Function],
+      "inlinedAssets": Set {},
       "tests": [
         /\\\\\\.css\\$/,
         /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,

--- a/tests/e2e/webpack-builder/inline-chunk/build.test.ts
+++ b/tests/e2e/webpack-builder/inline-chunk/build.test.ts
@@ -3,6 +3,9 @@ import { expect, test } from '@modern-js/e2e/playwright';
 import { RUNTIME_CHUNK_NAME } from '@modern-js/builder-shared';
 import { createStubBuilder } from '@modern-js/builder-webpack-provider/stub';
 
+const isRuntimeChunkInHtml = (html: string): boolean =>
+  Boolean(html.match(new RegExp(`${RUNTIME_CHUNK_NAME}\\.(.+)\\.js\\.map`)));
+
 test('inline runtime chunk by default', async () => {
   const builder = await createStubBuilder({
     webpack: true,
@@ -19,7 +22,30 @@ test('inline runtime chunk by default', async () => {
   const indexHtml =
     files[path.resolve(__dirname, './dist/html/index/index.html')];
 
+  expect(isRuntimeChunkInHtml(indexHtml)).toBeTruthy();
+});
+
+test('inline runtime chunk by default with multiple entries', async () => {
+  const builder = await createStubBuilder({
+    webpack: true,
+    entry: {
+      index: path.resolve('./src/index.js'),
+      another: path.resolve('./src/another.js'),
+    },
+  });
+  const files = await builder.unwrapOutputJSON();
+
+  // no builder-runtime file in output
   expect(
-    indexHtml.match(new RegExp(`${RUNTIME_CHUNK_NAME}\\.(.+)\\.js\\.map`)),
-  ).toBeTruthy();
+    Object.keys(files).some(fileName => fileName.includes(RUNTIME_CHUNK_NAME)),
+  ).toBe(false);
+
+  // found builder-runtime file in html
+  const indexHtml =
+    files[path.resolve(__dirname, './dist/html/index/index.html')];
+  const anotherHtml =
+    files[path.resolve(__dirname, './dist/html/another/index.html')];
+
+  expect(isRuntimeChunkInHtml(indexHtml)).toBeTruthy();
+  expect(isRuntimeChunkInHtml(anotherHtml)).toBeTruthy();
 });

--- a/tests/e2e/webpack-builder/inline-chunk/src/another.js
+++ b/tests/e2e/webpack-builder/inline-chunk/src/another.js
@@ -1,0 +1,8 @@
+import './style.css';
+
+import(
+  /* webpackChunkName: "foo" */
+  './foo'
+).then(({ foo }) => {
+  window.answer = 'another ' + foo();
+});


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

If there are more than one entries, the inlined assets are deleted right after the first html plugin being executed. That will cause the rest html files missing part of the assets (deleted ones).

This PR fixes that by delay the deletion of inlined assets to processAssets summarize stage.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
