### PR TITLE
fix: tsconfig paths plugins cause types only import preserve

### DIFF
--- a/.changeset/big-pears-lie.md
+++ b/.changeset/big-pears-lie.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-utils': patch
+---
+
+fix: tsconfig-paths plugin's new node use old node flag
+fix: tsconfig-paths 插件转换的新节点使用旧节点的 flag

--- a/packages/server/utils/src/compilers/typescript/tsconfig-paths-plugin.ts
+++ b/packages/server/utils/src/compilers/typescript/tsconfig-paths-plugin.ts
@@ -148,8 +148,9 @@ export function tsconfigPathsBeforeHookFactory(
               node as any
             ).moduleSpecifier.parent;
 
+            let newNode;
             if (tsBinary.isImportDeclaration(node)) {
-              return tsBinary.factory.updateImportDeclaration(
+              newNode = tsBinary.factory.updateImportDeclaration(
                 node,
                 node.decorators,
                 node.modifiers,
@@ -158,7 +159,7 @@ export function tsconfigPathsBeforeHookFactory(
                 node.assertClause,
               );
             } else {
-              return tsBinary.factory.updateExportDeclaration(
+              newNode = tsBinary.factory.updateExportDeclaration(
                 node,
                 node.decorators,
                 node.modifiers,
@@ -168,6 +169,8 @@ export function tsconfigPathsBeforeHookFactory(
                 node.assertClause,
               );
             }
+            (newNode as any).flags = node.flags;
+            return newNode;
           } catch {
             return node;
           }


### PR DESCRIPTION
# PR Details

use old node's flags to transfer node.

flag types: https://github.com/microsoft/TypeScript/blob/main/src/compiler/types.ts#L754

related issue: https://github.com/nestjs/nest-cli/pull/1449

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
