### PR TITLE
fix: runtime export field and state runtime plugin params

### DIFF
--- a/.changeset/honest-rocks-exist.md
+++ b/.changeset/honest-rocks-exist.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/plugin-storybook': patch
+'@modern-js/runtime': patch
+---
+
+fix: runtime export field
+
+fix: 修复 runtime 包导出字段

--- a/.changeset/late-ways-wave.md
+++ b/.changeset/late-ways-wave.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: state runtime plugin params
+
+fix: state 插件参数格式

--- a/packages/cli/plugin-storybook/src/runtime-addon/typings.d.ts
+++ b/packages/cli/plugin-storybook/src/runtime-addon/typings.d.ts
@@ -1,12 +1,15 @@
 declare module 'global';
 declare module '@modern-js/runtime/model' {
+  const state: any;
   const effects: any;
   const immer: any;
   const autoActions: any;
   const devtools: any;
+  export { effects, immer, autoActions, devtools };
+  export default state;
 }
 
 declare module '@modern-js/runtime/plugins' {
-  export { default as state } from '@modern-js/runtime/runtime-state';
-  export { default as router } from '@modern-js/runtime/runtime-router';
+  export { default as state } from '@modern-js/runtime/model';
+  export { default as router } from '@modern-js/runtime/router';
 }

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -50,38 +50,23 @@
       "default": "./dist/js/treeshaking/exports/server.js"
     },
     "./router": {
-      "jsnext:source": "./src/exports/router.ts",
-      "node": "./dist/js/node/exports/router.js",
-      "default": "./dist/js/treeshaking/exports/router.js"
-    },
-    "./ssr": {
-      "jsnext:source": "./src/exports/ssr.ts",
-      "node": "./dist/js/node/exports/ssr.js",
-      "default": "./dist/js/treeshaking/exports/ssr.js"
-    },
-    "./model": {
-      "jsnext:source": "./src/exports/model.ts",
-      "node": "./dist/js/node/exports/model.js",
-      "default": "./dist/js/treeshaking/exports/model.js"
-    },
-    "./cli": {
-      "jsnext:source": "./src/cli/index.ts",
-      "default": "./dist/js/node/cli/index.js"
-    },
-    "./runtime-router": {
       "jsnext:source": "./src/router/index.ts",
       "node": "./dist/js/node/router/index",
       "default": "./dist/js/treeshaking/router/index.js"
     },
-    "./runtime-state": {
+    "./ssr": {
+      "jsnext:source": "./src/ssr/index.ts",
+      "node": "./dist/js/node/ssr/index",
+      "default": "./dist/js/treeshaking/ssr/index.js"
+    },
+    "./model": {
       "jsnext:source": "./src/state/index.ts",
       "node": "./dist/js/node/state/index",
       "default": "./dist/js/treeshaking/state/index.js"
     },
-    "./runtime-ssr": {
-      "jsnext:source": "./src/ssr/index.ts",
-      "node": "./dist/js/node/ssr/index",
-      "default": "./dist/js/treeshaking/ssr/index.js"
+    "./cli": {
+      "jsnext:source": "./src/cli/index.ts",
+      "default": "./dist/js/node/cli/index.js"
     }
   },
   "typesVersions": {
@@ -105,22 +90,13 @@
         "./dist/types/exports/server.d.ts"
       ],
       "ssr": [
-        "./dist/types/exports/ssr.d.ts"
+        "./dist/types/ssr/index.d.ts"
       ],
       "router": [
-        "./dist/types/exports/router.d.ts"
+        "./dist/types/router/index.d.ts"
       ],
       "model": [
         "./types/model.d.ts"
-      ],
-      "runtime-router": [
-        "./dist/types/router/index.d.ts"
-      ],
-      "runtime-state": [
-        "./dist/types/state/index.d.ts"
-      ],
-      "runtime-ssr": [
-        "./dist/types/ssr/index.d.ts"
       ]
     }
   },

--- a/packages/runtime/plugin-runtime/src/exports/model.ts
+++ b/packages/runtime/plugin-runtime/src/exports/model.ts
@@ -1,3 +1,0 @@
-export { default as state } from '../state';
-
-export * from '../state';

--- a/packages/runtime/plugin-runtime/src/exports/router.ts
+++ b/packages/runtime/plugin-runtime/src/exports/router.ts
@@ -1,3 +1,0 @@
-export { default as router } from '../router';
-
-export * from '../router';

--- a/packages/runtime/plugin-runtime/src/exports/ssr.ts
+++ b/packages/runtime/plugin-runtime/src/exports/ssr.ts
@@ -1,3 +1,0 @@
-export { default as ssr } from '../ssr';
-
-export * from '../ssr';

--- a/packages/runtime/plugin-runtime/src/router/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/router/cli/index.ts
@@ -101,7 +101,7 @@ export default (): CliPlugin => ({
       },
       addRuntimeExports() {
         pluginsExportsUtils.addExport(
-          `export { default as router } from '@modern-js/runtime/runtime-router'`,
+          `export { default as router } from '@modern-js/runtime/router'`,
         );
       },
     };

--- a/packages/runtime/plugin-runtime/src/router/index.ts
+++ b/packages/runtime/plugin-runtime/src/router/index.ts
@@ -1,2 +1,3 @@
+export { default as router } from './runtime';
 export { default } from './runtime';
 export * from './runtime';

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -60,7 +60,7 @@ export default (): CliPlugin => ({
         const { packageName, entrypoints } = api.useAppContext();
 
         pluginsExportsUtils.addExport(
-          `export { default as ssr } from '@modern-js/runtime/runtime-ssr'`,
+          `export { default as ssr } from '@modern-js/runtime/ssr'`,
         );
 
         // if use ssg then set ssr config to true

--- a/packages/runtime/plugin-runtime/src/ssr/index.tsx
+++ b/packages/runtime/plugin-runtime/src/ssr/index.tsx
@@ -18,7 +18,7 @@ declare module '../core' {
   }
 }
 
-const ssr = (_: SSRPluginConfig): Plugin => ({
+export const ssr = (_: SSRPluginConfig): Plugin => ({
   name: '@modern-js/plugin-ssr',
   setup: () => {
     const mockResp = mockResponse();

--- a/packages/runtime/plugin-runtime/src/state/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/state/cli/index.ts
@@ -47,17 +47,6 @@ export default (): CliPlugin => ({
 
         stateConfigMap.set(entryName, stateConfig);
 
-        const getEnabledPlugins = () => {
-          const internalPlugins = [
-            'immer',
-            'effects',
-            'autoActions',
-            'devtools',
-          ];
-
-          return internalPlugins.filter(name => stateConfig[name] !== false);
-        };
-
         if (stateConfig) {
           imports.push({
             value: '@modern-js/runtime/plugins',
@@ -66,25 +55,6 @@ export default (): CliPlugin => ({
                 imported: PLUGIN_IDENTIFIER,
               },
             ],
-          });
-          imports.push({
-            value: '@modern-js/runtime/model',
-            specifiers: getEnabledPlugins().map(imported => ({ imported })),
-            initialize: `
-                const createStatePlugins = (config) => {
-                  const plugins = [];
-
-                  ${getEnabledPlugins()
-                    .map(
-                      name => `
-                      plugins.push(${name}(config['${name}']));
-                      `,
-                    )
-                    .join('\n')}
-
-                  return plugins;
-                }
-              `,
           });
         }
 
@@ -98,19 +68,11 @@ export default (): CliPlugin => ({
         const stateOptions = stateConfigMap.get(entrypoint.entryName);
 
         if (stateOptions) {
-          const isBoolean = typeof stateOptions === 'boolean';
-
-          let options = isBoolean ? '{}' : JSON.stringify(stateOptions);
-
-          options = `${options.substr(0, options.length - 1)}${
-            isBoolean ? '' : ','
-          }plugins: createStatePlugins(${JSON.stringify(
-            stateConfigMap.get(entrypoint.entryName),
-          )})}`;
-
           plugins.push({
             name: PLUGIN_IDENTIFIER,
-            options,
+            options: `${JSON.stringify(
+              stateConfigMap.get(entrypoint.entryName),
+            )}`,
           });
         }
         return {

--- a/packages/runtime/plugin-runtime/src/state/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/state/cli/index.ts
@@ -55,9 +55,7 @@ export default (): CliPlugin => ({
             'devtools',
           ];
 
-          return internalPlugins.filter(
-            name => (stateConfig as any)[name] !== false,
-          );
+          return internalPlugins.filter(name => stateConfig[name] !== false);
         };
 
         if (stateConfig) {
@@ -125,7 +123,7 @@ export default (): CliPlugin => ({
       },
       addRuntimeExports() {
         pluginsExportsUtils.addExport(
-          `export { default as state } from '@modern-js/runtime/runtime-state'`,
+          `export { default as state } from '@modern-js/runtime/model'`,
         );
       },
     };

--- a/packages/runtime/plugin-runtime/src/state/index.ts
+++ b/packages/runtime/plugin-runtime/src/state/index.ts
@@ -1,2 +1,3 @@
+export { default as state } from './runtime';
 export { default } from './runtime';
 export * from './runtime';

--- a/packages/runtime/plugin-runtime/src/state/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/state/runtime/plugin.tsx
@@ -2,11 +2,39 @@ import { useContext } from 'react';
 import { createStore } from '@modern-js-reduck/store';
 import { Provider } from '@modern-js-reduck/react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
+import { immer, effects, autoActions, devtools } from '../plugins';
 import { RuntimeReactContext } from '../../core';
 import type { Plugin } from '../../core';
 import { isBrowser } from '../../common';
 
-export type StateConfig = Parameters<typeof createStore>[0];
+export type StatePluginType = 'immer' | 'effects' | 'autoActions' | 'devtools';
+
+export type StateConfig = Record<Partial<StatePluginType>, boolean>;
+
+const StatePluginHandleMap: Record<StatePluginType, any> = {
+  immer,
+  effects,
+  autoActions,
+  devtools,
+};
+
+const getStoreConfig = (
+  config: StateConfig,
+): NonNullable<Parameters<typeof createStore>[0]> => {
+  const internalPlugins: StatePluginType[] = [
+    'immer',
+    'effects',
+    'autoActions',
+    'devtools',
+  ];
+  const plugins: any[] = [];
+  internalPlugins
+    .filter(plugin => config[plugin] !== false)
+    .forEach(plugin =>
+      plugins.push(StatePluginHandleMap[plugin](config[plugin])),
+    );
+  return { plugins };
+};
 
 const state = (config: StateConfig): Plugin => ({
   name: '@modern-js/plugin-state',
@@ -18,7 +46,7 @@ const state = (config: StateConfig): Plugin => ({
           const context = useContext(RuntimeReactContext);
 
           return (
-            <Provider store={context.store} config={config}>
+            <Provider store={context.store} config={getStoreConfig(config)}>
               <App {...props} />
             </Provider>
           );
@@ -28,7 +56,7 @@ const state = (config: StateConfig): Plugin => ({
         });
       },
       init({ context }, next) {
-        const storeConfig = config || {};
+        const storeConfig = getStoreConfig(config || {});
 
         if (isBrowser()) {
           storeConfig.initialState =

--- a/packages/runtime/plugin-runtime/tests/exports.test.ts
+++ b/packages/runtime/plugin-runtime/tests/exports.test.ts
@@ -4,10 +4,10 @@
 import * as PluginRuntime from '../src';
 import head from '../src/exports/head';
 import loadable from '../src/exports/loadable';
-import * as model from '../src/exports/model';
-import * as router from '../src/exports/router';
+import * as model from '../src/state';
+import * as router from '../src/router';
 import * as bff from '../src/exports/server';
-import * as ssr from '../src/exports/ssr';
+import * as ssr from '../src/ssr';
 import * as styled from '../src/exports/styled';
 
 describe('imported packages in plugin runtime', () => {

--- a/packages/runtime/plugin-runtime/types/model.d.ts
+++ b/packages/runtime/plugin-runtime/types/model.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="@modern-js-reduck/plugin-effects" />
 /// <reference types="@modern-js-reduck/plugin-immutable" />
 
-export * from '../dist/types/exports/model';
+export * from '../dist/types/router';

--- a/packages/runtime/plugin-runtime/types/model.d.ts
+++ b/packages/runtime/plugin-runtime/types/model.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="@modern-js-reduck/plugin-effects" />
 /// <reference types="@modern-js-reduck/plugin-immutable" />
 
-export * from '../dist/types/router';
+export * from '../dist/types/state';


### PR DESCRIPTION
# PR Details

- @modern-js/runtime exports field `/router` and `/runtime-router` is the same file, only use `/router`.

- state plugin generator main file is wrong
![image](https://user-images.githubusercontent.com/12605189/196589154-34d1f508-bd15-4893-b3e9-67747b2e2d19.png)

   expect:
   ![image](https://user-images.githubusercontent.com/12605189/196589413-38d391a7-6692-416b-95b3-44ae912fb2d3.png)

  StatePlugins' transform should handle in runtime.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
