### PR TITLE
feat(webpack): expose HtmlWebpackPlugin instance in tools.webpack

### DIFF
--- a/.changeset/purple-suns-beam.md
+++ b/.changeset/purple-suns-beam.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/core': patch
+'@modern-js/webpack': patch
+---
+
+feat(webpack): expose HtmlWebpackPlugin instance in tools.webpack
+
+feat(webpack): 支持在 tools.webpack 中获取到 HtmlWebpackPlugin 实例

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -64,6 +64,7 @@
     "autoprefixer": "^10.3.1",
     "btsm": "2.2.2",
     "electron-builder": "22.7.0",
+    "html-webpack-plugin": "5.5.0",
     "jest": "^27",
     "postcss": "^8.4.14",
     "sass": "^1.45.0",

--- a/packages/cli/core/src/config/types/index.ts
+++ b/packages/cli/core/src/config/types/index.ts
@@ -233,6 +233,7 @@ export type WebpackConfigUtils = {
   env: string;
   name: string;
   webpack: typeof webpack;
+  HtmlWebpackPlugin: typeof import('html-webpack-plugin');
   addRules: (rules: RuleSetRule | RuleSetRule[]) => void;
   prependPlugins: (
     plugins: WebpackPluginInstance | WebpackPluginInstance[],
@@ -259,6 +260,7 @@ export type WebpackChainConfigUtils = {
   name: string;
   webpack: typeof webpack;
   CHAIN_ID: ChainIdentifier;
+  HtmlWebpackPlugin: typeof import('html-webpack-plugin');
 };
 
 export type WebpackChainConfig = (

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -14,6 +14,7 @@ import {
   removeLeadingSlash,
 } from '@modern-js/utils';
 import webpack from 'webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { IAppContext, NormalizedConfig } from '@modern-js/core';
 import WebpackChain from '@modern-js/utils/webpack-chain';
 import type { Options as BabelPrestAppOptions } from '@modern-js/babel-preset-app';
@@ -355,6 +356,7 @@ class BaseWebpackConfig {
           env: process.env.NODE_ENV!,
           name: chain.get('name'),
           webpack,
+          HtmlWebpackPlugin,
           ...getWebpackUtils(chainConfig),
         },
         webpackMerge,
@@ -411,6 +413,7 @@ class BaseWebpackConfig {
           name: this.chain.get('name'),
           webpack,
           CHAIN_ID,
+          HtmlWebpackPlugin,
         });
       });
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,7 @@ importers:
       autoprefixer: ^10.3.1
       btsm: 2.2.2
       electron-builder: 22.7.0
+      html-webpack-plugin: 5.5.0
       jest: ^27
       postcss: ^8.4.14
       sass: ^1.45.0
@@ -392,6 +393,7 @@ importers:
       autoprefixer: 10.4.7_postcss@8.4.14
       btsm: 2.2.2
       electron-builder: 22.7.0
+      html-webpack-plugin: 5.5.0_webpack@5.74.0
       jest: 27.5.1
       postcss: 8.4.14
       sass: 1.53.0
@@ -11592,7 +11594,6 @@ packages:
 
   /@types/html-minifier-terser/6.1.0:
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
-    dev: false
 
   /@types/http-assert/1.5.3:
     resolution: {integrity: sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA==}
@@ -15302,7 +15303,6 @@ packages:
     engines: {node: '>= 10.0'}
     dependencies:
       source-map: 0.6.1
-    dev: false
 
   /clean-set/1.1.2:
     resolution: {integrity: sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==}
@@ -21551,7 +21551,6 @@ packages:
       param-case: 3.0.4
       relateurl: 0.2.7
       terser: 5.14.1
-    dev: false
 
   /html-minifier/3.5.21:
     resolution: {integrity: sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==}
@@ -21621,7 +21620,6 @@ packages:
       pretty-error: 4.0.0
       tapable: 2.2.1
       webpack: 5.74.0
-    dev: false
 
   /html5shiv/3.7.3:
     resolution: {integrity: sha512-SZwGvLGNtgp8GbgFX7oXEp8OR1aBt5LliX6dG0kdD1kl3KhMonN0QcSa/A3TsTgFewaGCbIryQunjayWDXzxmw==}
@@ -27718,7 +27716,6 @@ packages:
     dependencies:
       lodash: 4.17.21
       renderkid: 3.0.0
-    dev: false
 
   /pretty-format/26.6.2:
     resolution: {integrity: sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==}
@@ -29575,7 +29572,6 @@ packages:
       htmlparser2: 6.1.0
       lodash: 4.17.21
       strip-ansi: 6.0.1
-    dev: false
 
   /repeat-element/1.1.4:
     resolution: {integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==}

--- a/website/main/docs/apis/app/config/tools/webpack-chain.md
+++ b/website/main/docs/apis/app/config/tools/webpack-chain.md
@@ -139,6 +139,20 @@ export default defineConfig({
 });
 ```
 
+### HtmlWebpackPlugin
+
+通过 `HtmlWebpackPlugin` 参数可以获取 Modern.js 内部使用的 HtmlWebpackPlugin 对象。
+
+```js title="modern.config.js"
+export default defineConfig({
+  tools: {
+    webpackChain: (chain, { HtmlWebpackPlugin }) => {
+      console.log(HtmlWebpackPlugin);
+    },
+  },
+});
+```
+
 ## 预设 ID 用法
 
 Modern.js 中预先定义了大量的 plugins 和 loaders，通过常量 `CHAIN_ID` 可以读取到这些预设内容的 ID，便于进行修改。

--- a/website/main/docs/apis/app/config/tools/webpack.md
+++ b/website/main/docs/apis/app/config/tools/webpack.md
@@ -4,8 +4,6 @@ title: tools.webpack
 sidebar_label: webpack
 ---
 
-
-
 - 类型： `Object | (config, utils) => void`
 - 默认值： `undefined`
 
@@ -118,6 +116,20 @@ export default defineConfig({
 建议优先使用该参数来访问 webpack 对象，而不是通过 import 来引入 `webpack`。
 
 如果需要通过 import 引入，则项目里需要单独安装 webpack 依赖，这样可能会导致 webpack 被重复安装，因此不推荐该做法。
+
+### HtmlWebpackPlugin
+
+通过 `HtmlWebpackPlugin` 参数可以获取 Modern.js 内部使用的 HtmlWebpackPlugin 对象。
+
+```js title="modern.config.js"
+export default defineConfig({
+  tools: {
+    webpack: (config, { HtmlWebpackPlugin }) => {
+      console.log(HtmlWebpackPlugin);
+    },
+  },
+});
+```
 
 ### addRules
 


### PR DESCRIPTION
# PR Details

## Description

Expose HtmlWebpackPlugin instance in tools.webpack and tools.webpackChain.

This is useful to add plugins for HtmlWebpackPlugin and avoid multiple instances issue.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
