### PR TITLE
fix: `tools.webpack` of Storybook API not work

### DIFF
--- a/.changeset/late-ghosts-grin.md
+++ b/.changeset/late-ghosts-grin.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-storybook': patch
+'@modern-js/webpack': patch
+---
+
+fix: `tools.webpack` of Storybook API not work
+fix: 修复 Storybook API tools.webpack 不生效

--- a/packages/cli/plugin-storybook/src/features/utils/webpackConfig.ts
+++ b/packages/cli/plugin-storybook/src/features/utils/webpackConfig.ts
@@ -215,7 +215,7 @@ export const getCustomWebpackConfigHandle: any = ({
     chain.merge({
       resolve: sbWebpackConfig.resolve,
     });
-    const config = chain.toConfig();
+    const config = webpackConfig.applyToolsWebpack(chain);
     resolveStorybookWebPackConfig(sbWebpackConfig, config, { appDirectory });
     return sbWebpackConfig;
   };

--- a/packages/cli/webpack/src/config/base.ts
+++ b/packages/cli/webpack/src/config/base.ts
@@ -334,6 +334,10 @@ class BaseWebpackConfig {
 
   config() {
     const chain = this.getChain();
+    return this.applyToolsWebpack(chain);
+  }
+
+  applyToolsWebpack(chain: WebpackChain) {
     const chainConfig = chain.toConfig();
 
     let finalConfig = chainConfig;


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

When debugging with Storybook, the tools.webpack configuration does not work。

Because we need to call the `config` function in BaseWebpackConfig in @modern-js/webpack to trigger tools.webpack to work, we put the main logic of the config function into the `applyToolsWebpack` function.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
