### PR TITLE
fix(prod-server): failed to match URL which ends with ".html"

### DIFF
--- a/.changeset/ten-stingrays-hide.md
+++ b/.changeset/ten-stingrays-hide.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix(prod-server): failed to match URL which ends with ".html"
+
+fix(prod-server): 修复无法匹配到以 ".html" 结尾的 URL 的问题

--- a/packages/server/prod-server/src/libs/route/matcher.ts
+++ b/packages/server/prod-server/src/libs/route/matcher.ts
@@ -59,10 +59,14 @@ export class RouteMatcher {
 
   // if match url path
   public matchUrlPath(requestUrl: string): boolean {
-    const urlWithoutSlash =
+    let urlWithoutSlash =
       requestUrl.endsWith('/') && requestUrl !== '/'
         ? requestUrl.slice(0, -1)
         : requestUrl;
+
+    if (urlWithoutSlash.endsWith('.html')) {
+      urlWithoutSlash = urlWithoutSlash.slice(0, -5);
+    }
 
     if (this.urlMatcher) {
       return Boolean(this.urlMatcher(urlWithoutSlash));

--- a/packages/server/prod-server/tests/route.test.ts
+++ b/packages/server/prod-server/tests/route.test.ts
@@ -26,7 +26,12 @@ describe('test route', () => {
       expect(matcher.matchEntry('home')).toBeFalsy();
       expect(matcher.matchLength('/entry')).toBe(6);
       expect(matcher.matchUrlPath('/entry')).toBeTruthy();
+      expect(matcher.matchUrlPath('/entry.html')).toBeTruthy();
+      expect(matcher.matchUrlPath('/entry_html')).toBeFalsy();
+      expect(matcher.matchUrlPath('/entry_2')).toBeFalsy();
+      expect(matcher.matchUrlPath('/entry_2.html')).toBeFalsy();
       expect(matcher.matchUrlPath('/home')).toBeFalsy();
+      expect(matcher.matchUrlPath('/home.html')).toBeFalsy();
     });
   });
 


### PR DESCRIPTION
# PR Details

## Description

Fix Server failed to match URL which ends with ".html", such as `http://localhost:3000/index.html`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
