### PR TITLE
fix(builder): default value of tools.tsChecker config

### DIFF
--- a/.changeset/tiny-knives-collect.md
+++ b/.changeset/tiny-knives-collect.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-doc': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): default value of tools.tsChecker config
+
+fix(builder): 修复 tools.tsChecker 默认值错误的问题

--- a/packages/builder/builder-doc/en/config/tools/tsChecker.md
+++ b/packages/builder/builder-doc/en/config/tools/tsChecker.md
@@ -1,10 +1,13 @@
-- Type: `Object | Function | false`
-- Default: `Object`
+- Type: `boolean | Object | Function`
+- Default: `true`
 
-By default, the [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin) is enabled for type checking. You can:
+By default, the [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin) is enabled for type checking.
 
+You can:
+
+- Configure to `true` to enable type checking by `fork-ts-checker-webpack-plugin`.
+- Configure to `false` to disable type checking by `fork-ts-checker-webpack-plugin`.
 - Configure as `Object` or `Function` to modify the default config.
-- Configure to `false` to turn off type checking for `fork-ts-checker-webpack-plugin`.
 
 The default config is as follows:
 

--- a/packages/builder/builder-doc/zh/config/tools/tsChecker.md
+++ b/packages/builder/builder-doc/zh/config/tools/tsChecker.md
@@ -1,10 +1,13 @@
-- Type: `Object | Function | false`
-- Default: `Object`
+- Type: `boolean | Object | Function`
+- Default: `true`
 
-默认情况下，开启 [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin) 进行类型检查，你可以通过:
+默认情况下，Builder 会开启 [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin) 进行类型检查。
 
-- 配置为 `Object` 或者 `Function` 修改默认配置；
+你可以通过:
+
+- 配置为 `true` 以开启 `fork-ts-checker-webpack-plugin` 的类型检查。
 - 配置为 `false` 以关闭 `fork-ts-checker-webpack-plugin` 的类型检查。
+- 配置为 `Object` 或者 `Function` 修改默认配置；
 
 默认配置如下:
 

--- a/packages/builder/builder-webpack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-webpack-provider/src/config/defaults.ts
@@ -1,4 +1,6 @@
 import {
+  extendsType,
+  DEFAULT_PORT,
   ROOT_DIST_DIR,
   HTML_DIST_DIR,
   JS_DIST_DIR,
@@ -8,7 +10,6 @@ import {
   IMAGE_DIST_DIR,
   MEDIA_DIST_DIR,
   mergeBuilderConfig,
-  extendsType,
 } from '@modern-js/builder-shared';
 import type { BuilderConfig } from '../types';
 
@@ -17,22 +18,24 @@ const defineDefaultConfig = extendsType<BuilderConfig>();
 export const createDefaultConfig = () =>
   defineDefaultConfig({
     dev: {
-      port: 8080,
-      assetPrefix: '/',
-      https: false,
-      startUrl: false,
       hmr: true,
+      https: false,
+      port: DEFAULT_PORT,
+      assetPrefix: '/',
+      startUrl: false,
       progressBar: true,
     },
     html: {
       crossorigin: false,
       disableHtmlFolder: false,
     },
-    tools: {},
+    tools: {
+      tsChecker: true,
+    },
     source: {
+      alias: {},
       preEntry: [],
       globalVars: {},
-      alias: {},
       compileJsDataURI: false,
     },
     output: {

--- a/packages/builder/builder-webpack-provider/src/plugins/tsChecker.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/tsChecker.ts
@@ -7,8 +7,8 @@ export const PluginTsChecker = (): BuilderPlugin => {
       api.modifyWebpackChain(async chain => {
         const config = api.getBuilderConfig();
         // Use tsChecker if tsChecker is not `false`, So there are two situations for user:
-        // 1. tsLoader + transpileOnly + tschecker
-        // 2. @babel/preset-typescript + tschecker
+        // 1. tsLoader + transpileOnly + tsChecker
+        // 2. @babel/preset-typescript + tsChecker
         if (config.tools?.tsChecker === false || !api.context.tsconfigPath) {
           return;
         }
@@ -46,7 +46,9 @@ export const PluginTsChecker = (): BuilderPlugin => {
               },
             },
           },
-          config.tools?.tsChecker || {},
+          typeof config.tools?.tsChecker === 'object'
+            ? config.tools?.tsChecker
+            : {},
         );
 
         chain

--- a/packages/builder/builder-webpack-provider/src/types/config/output.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/output.ts
@@ -87,15 +87,19 @@ export type RemOptions = Partial<{
 
 export type ExternalsOptions = WebpackConfig['externals'];
 
+export type Charset = 'ascii' | 'utf8';
+export type SvgDefaultExport = 'component' | 'url';
+export type LegalComments = 'none' | 'inline' | 'linked';
+
 export interface OutputConfig {
   copy?: CopyPluginOptions | CopyPluginOptions['patterns'];
   distPath?: DistPathConfig;
   filename?: FilenameConfig;
-  charset?: 'ascii' | 'utf8';
+  charset?: Charset;
   polyfill?: Polyfill;
   assetPrefix?: string;
   dataUriLimit?: number | DataUriLimit;
-  legalComments?: 'none' | 'inline' | 'linked';
+  legalComments?: LegalComments;
   cleanDistPath?: boolean;
   disableMinimize?: boolean;
   disableSourceMap?: boolean;
@@ -108,7 +112,7 @@ export interface OutputConfig {
   enableInlineScripts?: boolean;
   enableInlineStyles?: boolean;
   overrideBrowserslist?: string[];
-  svgDefaultExport?: 'component' | 'url';
+  svgDefaultExport?: SvgDefaultExport;
   assetsRetry?: AssetsRetryOptions;
   convertToRem?: boolean | RemOptions;
   externals?: ExternalsOptions;
@@ -119,5 +123,5 @@ export interface NormalizedOutputConfig extends OutputConfig {
   distPath: DistPathConfig;
   polyfill: Polyfill;
   cleanDistPath: boolean;
-  svgDefaultExport: 'component' | 'url';
+  svgDefaultExport: SvgDefaultExport;
 }

--- a/packages/builder/builder-webpack-provider/src/types/config/tools.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/tools.ts
@@ -102,7 +102,7 @@ export interface ToolsConfig {
   babel?: ToolsBabelConfig;
   terser?: ToolsTerserConfig;
   tsLoader?: ToolsTSLoaderConfig;
-  tsChecker?: false | ToolsTSCheckerConfig;
+  tsChecker?: boolean | ToolsTSCheckerConfig;
   devServer?: ToolsDevServerConfig;
   minifyCss?: ToolsMinifyCssConfig;
   htmlPlugin?: false | ToolsHtmlPluginConfig;

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/tsChecker.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/tsChecker.test.ts.snap
@@ -1,5 +1,32 @@
 // Vitest Snapshot v1
 
-exports[`plugins/tsChecker > should set tsChecker plugin 1`] = `{}`;
-
-exports[`plugins/tsChecker > should't set ts-checker 1`] = `{}`;
+exports[`plugins/tsChecker > should allow to modify the config of tsChecker plugin 1`] = `
+{
+  "plugins": [
+    ForkTsCheckerWebpackPlugin {
+      "options": {
+        "async": false,
+        "issue": {
+          "exclude": [
+            {
+              "file": "**/*.(spec|test).ts",
+            },
+            {
+              "file": "**/node_modules/**/*",
+            },
+          ],
+        },
+        "logger": {
+          "error": [Function],
+          "log": [Function],
+        },
+        "typescript": {
+          "configFile": "/path/tsconfig.json",
+          "memoryLimit": 8192,
+          "typescriptPath": "<ROOT>/node_modules/<PNPM_INNER>/typescript/lib/typescript.js",
+        },
+      },
+    },
+  ],
+}
+`;

--- a/packages/builder/builder-webpack-provider/tests/plugins/tsChecker.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/tsChecker.test.ts
@@ -1,31 +1,88 @@
 import { expect, describe, it } from 'vitest';
-import { PluginTsLoader } from '../../src/plugins/tsLoader';
+import { PluginTsChecker } from '../../src/plugins/tsChecker';
 import { createStubBuilder } from '../../src/stub';
+import type { Context } from '../../src/types';
 
 describe('plugins/tsChecker', () => {
-  it("should't set ts-checker", async () => {
+  const context = {
+    tsconfigPath: '/path/tsconfig.json',
+  } as Context;
+
+  it('should disable ts-checker when tools.tsChecker is false', async () => {
     const builder = await createStubBuilder({
-      plugins: [PluginTsLoader()],
+      plugins: [PluginTsChecker()],
+      context,
       builderConfig: {
         tools: {
           tsChecker: false,
         },
       },
     });
-    const config = await builder.unwrapWebpackConfig();
 
-    expect(config).toMatchSnapshot();
+    expect(
+      await builder.matchWebpackPlugin('ForkTsCheckerWebpackPlugin'),
+    ).toBeFalsy();
   });
 
-  it('should set tsChecker plugin', async () => {
+  it('should enable tsChecker plugin by default', async () => {
     const builder = await createStubBuilder({
-      plugins: [PluginTsLoader()],
+      plugins: [PluginTsChecker()],
+      context,
       builderConfig: {
         tools: {},
       },
     });
-    const config = await builder.unwrapWebpackConfig();
 
+    expect(
+      await builder.matchWebpackPlugin('ForkTsCheckerWebpackPlugin'),
+    ).toBeTruthy();
+  });
+
+  it('should enable tsChecker plugin when tools.tsChecker is true', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginTsChecker()],
+      context,
+      builderConfig: {
+        tools: {
+          tsChecker: true,
+        },
+      },
+    });
+
+    expect(
+      await builder.matchWebpackPlugin('ForkTsCheckerWebpackPlugin'),
+    ).toBeTruthy();
+  });
+
+  it('should enable tsChecker plugin when tools.tsChecker is empty object', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginTsChecker()],
+      context,
+      builderConfig: {
+        tools: {
+          tsChecker: {},
+        },
+      },
+    });
+
+    expect(
+      await builder.matchWebpackPlugin('ForkTsCheckerWebpackPlugin'),
+    ).toBeTruthy();
+  });
+
+  it('should allow to modify the config of tsChecker plugin', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginTsChecker()],
+      context,
+      builderConfig: {
+        tools: {
+          tsChecker: {
+            async: false,
+          },
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
     expect(config).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
# PR Details

## Description

- Support configure `tools.tsChecker` to `true` to enable type checking.
- Fix the default value of `tools.tsChecker`, the value should be `true` or `{}` instead of `undefined`.
- Fix the test cases of `tools.tsChecker`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
