### PR TITLE
feat(builder): support distPath.server config

### DIFF
--- a/.changeset/weak-comics-turn.md
+++ b/.changeset/weak-comics-turn.md
@@ -5,3 +5,5 @@
 ---
 
 feat(builder): support distPath.server config
+
+feat(builder): 支持 distPath.server 配置项

--- a/.changeset/weak-comics-turn.md
+++ b/.changeset/weak-comics-turn.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-doc': patch
+'@modern-js/builder-shared': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+feat(builder): support distPath.server config

--- a/packages/builder/builder-doc/en/config/output/assetsRetry.md
+++ b/packages/builder/builder-doc/en/config/output/assetsRetry.md
@@ -37,7 +37,7 @@ export const defaultAssetsRetryOptions: AssetsRetryOptions = {
 };
 ```
 
-#### assetsRetry.max
+### assetsRetry.max
 
 - Type: `number`
 - Default: `3`

--- a/packages/builder/builder-doc/en/config/output/distPath.md
+++ b/packages/builder/builder-doc/en/config/output/distPath.md
@@ -10,6 +10,7 @@ type DistPathConfig = {
   html?: string;
   image?: string;
   media?: string;
+  server?: string;
 };
 ```
 
@@ -25,6 +26,7 @@ const defaultDistPath = {
   font: 'static/font',
   image: 'static/image',
   media: 'static/media',
+  server: 'bundles',
 };
 ```
 
@@ -40,6 +42,7 @@ Detail:
 - `font`: The output directory of font files.
 - `image`: The output directory of non-SVG images.
 - `media`: The output directory of media resources, such as videos.
+- `server`: The output directory of server bundles when target is `node`.
 
 #### Example
 

--- a/packages/builder/builder-doc/en/config/output/enableLatestDecorators.md
+++ b/packages/builder/builder-doc/en/config/output/enableLatestDecorators.md
@@ -1,1 +1,14 @@
-TODO
+- Type: `boolean`
+- Default: `false`
+
+By default, Builder uses the [legacy decorator proposal](https://github.com/wycats/javascript-decorators/blob/e1bf8d41bfa2591d949dd3bbf013514c8904b913/README.md) when compiling decorators.
+
+When `output.enableLatestDecorators` is set to `true`, the Builder will compile with the [new decorator proposal](https://github.com/tc39/proposal-decorators/tree/7fa580b40f2c19c561511ea2c978e307ae689a1b) (version 2018-09).
+
+```ts
+export default {
+  output: {
+    enableLatestDecorators: true,
+  },
+};
+```

--- a/packages/builder/builder-doc/zh/config/output/assetsRetry.md
+++ b/packages/builder/builder-doc/zh/config/output/assetsRetry.md
@@ -37,7 +37,7 @@ export const defaultAssetsRetryOptions: AssetsRetryOptions = {
 };
 ```
 
-#### assetsRetry.max
+### assetsRetry.max
 
 - Type: `number`
 - Default: `3`

--- a/packages/builder/builder-doc/zh/config/output/distPath.md
+++ b/packages/builder/builder-doc/zh/config/output/distPath.md
@@ -10,6 +10,7 @@ type DistPathConfig = {
   html?: string;
   image?: string;
   media?: string;
+  server?: string;
 };
 ```
 
@@ -25,6 +26,7 @@ const defaultDistPath = {
   font: 'static/font',
   image: 'static/image',
   media: 'static/media',
+  server: 'bundles',
 };
 ```
 
@@ -40,6 +42,7 @@ const defaultDistPath = {
 - `font`：表示字体文件的输出目录。
 - `image`：表示非 SVG 图片的输出目录。
 - `media`：表示视频等媒体资源的输出目录。
+- `server`: 表示服务端产物的输出目录，仅在 target 为 `node` 时有效。
 
 #### 示例
 

--- a/packages/builder/builder-doc/zh/config/output/enableLatestDecorators.md
+++ b/packages/builder/builder-doc/zh/config/output/enableLatestDecorators.md
@@ -1,1 +1,14 @@
-TODO
+- Type: `boolean`
+- Default: `false`
+
+默认情况下，Builder 在编译装饰器时采用[旧版 decorator 提案](https://github.com/wycats/javascript-decorators/blob/e1bf8d41bfa2591d949dd3bbf013514c8904b913/README.md)。
+
+将 `output.enableLatestDecorators` 设置为 `true` 时，Builder 会采用[新版 decorator 提案](https://github.com/tc39/proposal-decorators/tree/7fa580b40f2c19c561511ea2c978e307ae689a1b)(2018-09 版本) 进行编译。
+
+```ts
+export default {
+  output: {
+    enableLatestDecorators: true,
+  },
+};
+```

--- a/packages/builder/builder-shared/src/constants.ts
+++ b/packages/builder/builder-shared/src/constants.ts
@@ -7,6 +7,7 @@ export const DEFAULT_BROWSERSLIST = ['> 0.01%', 'not dead', 'not op_mini all'];
 // Paths
 export const ROOT_DIST_DIR = 'dist';
 export const HTML_DIST_DIR = 'html';
+export const SERVER_DIST_DIR = 'bundles';
 export const JS_DIST_DIR = 'static/js';
 export const CSS_DIST_DIR = 'static/css';
 export const SVG_DIST_DIR = 'static/svg';

--- a/packages/builder/builder-webpack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-webpack-provider/src/config/defaults.ts
@@ -9,6 +9,7 @@ import {
   FONT_DIST_DIR,
   IMAGE_DIST_DIR,
   MEDIA_DIST_DIR,
+  SERVER_DIST_DIR,
   mergeBuilderConfig,
 } from '@modern-js/builder-shared';
 import type { BuilderConfig } from '../types';
@@ -48,6 +49,7 @@ export const createDefaultConfig = () =>
         font: FONT_DIST_DIR,
         image: IMAGE_DIST_DIR,
         media: MEDIA_DIST_DIR,
+        server: SERVER_DIST_DIR,
       },
       filename: {},
       charset: 'ascii',

--- a/packages/builder/builder-webpack-provider/src/plugins/output.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/output.ts
@@ -52,7 +52,6 @@ export const PluginOutput = (): BuilderPlugin => ({
         isProd,
         context: api.context,
       });
-      const enableExtractCSS = !config.tools?.styleLoader;
 
       // js output
       const jsFilename = getFilename(config, 'js', isProd);
@@ -70,6 +69,7 @@ export const PluginOutput = (): BuilderPlugin => ({
         .hashFunction('xxhash64');
 
       // css output
+      const enableExtractCSS = !config.tools?.styleLoader && !isServer;
       if (enableExtractCSS) {
         const { default: MiniCssExtractPlugin } = await import(
           'mini-css-extract-plugin'
@@ -94,12 +94,10 @@ export const PluginOutput = (): BuilderPlugin => ({
           ]);
       }
 
-      // ssr output
+      // server output
       if (isServer) {
-        const { SERVER_BUNDLE_DIRECTORY } = await import(
-          '@modern-js/utils/constants'
-        );
-        const filename = `${SERVER_BUNDLE_DIRECTORY}/[name].js`;
+        const serverPath = getDistPath(config, 'server');
+        const filename = `${serverPath}/[name].js`;
 
         chain.output
           .filename(filename)

--- a/packages/builder/builder-webpack-provider/src/shared/fs.ts
+++ b/packages/builder/builder-webpack-provider/src/shared/fs.ts
@@ -1,13 +1,14 @@
 import { join } from 'path';
 import {
+  JS_DIST_DIR,
   CSS_DIST_DIR,
+  SVG_DIST_DIR,
+  ROOT_DIST_DIR,
   FONT_DIST_DIR,
   HTML_DIST_DIR,
   IMAGE_DIST_DIR,
-  JS_DIST_DIR,
   MEDIA_DIST_DIR,
-  ROOT_DIST_DIR,
-  SVG_DIST_DIR,
+  SERVER_DIST_DIR,
 } from '@modern-js/builder-shared';
 import type { BuilderConfig, DistPathConfig, FilenameConfig } from '../types';
 
@@ -37,6 +38,8 @@ export const getDistPath = (
       return distPath.root ?? ROOT_DIST_DIR;
     case 'image':
       return distPath.image ?? IMAGE_DIST_DIR;
+    case 'server':
+      return distPath.server ?? SERVER_DIST_DIR;
     default:
       throw new Error(`unknown key ${type} in "output.distPath"`);
   }

--- a/packages/builder/builder-webpack-provider/src/types/config/output.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/output.ts
@@ -9,6 +9,7 @@ export type DistPathConfig = {
   html?: string;
   image?: string;
   media?: string;
+  server?: string;
 };
 
 export type FilenameConfig = {

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/output.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/output.test.ts.snap
@@ -1,5 +1,19 @@
 // Vitest Snapshot v1
 
+exports[`plugins/output > should allow to custom server directory with distPath.server 1`] = `
+{
+  "output": {
+    "chunkFilename": "server/[name].js",
+    "filename": "server/[name].js",
+    "hashFunction": "xxhash64",
+    "libraryTarget": "commonjs2",
+    "path": "<ROOT>/packages/builder/builder-webpack-provider/dist",
+    "pathinfo": false,
+    "publicPath": "/",
+  },
+}
+`;
+
 exports[`plugins/output > should allow to use filename.js to modify filename 1`] = `
 {
   "output": {

--- a/packages/builder/builder-webpack-provider/tests/plugins/output.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/output.test.ts
@@ -12,6 +12,23 @@ describe('plugins/output', () => {
     expect(config).toMatchSnapshot();
   });
 
+  it('should allow to custom server directory with distPath.server', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginOutput()],
+      target: ['node'],
+      builderConfig: {
+        output: {
+          distPath: {
+            server: 'server',
+          },
+        },
+      },
+    });
+
+    const config = await builder.unwrapWebpackConfig();
+    expect(config).toMatchSnapshot();
+  });
+
   it('should allow to use filename.js to modify filename', async () => {
     const builder = await createStubBuilder({
       plugins: [PluginOutput()],


### PR DESCRIPTION
# PR Details

## Description

- Support `distPath.server` config to custom the server bundles path.
- Fix the MiniCssExtractPlugin is registered when target is node.
- Add documents of `output.enableLatestDecorators`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
