### PR TITLE
feat(builder): move part of config types to shared

### DIFF
--- a/.changeset/shiny-coats-mix.md
+++ b/.changeset/shiny-coats-mix.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+feat(builder): move part of config types to shared
+
+feat(builder): 将一部分公共的 config 类型定义下沉到 shared 中

--- a/packages/builder/builder-doc/en/config/performance/buildCache.md
+++ b/packages/builder/builder-doc/en/config/performance/buildCache.md
@@ -15,7 +15,7 @@ type BuildCacheConfig =
 
 ```js
 const defaultBuildCacheConfig = {
-  cacheDirectory: './node_modules/.cache/webapck',
+  cacheDirectory: './node_modules/.cache/webpack',
 };
 ```
 

--- a/packages/builder/builder-doc/zh/config/performance/buildCache.md
+++ b/packages/builder/builder-doc/zh/config/performance/buildCache.md
@@ -15,7 +15,7 @@ type BuildCacheConfig =
 
 ```js
 const defaultBuildCacheConfig = {
-  cacheDirectory: './node_modules/.cache/webapck',
+  cacheDirectory: './node_modules/.cache/webpack',
 };
 ```
 

--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@modern-js/server": "workspace:*",
+    "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*"
   },
   "devDependencies": {

--- a/packages/builder/builder-shared/src/types/config/dev.ts
+++ b/packages/builder/builder-shared/src/types/config/dev.ts
@@ -1,0 +1,16 @@
+import type { DevServerHttpsOptions } from '@modern-js/types';
+
+export type ProgressBarConfig = {
+  id?: string;
+  quite?: boolean;
+  quiteOnDev?: boolean;
+};
+
+export interface SharedDevConfig {
+  hmr?: boolean;
+  port?: number;
+  https?: DevServerHttpsOptions;
+  startUrl?: boolean | string | string[];
+  assetPrefix?: string | boolean;
+  progressBar?: boolean | ProgressBarConfig;
+}

--- a/packages/builder/builder-shared/src/types/config/html.ts
+++ b/packages/builder/builder-shared/src/types/config/html.ts
@@ -1,0 +1,28 @@
+import type { MetaOptions } from '@modern-js/utils';
+import type { ChainedConfig } from '../utils';
+
+export type CrossOrigin = 'anonymous' | 'use-credentials';
+
+export type ScriptInject = boolean | 'body' | 'head';
+
+export interface SharedHtmlConfig {
+  meta?: MetaOptions;
+  metaByEntries?: Record<string, MetaOptions>;
+  title?: string;
+  titleByEntries?: Record<string, string>;
+  inject?: ScriptInject;
+  injectByEntries?: Record<string, ScriptInject>;
+  favicon?: string;
+  faviconByEntries?: Record<string, string | undefined>;
+  appIcon?: string;
+  mountId?: string;
+  crossorigin?: boolean | CrossOrigin;
+  disableHtmlFolder?: boolean;
+  template?: string;
+  templateByEntries?: Partial<Record<string, string>>;
+  templateParameters?: ChainedConfig<Record<string, unknown>>;
+  templateParametersByEntries?: Record<
+    string,
+    ChainedConfig<Record<string, unknown>>
+  >;
+}

--- a/packages/builder/builder-shared/src/types/config/index.ts
+++ b/packages/builder/builder-shared/src/types/config/index.ts
@@ -1,0 +1,26 @@
+import type { SharedDevConfig } from './dev';
+import type { SharedHtmlConfig } from './html';
+import type { SharedOutputConfig } from './output';
+import type { SharedSourceConfig } from './source';
+import type { SharedSecurityConfig } from './security';
+import type { SharedPerformanceConfig } from './performance';
+
+/**
+ * The shared Builder Config.
+ * Can be used with webpack-provider or rspack-provider.
+ * */
+export interface SharedBuilderConfig {
+  dev?: SharedDevConfig;
+  html?: SharedHtmlConfig;
+  source?: SharedSourceConfig;
+  output?: SharedOutputConfig;
+  security?: SharedSecurityConfig;
+  performance?: SharedPerformanceConfig;
+}
+
+export * from './dev';
+export * from './html';
+export * from './output';
+export * from './source';
+export * from './security';
+export * from './performance';

--- a/packages/builder/builder-shared/src/types/config/output.ts
+++ b/packages/builder/builder-shared/src/types/config/output.ts
@@ -1,0 +1,79 @@
+export type DistPathConfig = {
+  root?: string;
+  js?: string;
+  css?: string;
+  svg?: string;
+  font?: string;
+  html?: string;
+  image?: string;
+  media?: string;
+  server?: string;
+};
+
+export type FilenameConfig = {
+  js?: string;
+  css?: string;
+  svg?: string;
+  font?: string;
+  image?: string;
+  media?: string;
+};
+
+export type DataUriLimit = {
+  svg?: number;
+  font?: number;
+  image?: number;
+  media?: number;
+};
+
+export type Charset = 'ascii' | 'utf8';
+
+export type SvgDefaultExport = 'component' | 'url';
+
+export type LegalComments = 'none' | 'inline' | 'linked';
+
+export type NormalizedDataUriLimit = Required<DataUriLimit>;
+
+export type Polyfill = 'usage' | 'entry' | 'ua' | 'off';
+
+export interface SharedOutputConfig {
+  distPath?: DistPathConfig;
+  filename?: FilenameConfig;
+  charset?: Charset;
+  polyfill?: Polyfill;
+  assetPrefix?: string;
+  dataUriLimit?: number | DataUriLimit;
+  legalComments?: LegalComments;
+  cleanDistPath?: boolean;
+  disableMinimize?: boolean;
+  disableSourceMap?: boolean;
+  disableFilenameHash?: boolean;
+  disableInlineRuntimeChunk?: boolean;
+  enableAssetManifest?: boolean;
+  enableAssetFallback?: boolean;
+  enableLatestDecorators?: boolean;
+  enableCssModuleTSDeclaration?: boolean;
+  enableInlineScripts?: boolean;
+  enableInlineStyles?: boolean;
+  overrideBrowserslist?: string[];
+  svgDefaultExport?: SvgDefaultExport;
+}
+
+export interface NormalizedSharedOutputConfig extends SharedOutputConfig {
+  filename: FilenameConfig;
+  distPath: DistPathConfig;
+  polyfill: Polyfill;
+  dataUriLimit: NormalizedDataUriLimit;
+  cleanDistPath: boolean;
+  disableMinimize: boolean;
+  disableSourceMap: boolean;
+  disableFilenameHash: boolean;
+  disableInlineRuntimeChunk: boolean;
+  enableAssetManifest: boolean;
+  enableAssetFallback: boolean;
+  enableLatestDecorators: boolean;
+  enableCssModuleTSDeclaration: boolean;
+  enableInlineScripts: boolean;
+  enableInlineStyles: boolean;
+  svgDefaultExport: SvgDefaultExport;
+}

--- a/packages/builder/builder-shared/src/types/config/output.ts
+++ b/packages/builder/builder-shared/src/types/config/output.ts
@@ -26,6 +26,24 @@ export type DataUriLimit = {
   media?: number;
 };
 
+export type AssetsRetryHookContext = {
+  url: string;
+  times: number;
+  domain: string;
+  tagName: string;
+};
+
+export type AssetsRetryOptions = {
+  max?: number;
+  type?: string[];
+  test?: string | ((url: string) => boolean);
+  domain?: string[];
+  crossOrigin?: boolean;
+  onFail?: (options: AssetsRetryHookContext) => void;
+  onRetry?: (options: AssetsRetryHookContext) => void;
+  onSuccess?: (options: AssetsRetryHookContext) => void;
+};
+
 export type Charset = 'ascii' | 'utf8';
 
 export type SvgDefaultExport = 'component' | 'url';
@@ -63,6 +81,7 @@ export interface NormalizedSharedOutputConfig extends SharedOutputConfig {
   filename: FilenameConfig;
   distPath: DistPathConfig;
   polyfill: Polyfill;
+  assetsRetry?: AssetsRetryOptions;
   dataUriLimit: NormalizedDataUriLimit;
   cleanDistPath: boolean;
   disableMinimize: boolean;

--- a/packages/builder/builder-shared/src/types/config/performance.ts
+++ b/packages/builder/builder-shared/src/types/config/performance.ts
@@ -1,0 +1,14 @@
+export type ConsoleType = 'log' | 'info' | 'warn' | 'error' | 'table' | 'group';
+
+// may extends cache options in the futures
+export type BuildCacheOptions = {
+  /** the build file cache directory. */
+  cacheDirectory?: string;
+};
+
+export interface SharedPerformanceConfig {
+  removeConsole?: boolean | ConsoleType[];
+  removeMomentLocale?: boolean;
+  buildCache?: BuildCacheOptions | boolean;
+  profile?: boolean;
+}

--- a/packages/builder/builder-shared/src/types/config/security.ts
+++ b/packages/builder/builder-shared/src/types/config/security.ts
@@ -1,0 +1,9 @@
+export type SriOptions = {
+  hashFuncNames?: [string, ...string[]];
+  enabled?: 'auto' | true | false;
+  hashLoading?: 'eager' | 'lazy';
+};
+
+export interface SharedSecurityConfig {
+  sri?: SriOptions | boolean;
+}

--- a/packages/builder/builder-shared/src/types/config/source.ts
+++ b/packages/builder/builder-shared/src/types/config/source.ts
@@ -1,0 +1,26 @@
+import type { ChainedConfig, JSONValue } from '../utils';
+
+export type Alias = {
+  [index: string]: string | false | string[];
+};
+
+export type ModuleScopes = Array<string | RegExp>;
+
+export interface SharedSourceConfig {
+  include?: (string | RegExp)[];
+  alias?: ChainedConfig<Alias>;
+  preEntry?: string | string[];
+  globalVars?: Record<string, JSONValue>;
+  define?: Record<string, any>;
+  moduleScopes?: ChainedConfig<ModuleScopes>;
+  compileJsDataURI?: boolean;
+  resolveExtensionPrefix?: string;
+  resolveMainFields?: (string[] | string)[];
+}
+
+export interface NormalizedSharedSourceConfig extends SharedSourceConfig {
+  preEntry: string[];
+  globalVars: Record<string, JSONValue>;
+  define: Record<string, any>;
+  compileJsDataURI: boolean;
+}

--- a/packages/builder/builder-shared/src/types/index.ts
+++ b/packages/builder/builder-shared/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './context';
 export * from './utils';
 export * from './plugin';
 export * from './provider';
+export * from './config';

--- a/packages/builder/builder-webpack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-webpack-provider/src/config/defaults.ts
@@ -86,6 +86,7 @@ export const createDefaultConfig = () =>
       removeConsole: false,
       removeMomentLocale: false,
       profile: false,
+      buildCache: true,
       chunkSplit: {
         strategy: 'split-by-experience',
       },

--- a/packages/builder/builder-webpack-provider/src/plugins/cache.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/cache.ts
@@ -17,7 +17,7 @@ export const PluginCache = (): BuilderPlugin => ({
       const { context } = api;
 
       const cacheDirectory =
-        buildCacheConfig?.cacheDirectory || join(context.cachePath, 'webpack');
+        buildCacheConfig.cacheDirectory || join(context.cachePath, 'webpack');
       const rootPackageJson = join(context.rootPath, 'package.json');
       const browserslistConfig = join(context.rootPath, '.browserslistrc');
 

--- a/packages/builder/builder-webpack-provider/src/plugins/compatModern.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/compatModern.ts
@@ -1,5 +1,6 @@
 import { isPrimitiveScope } from './moduleScopes';
-import type { BuilderPlugin, ModuleScopes } from '../types';
+import type { ModuleScopes } from '@modern-js/builder-shared';
+import type { BuilderPlugin } from '../types';
 
 /**
  * Provides default configuration consistent with `@modern-js/webpack`

--- a/packages/builder/builder-webpack-provider/src/plugins/moduleScopes.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/moduleScopes.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import type { ChainedConfig } from '@modern-js/builder-shared';
-import type { BuilderPlugin, ModuleScopes } from '../types';
+import type { ChainedConfig, ModuleScopes } from '@modern-js/builder-shared';
+import type { BuilderPlugin } from '../types';
 
 export const isPrimitiveScope = (
   items: unknown[],

--- a/packages/builder/builder-webpack-provider/src/runtime/assets-retry.ts
+++ b/packages/builder/builder-webpack-provider/src/runtime/assets-retry.ts
@@ -1,7 +1,7 @@
-import {
+import type {
   AssetsRetryOptions,
   AssetsRetryHookContext,
-} from '../types/config/output';
+} from '@modern-js/builder-shared';
 
 interface ScriptElementAttributes {
   url: string;

--- a/packages/builder/builder-webpack-provider/src/shared/fs.ts
+++ b/packages/builder/builder-webpack-provider/src/shared/fs.ts
@@ -1,9 +1,6 @@
 import { join } from 'path';
-import type {
-  DistPathConfig,
-  FilenameConfig,
-  NormalizedConfig,
-} from '../types';
+import type { DistPathConfig, FilenameConfig } from '@modern-js/builder-shared';
+import type { NormalizedConfig } from '../types';
 
 export const getCompiledPath = (packageName: string) =>
   join(__dirname, '../../compiled', packageName);

--- a/packages/builder/builder-webpack-provider/src/shared/utils.ts
+++ b/packages/builder/builder-webpack-provider/src/shared/utils.ts
@@ -3,10 +3,12 @@ import {
   DEFAULT_BROWSERSLIST,
   type BuilderTarget,
 } from '@modern-js/builder-shared';
+import { URLSearchParams } from 'url';
+
 import type { Buffer } from 'buffer';
 import type { SomeJSONSchema } from '@modern-js/utils/ajv/json-schema';
-import { URLSearchParams } from 'url';
-import type { BuilderConfig, DataUriLimit, NormalizedConfig } from '../types';
+import type { DataUriLimit } from '@modern-js/builder-shared';
+import type { BuilderConfig, NormalizedConfig } from '../types';
 
 export async function getBrowserslistWithDefault(
   path: string,

--- a/packages/builder/builder-webpack-provider/src/types/config/dev.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/dev.ts
@@ -1,13 +1,5 @@
-import type { DevServerHttpsOptions } from '@modern-js/types';
-import type { ProgressOptions } from '../../webpackPlugins/ProgressPlugin/ProgressPlugin';
+import type { SharedDevConfig } from '@modern-js/builder-shared';
 
-export interface DevConfig {
-  hmr?: boolean;
-  port?: number;
-  https?: DevServerHttpsOptions;
-  startUrl?: boolean | string | string[];
-  assetPrefix?: string | boolean;
-  progressBar?: boolean | ProgressOptions;
-}
+export type DevConfig = SharedDevConfig;
 
 export type NormalizedDevConfig = Required<DevConfig>;

--- a/packages/builder/builder-webpack-provider/src/types/config/html.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/html.ts
@@ -1,33 +1,5 @@
-import type { ChainedConfig } from '@modern-js/builder-shared';
-import type { MetaOptions } from '@modern-js/utils';
-import type { HTMLPluginOptions } from '../thirdParty';
+import type { SharedHtmlConfig } from '@modern-js/builder-shared';
 
-export type CrossOrigin = 'anonymous' | 'use-credentials';
-
-export interface HtmlConfig {
-  meta?: MetaOptions;
-  metaByEntries?: Record<string, MetaOptions>;
-  title?: string;
-  titleByEntries?: Record<string, string>;
-  inject?: HTMLPluginOptions['inject'];
-  injectByEntries?: Record<string, HTMLPluginOptions['inject']>;
-  favicon?: string;
-  faviconByEntries?: Record<string, string | undefined>;
-  appIcon?: string;
-  mountId?: string;
-  crossorigin?: boolean | CrossOrigin;
-  disableHtmlFolder?: boolean;
-  template?: string;
-  templateByEntries?: Partial<Record<string, string>>;
-  templateParameters?:
-    | Record<string, unknown>
-    | ChainedConfig<Record<string, unknown>>;
-  templateParametersByEntries?: Record<
-    string,
-    | Record<string, unknown>
-    | ChainedConfig<Record<string, unknown>>
-    | HTMLPluginOptions['templateParameters']
-  >;
-}
+export type HtmlConfig = SharedHtmlConfig;
 
 export type NormalizedHtmlConfig = HtmlConfig;

--- a/packages/builder/builder-webpack-provider/src/types/config/index.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/index.ts
@@ -13,6 +13,7 @@ import type { NormalizedSecurityConfig, SecurityConfig } from './security';
 import type { NormalizedSourceConfig, SourceConfig } from './source';
 import type { NormalizedToolsConfig, ToolsConfig } from './tools';
 
+/** The Builder Config when using webpack provider */
 export interface BuilderConfig {
   dev?: DevConfig;
   html?: HtmlConfig;
@@ -24,7 +25,7 @@ export interface BuilderConfig {
   experiments?: ExperimentsConfig;
 }
 
-export interface NormalizedConfig extends Required<BuilderConfig> {
+export interface NormalizedConfig {
   dev: NormalizedDevConfig;
   html: NormalizedHtmlConfig;
   tools: NormalizedToolsConfig;

--- a/packages/builder/builder-webpack-provider/src/types/config/output.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/output.ts
@@ -1,141 +1,69 @@
+import type {
+  SharedOutputConfig,
+  NormalizedSharedOutputConfig,
+} from '@modern-js/builder-shared';
 import type { CopyPluginOptions, WebpackConfig } from '../thirdParty';
 
-export type DistPathConfig = {
-  root?: string;
-  js?: string;
-  css?: string;
-  svg?: string;
-  font?: string;
-  html?: string;
-  image?: string;
-  media?: string;
-  server?: string;
-};
-
-export type FilenameConfig = {
-  js?: string;
-  css?: string;
-  svg?: string;
-  font?: string;
-  image?: string;
-  media?: string;
-};
-
-export type DataUriLimit = {
-  svg?: number;
-  font?: number;
-  image?: number;
-  media?: number;
-};
-
-export type NormalizedDataUriLimit = Required<DataUriLimit>;
-
-export type Polyfill = 'usage' | 'entry' | 'ua' | 'off';
-
 export type AssetsRetryHookContext = {
+  url: string;
   times: number;
   domain: string;
-  url: string;
   tagName: string;
 };
 
 export type AssetsRetryOptions = {
-  type?: string[];
-  domain?: string[];
   max?: number;
+  type?: string[];
   test?: string | ((url: string) => boolean);
+  domain?: string[];
   crossOrigin?: boolean;
+  onFail?: (options: AssetsRetryHookContext) => void;
   onRetry?: (options: AssetsRetryHookContext) => void;
   onSuccess?: (options: AssetsRetryHookContext) => void;
-  onFail?: (options: AssetsRetryHookContext) => void;
 };
 
 /**
  * postcss-pxtorem options
- *
  * https://github.com/cuth/postcss-pxtorem#options
  */
-export type PxToRemOptions = Partial<{
-  rootValue: number;
-  unitPrecision: number;
-  propList: Array<string>;
-  selectorBlackList: Array<string>;
-  replace: boolean;
-  mediaQuery: boolean;
-  minPixelValue: number;
-  exclude: string | RegExp | ((filePath: string) => boolean);
-}>;
+export type PxToRemOptions = {
+  rootValue?: number;
+  unitPrecision?: number;
+  propList?: Array<string>;
+  selectorBlackList?: Array<string>;
+  replace?: boolean;
+  mediaQuery?: boolean;
+  minPixelValue?: number;
+  exclude?: string | RegExp | ((filePath: string) => boolean);
+};
 
-export type RemOptions = Partial<{
-  /** Runtime options */
+export type RemOptions = {
   /** Whether to inject runtime code into html templates。Default: true */
-  enableRuntime: boolean;
+  enableRuntime?: boolean;
   /** Usually, `fontSize = (clientWidth * rootFontSize) / screenWidth` */
-  screenWidth: number;
-  rootFontSize: number;
-  maxRootFontSize: number;
+  screenWidth?: number;
+  rootFontSize?: number;
+  maxRootFontSize?: number;
   /** Get clientWidth from the url query based on widthQueryKey */
-  widthQueryKey: string;
+  widthQueryKey?: string;
   /** The entries to ignore */
-  excludeEntries: Array<string>;
+  excludeEntries?: string[];
   /** Use height to calculate rem in landscape。Default: false */
-  supportLandscape: boolean;
-  /**
-   * Whether to use rootFontSize when large than maxRootFontSize （scene：pc）
-   */
-  useRootFontSizeBeyondMax: boolean;
+  supportLandscape?: boolean;
+  /** Whether to use rootFontSize when large than maxRootFontSize（scene：pc） */
+  useRootFontSizeBeyondMax?: boolean;
   /** CSS (postcss-pxtorem) option */
-  pxtorem: PxToRemOptions;
-}>;
+  pxtorem?: PxToRemOptions;
+};
 
 export type ExternalsOptions = WebpackConfig['externals'];
 
-export type Charset = 'ascii' | 'utf8';
-export type SvgDefaultExport = 'component' | 'url';
-export type LegalComments = 'none' | 'inline' | 'linked';
-
-export interface OutputConfig {
+export type OutputConfig = SharedOutputConfig & {
   copy?: CopyPluginOptions | CopyPluginOptions['patterns'];
-  distPath?: DistPathConfig;
-  filename?: FilenameConfig;
-  charset?: Charset;
-  polyfill?: Polyfill;
-  assetPrefix?: string;
-  dataUriLimit?: number | DataUriLimit;
-  legalComments?: LegalComments;
-  cleanDistPath?: boolean;
-  disableMinimize?: boolean;
-  disableSourceMap?: boolean;
-  disableFilenameHash?: boolean;
-  disableInlineRuntimeChunk?: boolean;
-  enableAssetManifest?: boolean;
-  enableAssetFallback?: boolean;
-  enableLatestDecorators?: boolean;
-  enableCssModuleTSDeclaration?: boolean;
-  enableInlineScripts?: boolean;
-  enableInlineStyles?: boolean;
-  overrideBrowserslist?: string[];
-  svgDefaultExport?: SvgDefaultExport;
   assetsRetry?: AssetsRetryOptions;
   convertToRem?: boolean | RemOptions;
   externals?: ExternalsOptions;
-}
+};
 
-export interface NormalizedOutputConfig extends OutputConfig {
-  filename: FilenameConfig;
-  distPath: DistPathConfig;
-  polyfill: Polyfill;
-  dataUriLimit: NormalizedDataUriLimit;
-  cleanDistPath: boolean;
-  disableMinimize: boolean;
-  disableSourceMap: boolean;
-  disableFilenameHash: boolean;
-  disableInlineRuntimeChunk: boolean;
-  enableAssetManifest: boolean;
-  enableAssetFallback: boolean;
-  enableLatestDecorators: boolean;
-  enableCssModuleTSDeclaration: boolean;
-  enableInlineScripts: boolean;
-  enableInlineStyles: boolean;
-  svgDefaultExport: SvgDefaultExport;
-}
+export type NormalizedOutputConfig = OutputConfig &
+  NormalizedSharedOutputConfig;

--- a/packages/builder/builder-webpack-provider/src/types/config/output.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/output.ts
@@ -4,24 +4,6 @@ import type {
 } from '@modern-js/builder-shared';
 import type { CopyPluginOptions, WebpackConfig } from '../thirdParty';
 
-export type AssetsRetryHookContext = {
-  url: string;
-  times: number;
-  domain: string;
-  tagName: string;
-};
-
-export type AssetsRetryOptions = {
-  max?: number;
-  type?: string[];
-  test?: string | ((url: string) => boolean);
-  domain?: string[];
-  crossOrigin?: boolean;
-  onFail?: (options: AssetsRetryHookContext) => void;
-  onRetry?: (options: AssetsRetryHookContext) => void;
-  onSuccess?: (options: AssetsRetryHookContext) => void;
-};
-
 /**
  * postcss-pxtorem options
  * https://github.com/cuth/postcss-pxtorem#options
@@ -60,7 +42,6 @@ export type ExternalsOptions = WebpackConfig['externals'];
 
 export type OutputConfig = SharedOutputConfig & {
   copy?: CopyPluginOptions | CopyPluginOptions['patterns'];
-  assetsRetry?: AssetsRetryOptions;
   convertToRem?: boolean | RemOptions;
   externals?: ExternalsOptions;
 };

--- a/packages/builder/builder-webpack-provider/src/types/config/performance.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/performance.ts
@@ -1,7 +1,6 @@
+import type { SharedPerformanceConfig } from '@modern-js/builder-shared';
 import type { BundleAnalyzerPlugin } from '../../../compiled/webpack-bundle-analyzer';
 import type webpack from 'webpack';
-
-export type ConsoleType = 'log' | 'info' | 'warn' | 'error' | 'table' | 'group';
 
 export type SplitChunks = webpack.Configuration extends {
   optimization?: {
@@ -49,26 +48,12 @@ export interface SplitCustom {
 
 export type BuilderChunkSplit = BaseChunkSplit | SplitBySize | SplitCustom;
 
-// may extends cache options in the futures
-export type BuildCacheOptions = {
-  /**
-   * the webpack file cache direactory (defaults to .node_modules/.cache/webpack).
-   */
-  cacheDirectory?: string;
-};
-
-export interface PerformanceConfig {
-  removeConsole?: boolean | ConsoleType[];
-  removeMomentLocale?: boolean;
+export interface PerformanceConfig extends SharedPerformanceConfig {
   bundleAnalyze?: BundleAnalyzerPlugin.Options;
   chunkSplit?: BuilderChunkSplit;
-  buildCache?: BuildCacheOptions | boolean;
-  profile?: boolean;
 }
 
-export interface NormalizedPerformanceConfig extends PerformanceConfig {
-  removeConsole: boolean | ConsoleType[];
-  removeMomentLocale: boolean;
-  chunkSplit: BuilderChunkSplit;
-  profile: boolean;
-}
+export type NormalizedPerformanceConfig = PerformanceConfig &
+  Required<SharedPerformanceConfig> & {
+    chunkSplit: BuilderChunkSplit;
+  };

--- a/packages/builder/builder-webpack-provider/src/types/config/security.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/security.ts
@@ -1,7 +1,5 @@
-import type { SubresourceIntegrityOptions } from '../thirdParty';
+import type { SharedSecurityConfig } from '@modern-js/builder-shared';
 
-export interface SecurityConfig {
-  sri?: SubresourceIntegrityOptions | boolean;
-}
+export type SecurityConfig = SharedSecurityConfig;
 
-export type NormalizedSecurityConfig = SecurityConfig;
+export type NormalizedSecurityConfig = Required<SecurityConfig>;

--- a/packages/builder/builder-webpack-provider/src/types/config/source.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/source.ts
@@ -1,30 +1,8 @@
-import type { ChainedConfig, JSONValue } from '@modern-js/builder-shared';
-import type { WebpackAlias } from '../thirdParty';
-import type * as webpack from 'webpack';
+import type {
+  SharedSourceConfig,
+  NormalizedSharedSourceConfig,
+} from '@modern-js/builder-shared';
 
-export type ModuleScopes = Array<string | RegExp>;
-export type CodeValue = webpack.DefinePlugin['definitions'][string];
+export type SourceConfig = SharedSourceConfig;
 
-export interface SourceConfig {
-  include?: (string | RegExp)[];
-  alias?: ChainedConfig<WebpackAlias>;
-  preEntry?: string | string[];
-  globalVars?: Record<string, JSONValue>;
-  define?: Record<string, CodeValue>;
-  moduleScopes?: ChainedConfig<ModuleScopes>;
-  compileJsDataURI?: boolean;
-  resolveExtensionPrefix?: string;
-  resolveMainFields?: (string[] | string)[];
-}
-
-export interface SourceFinalConfig {
-  preEntry?: string | string[];
-  resolveExtensionPrefix?: string;
-}
-
-export interface NormalizedSourceConfig extends SourceConfig {
-  preEntry: string[];
-  globalVars: Record<string, JSONValue>;
-  define: Record<string, CodeValue>;
-  compileJsDataURI: boolean;
-}
+export type NormalizedSourceConfig = NormalizedSharedSourceConfig;

--- a/packages/builder/builder-webpack-provider/src/types/thirdParty/index.ts
+++ b/packages/builder/builder-webpack-provider/src/types/thirdParty/index.ts
@@ -33,10 +33,6 @@ export type ForkTSCheckerOptions = ConstructorParameters<
 
 export type { webpack, WebpackChain, WebpackConfig };
 
-export type WebpackAlias = {
-  [index: string]: string | false | string[];
-};
-
 export type {
   CSSLoaderOptions,
   StyleLoaderOptions,

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/AssetsRetryPlugin.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/AssetsRetryPlugin.ts
@@ -1,8 +1,8 @@
-import { AssetsRetryOptions } from '../types';
-import type { WebpackPluginInstance, Compiler } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import fs from 'fs/promises';
 import { getCompiledPath } from '../shared/fs';
+import type { WebpackPluginInstance, Compiler } from 'webpack';
+import type { AssetsRetryOptions } from '@modern-js/builder-shared';
 
 export class AssetsRetryPlugin implements WebpackPluginInstance {
   readonly name: string;

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/HtmlCrossOriginPlugin.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/HtmlCrossOriginPlugin.ts
@@ -1,5 +1,5 @@
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-import type { CrossOrigin } from '../types';
+import type { CrossOrigin } from '@modern-js/builder-shared';
 import type { Compiler, WebpackPluginInstance } from 'webpack';
 
 type CrossOriginOptions = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,7 @@ importers:
     specifiers:
       '@babel/core': 7.18.0
       '@modern-js/server': workspace:*
+      '@modern-js/types': workspace:*
       '@modern-js/utils': workspace:*
       '@scripts/vitest-config': workspace:*
       '@types/babel__core': ^7.1.19
@@ -99,6 +100,7 @@ importers:
       webpack: ^5.74.0
     dependencies:
       '@modern-js/server': link:../../server/server
+      '@modern-js/types': link:../../toolkit/types
       '@modern-js/utils': link:../../toolkit/utils
     devDependencies:
       '@babel/core': 7.18.0
@@ -12293,8 +12295,10 @@ packages:
     dependencies:
       ajv: 6.12.6
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -28422,7 +28426,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scmp/2.1.0:


### PR DESCRIPTION
# PR Details

## Description

Move part of `BuilderConfig` type to `@modern-js/builder-shared`.

Some config items are still defined in the `builder-webpack-provider` because they are relevant  to webpack or other third party libraries.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
