### PR TITLE
fix(builder): only apply one tsChecker plugin when multiple targets

### DIFF
--- a/.changeset/friendly-beers-teach.md
+++ b/.changeset/friendly-beers-teach.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): only apply one tsChecker plugin when multiple targets
+
+fix(builder): 当同时存在多个 target 时，仅启用一个 tsChecker 插件

--- a/packages/builder/builder-shared/src/createPublicContext.ts
+++ b/packages/builder/builder-shared/src/createPublicContext.ts
@@ -7,6 +7,7 @@ export function createPublicContext(
 ): Readonly<BuilderContext> {
   const ctx = pick(context, [
     'entry',
+    'target',
     'srcPath',
     'rootPath',
     'distPath',

--- a/packages/builder/builder-shared/src/types/context.ts
+++ b/packages/builder/builder-shared/src/types/context.ts
@@ -1,9 +1,11 @@
-import type { BuilderEntry } from './builder';
+import type { BuilderEntry, BuilderTarget } from './builder';
 
 /** The public context */
 export type BuilderContext = {
   /** The entry points object. */
   entry: BuilderEntry;
+  /** The build target type. */
+  target: BuilderTarget | BuilderTarget[];
   /** The root path of current project. */
   rootPath: string;
   /** Absolute path of source files. */

--- a/packages/builder/builder-webpack-provider/src/core/createContext.ts
+++ b/packages/builder/builder-webpack-provider/src/core/createContext.ts
@@ -26,7 +26,7 @@ export function createPrimaryContext(
   options: Required<CreateBuilderOptions>,
   userBuilderConfig: BuilderConfig,
 ): Context {
-  const { cwd, configPath, framework } = options;
+  const { cwd, target, configPath, framework } = options;
   const builderConfig = withDefaultConfig(userBuilderConfig);
   const hooks = initHooks();
   const rootPath = cwd;
@@ -40,6 +40,7 @@ export function createPrimaryContext(
   const context: Context = {
     hooks,
     entry: options.entry,
+    target,
     srcPath,
     rootPath,
     distPath,

--- a/packages/builder/builder-webpack-provider/src/plugins/tsChecker.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/tsChecker.ts
@@ -4,12 +4,22 @@ export const PluginTsChecker = (): BuilderPlugin => {
   return {
     name: 'builder-plugin-ts-checker',
     setup(api) {
-      api.modifyWebpackChain(async chain => {
+      api.modifyWebpackChain(async (chain, { target }) => {
         const config = api.getNormalizedConfig();
+
         // Use tsChecker if tsChecker is not `false`, So there are two situations for user:
         // 1. tsLoader + transpileOnly + tsChecker
         // 2. @babel/preset-typescript + tsChecker
         if (config.tools.tsChecker === false || !api.context.tsconfigPath) {
+          return;
+        }
+
+        // If there is multiple target, only apply tsChecker to the first target
+        // to avoid multiple tsChecker running at the same time
+        if (
+          Array.isArray(api.context.target) &&
+          target !== api.context.target[0]
+        ) {
           return;
         }
 

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/tsChecker.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/tsChecker.test.ts.snap
@@ -30,3 +30,36 @@ exports[`plugins/tsChecker > should allow to modify the config of tsChecker plug
   ],
 }
 `;
+
+exports[`plugins/tsChecker > should only apply one tsChecker plugin when there is multiple targets 1`] = `
+[
+  {
+    "plugins": [
+      ForkTsCheckerWebpackPlugin {
+        "options": {
+          "issue": {
+            "exclude": [
+              {
+                "file": "**/*.(spec|test).ts",
+              },
+              {
+                "file": "**/node_modules/**/*",
+              },
+            ],
+          },
+          "logger": {
+            "error": [Function],
+            "log": [Function],
+          },
+          "typescript": {
+            "configFile": "/path/tsconfig.json",
+            "memoryLimit": 8192,
+            "typescriptPath": "<ROOT>/node_modules/<PNPM_INNER>/typescript/lib/typescript.js",
+          },
+        },
+      },
+    ],
+  },
+  {},
+]
+`;

--- a/packages/builder/builder-webpack-provider/tests/plugins/tsChecker.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/tsChecker.test.ts
@@ -85,4 +85,15 @@ describe('plugins/tsChecker', () => {
     const config = await builder.unwrapWebpackConfig();
     expect(config).toMatchSnapshot();
   });
+
+  it('should only apply one tsChecker plugin when there is multiple targets', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginTsChecker()],
+      context,
+      target: ['web', 'node'],
+    });
+
+    const configs = await builder.unwrapWebpackConfigs();
+    expect(configs).toMatchSnapshot();
+  });
 });

--- a/website/builder/src/en/api/builder-instance.md
+++ b/website/builder/src/en/api/builder-instance.md
@@ -20,6 +20,20 @@ The entry object, corresponding to the `entry` option of `createBuilder` method.
 type BuilderEntry = Record<string, string | string[]>;
 ```
 
+### builder.context.target
+
+Build target type, corresponding to the `target` option of `createBuilder` method.
+
+- **Type**
+
+```ts
+type BuilderTarget = 'web' | 'node' | 'modern-web';
+
+type Context = {
+  target: BuilderTarget | BuilderTarget[];
+};
+```
+
 ### builder.context.rootPath
 
 The root path of current build, corresponding to the `cwd` option of `createBuilder` method.

--- a/website/builder/src/zh/api/builder-instance.md
+++ b/website/builder/src/zh/api/builder-instance.md
@@ -20,6 +20,20 @@ extractApiHeaders: [2]
 type BuilderEntry = Record<string, string | string[]>;
 ```
 
+### builder.context.target
+
+构建产物类型，对应调用 `createBuilder` 时传入的 `target` 选项。
+
+- **Type**
+
+```ts
+type BuilderTarget = 'web' | 'node' | 'modern-web';
+
+type Context = {
+  target: BuilderTarget | BuilderTarget[];
+};
+```
+
 ### builder.context.rootPath
 
 当前执行构建的根路径，对应调用 `createBuilder` 时传入的 `cwd` 选项。


### PR DESCRIPTION
# PR Details

## Description

If there is multiple target, only apply tsChecker to the first target, to avoid multiple tsChecker running at the same time.

Expose target in the builder context.

This change can improve the compile performance when have multiple targets.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
