### PR TITLE
feat(builder): support web-worker target

### DIFF
--- a/packages/builder/builder-shared/src/constants.ts
+++ b/packages/builder/builder-shared/src/constants.ts
@@ -2,9 +2,11 @@
 export const DEFAULT_PORT = 8080;
 export const DEFAULT_DATA_URL_SIZE = 10000;
 export const DEFAULT_MOUNT_ID = 'root';
+
 export const DEFAULT_BROWSERSLIST = {
   web: ['> 0.01%', 'not dead', 'not op_mini all'],
   node: ['node >= 12'],
+  'web-worker': ['> 0.01%', 'not dead', 'not op_mini all'],
   'modern-web': [
     'chrome > 61',
     'edge > 16',

--- a/packages/builder/builder-shared/src/types/builder.ts
+++ b/packages/builder/builder-shared/src/types/builder.ts
@@ -2,7 +2,7 @@ import type { BuilderContext } from './context';
 import type { PluginStore } from './plugin';
 import type { ProviderInstance } from './provider';
 
-export type BuilderTarget = 'web' | 'node' | 'modern-web';
+export type BuilderTarget = 'web' | 'node' | 'modern-web' | 'web-worker';
 
 export type BuilderEntry = Record<string, string | string[]>;
 

--- a/packages/builder/builder-webpack-provider/src/core/webpackConfig.ts
+++ b/packages/builder/builder-webpack-provider/src/core/webpackConfig.ts
@@ -75,6 +75,7 @@ export async function generateWebpackConfig({
     webpack,
     isProd: nodeEnv === 'production',
     isServer: target === 'node',
+    isWebWorker: target === 'web-worker',
     CHAIN_ID,
     getCompiledPath,
   };

--- a/packages/builder/builder-webpack-provider/src/plugins/assetsRetry.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/assetsRetry.ts
@@ -1,4 +1,5 @@
 import { BuilderPlugin } from '../types';
+import { isHtmlDisabled } from './html';
 
 export function PluginAssetsRetry(): BuilderPlugin {
   return {
@@ -6,9 +7,11 @@ export function PluginAssetsRetry(): BuilderPlugin {
     setup(api) {
       api.modifyWebpackChain(async (chain, { CHAIN_ID, target }) => {
         const config = api.getNormalizedConfig();
-        if (!config.output.assetsRetry || target === 'node') {
+
+        if (!config.output.assetsRetry || isHtmlDisabled(config, target)) {
           return;
         }
+
         const { AssetsRetryPlugin } = await import(
           '../webpackPlugins/AssetsRetryPlugin'
         );

--- a/packages/builder/builder-webpack-provider/src/plugins/css.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/css.ts
@@ -1,23 +1,43 @@
-import { CSS_REGEX, type BuilderContext } from '@modern-js/builder-shared';
-import { getBrowserslistWithDefault } from '../shared';
 import {
+  CSS_REGEX,
+  type BuilderTarget,
+  type BuilderContext,
+} from '@modern-js/builder-shared';
+import { getBrowserslistWithDefault } from '../shared';
+import type {
+  WebpackChain,
   BuilderPlugin,
   CssExtractOptions,
   CSSLoaderOptions,
   ModifyWebpackUtils,
   NormalizedConfig,
   StyleLoaderOptions,
-  WebpackChain,
 } from '../types';
 
 import assert from 'assert';
 import type { AcceptedPlugin, ProcessOptions } from 'postcss';
 
+export const isUseCssExtract = (
+  config: NormalizedConfig,
+  target: BuilderTarget,
+) =>
+  config.tools.cssExtract !== false &&
+  !config.tools.styleLoader &&
+  target !== 'node' &&
+  target !== 'web-worker';
+
 export async function applyBaseCSSRule(
   rule: WebpackChain.Rule,
   config: NormalizedConfig,
   context: BuilderContext,
-  { isServer, isProd, target, CHAIN_ID, getCompiledPath }: ModifyWebpackUtils,
+  {
+    target,
+    isProd,
+    isServer,
+    CHAIN_ID,
+    isWebWorker,
+    getCompiledPath,
+  }: ModifyWebpackUtils,
 ) {
   const { applyOptionsChain } = await import('@modern-js/utils');
   const browserslist = await getBrowserslistWithDefault(
@@ -83,8 +103,7 @@ export async function applyBaseCSSRule(
   };
 
   // 1. Check user config
-  const enableExtractCSS =
-    config.tools.cssExtract !== false && !config.tools.styleLoader;
+  const enableExtractCSS = isUseCssExtract(config, target);
   const enableCSSModuleTS = Boolean(config.output.enableCssModuleTSDeclaration);
   const enableSourceMap =
     isProd && enableExtractCSS && !config.output.disableSourceMap;
@@ -119,7 +138,7 @@ export async function applyBaseCSSRule(
 
   // 3. Create webpack rule
   // Order: style-loader/mini-css-extract -> css-loader -> postcss-loader
-  if (!isServer) {
+  if (!isServer && !isWebWorker) {
     // use mini-css-extract-plugin loader
     if (enableExtractCSS) {
       rule
@@ -152,7 +171,7 @@ export async function applyBaseCSSRule(
     .options(cssLoaderOptions)
     .end();
 
-  if (!isServer) {
+  if (!isServer && !isWebWorker) {
     rule
       .use(CHAIN_ID.USE.POSTCSS)
       .loader(getCompiledPath('postcss-loader'))

--- a/packages/builder/builder-webpack-provider/src/plugins/hmr.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/hmr.ts
@@ -1,20 +1,27 @@
-import type { BuilderPlugin } from '../types';
+import type {
+  BuilderPlugin,
+  NormalizedConfig,
+  ModifyWebpackUtils,
+} from '../types';
+
+export const isUsingHMR = (
+  config: NormalizedConfig,
+  { isProd, target }: ModifyWebpackUtils,
+) => !isProd && target !== 'node' && target !== 'web-worker' && config.dev.hmr;
 
 export const PluginHMR = (): BuilderPlugin => ({
   name: 'builder-plugin-hmr',
 
   setup(api) {
-    api.modifyWebpackChain((chain, { isProd, isServer, CHAIN_ID, webpack }) => {
-      if (isProd || isServer) {
-        return;
-      }
+    api.modifyWebpackChain((chain, utils) => {
       const config = api.getNormalizedConfig();
 
-      if (config.dev.hmr) {
-        chain
-          .plugin(CHAIN_ID.PLUGIN.HMR)
-          .use(webpack.HotModuleReplacementPlugin);
+      if (!isUsingHMR(config, utils)) {
+        return;
       }
+
+      const { webpack, CHAIN_ID } = utils;
+      chain.plugin(CHAIN_ID.PLUGIN.HMR).use(webpack.HotModuleReplacementPlugin);
     });
   },
 });

--- a/packages/builder/builder-webpack-provider/src/plugins/html.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/html.ts
@@ -1,5 +1,9 @@
 import path from 'path';
-import { isFileExists, DEFAULT_MOUNT_ID } from '@modern-js/builder-shared';
+import {
+  isFileExists,
+  DEFAULT_MOUNT_ID,
+  type BuilderTarget,
+} from '@modern-js/builder-shared';
 import { getDistPath } from '../shared';
 import type {
   BuilderPlugin,
@@ -133,17 +137,25 @@ async function getChunks(
   return [...dependOn, entryName];
 }
 
+export const isHtmlDisabled = (
+  config: NormalizedConfig,
+  target: BuilderTarget,
+) =>
+  config.tools.htmlPlugin === false ||
+  target === 'node' ||
+  target === 'web-worker';
+
 export const PluginHtml = (): BuilderPlugin => ({
   name: 'builder-plugin-html',
 
   setup(api) {
     const routesInfo: RoutesInfo[] = [];
 
-    api.modifyWebpackChain(async (chain, { isProd, isServer, CHAIN_ID }) => {
+    api.modifyWebpackChain(async (chain, { isProd, CHAIN_ID, target }) => {
       const config = api.getNormalizedConfig();
 
       // if html is disabled or target is server, skip html plugin
-      if (config.tools.htmlPlugin === false || isServer) {
+      if (isHtmlDisabled(config, target)) {
         return;
       }
 

--- a/packages/builder/builder-webpack-provider/src/plugins/inlineChunk.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/inlineChunk.ts
@@ -1,12 +1,15 @@
 import { RUNTIME_CHUNK_NAME } from '@modern-js/builder-shared';
+import { isHtmlDisabled } from './html';
 import type { BuilderPlugin } from '../types';
 
 export const PluginInlineChunk = (): BuilderPlugin => ({
   name: 'builder-plugin-inline-chunk',
 
   setup(api) {
-    api.modifyWebpackChain(async (chain, { CHAIN_ID, isServer }) => {
-      if (isServer) {
+    api.modifyWebpackChain(async (chain, { target, CHAIN_ID }) => {
+      const config = api.getNormalizedConfig();
+
+      if (isHtmlDisabled(config, target)) {
         return;
       }
 
@@ -17,7 +20,6 @@ export const PluginInlineChunk = (): BuilderPlugin => ({
         '../webpackPlugins/InlineChunkHtmlPlugin'
       );
 
-      const config = api.getNormalizedConfig();
       const {
         disableInlineRuntimeChunk,
         enableInlineStyles,

--- a/packages/builder/builder-webpack-provider/src/plugins/output.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/output.ts
@@ -4,6 +4,7 @@ import {
 } from '../types/thirdParty/css';
 import { DEFAULT_PORT, type BuilderContext } from '@modern-js/builder-shared';
 import { getDistPath, getFilename } from '../shared';
+import { isUseCssExtract } from './css';
 import type { BuilderPlugin, NormalizedConfig } from '../types';
 
 function getPublicPath({
@@ -42,74 +43,72 @@ export const PluginOutput = (): BuilderPlugin => ({
   name: 'builder-plugin-output',
 
   setup(api) {
-    api.modifyWebpackChain(async (chain, { isProd, isServer, CHAIN_ID }) => {
-      const config = api.getNormalizedConfig();
-      const jsPath = getDistPath(config, 'js');
-      const cssPath = getDistPath(config, 'css');
+    api.modifyWebpackChain(
+      async (chain, { isProd, isServer, target, CHAIN_ID }) => {
+        const config = api.getNormalizedConfig();
+        const jsPath = getDistPath(config, 'js');
+        const cssPath = getDistPath(config, 'css');
 
-      const publicPath = getPublicPath({
-        config,
-        isProd,
-        context: api.context,
-      });
+        const publicPath = getPublicPath({
+          config,
+          isProd,
+          context: api.context,
+        });
 
-      // js output
-      const jsFilename = getFilename(config, 'js', isProd);
-      chain.output
-        .path(api.context.distPath)
-        .filename(`${jsPath}/${jsFilename}`)
-        .chunkFilename(`${jsPath}/async/${jsFilename}`)
-        .publicPath(publicPath)
-        // disable pathinfo to improve compile performance
-        // the path info is useless in most cases
-        // see: https://webpack.js.org/guides/build-performance/#output-without-path-info
-        .pathinfo(false)
-        // since webpack v5.54.0+, hashFunction supports xxhash64 as a faster algorithm
-        // which will be used as default when experiments.futureDefaults is enabled.
-        .hashFunction('xxhash64');
-
-      // css output
-      const enableExtractCSS =
-        config.tools.cssExtract !== false &&
-        !config.tools.styleLoader &&
-        !isServer;
-      if (enableExtractCSS) {
-        const { default: MiniCssExtractPlugin } = await import(
-          'mini-css-extract-plugin'
-        );
-        const { applyOptionsChain } = await import('@modern-js/utils');
-        const extractPluginOptions = applyOptionsChain<
-          MiniCSSExtractPluginOptions,
-          null
-        >(
-          {},
-          (config.tools.cssExtract as CssExtractOptions)?.pluginOptions || {},
-        );
-
-        const cssFilename = getFilename(config, 'css', isProd);
-
-        chain
-          .plugin(CHAIN_ID.PLUGIN.MINI_CSS_EXTRACT)
-          .use(MiniCssExtractPlugin, [
-            {
-              filename: `${cssPath}/${cssFilename}`,
-              chunkFilename: `${cssPath}/async/${cssFilename}`,
-              ignoreOrder: true,
-              ...extractPluginOptions,
-            },
-          ]);
-      }
-
-      // server output
-      if (isServer) {
-        const serverPath = getDistPath(config, 'server');
-        const filename = `${serverPath}/[name].js`;
-
+        // js output
+        const jsFilename = getFilename(config, 'js', isProd);
         chain.output
-          .filename(filename)
-          .chunkFilename(filename)
-          .libraryTarget('commonjs2');
-      }
-    });
+          .path(api.context.distPath)
+          .filename(`${jsPath}/${jsFilename}`)
+          .chunkFilename(`${jsPath}/async/${jsFilename}`)
+          .publicPath(publicPath)
+          // disable pathinfo to improve compile performance
+          // the path info is useless in most cases
+          // see: https://webpack.js.org/guides/build-performance/#output-without-path-info
+          .pathinfo(false)
+          // since webpack v5.54.0+, hashFunction supports xxhash64 as a faster algorithm
+          // which will be used as default when experiments.futureDefaults is enabled.
+          .hashFunction('xxhash64');
+
+        // css output
+        if (isUseCssExtract(config, target)) {
+          const { default: MiniCssExtractPlugin } = await import(
+            'mini-css-extract-plugin'
+          );
+          const { applyOptionsChain } = await import('@modern-js/utils');
+          const extractPluginOptions = applyOptionsChain<
+            MiniCSSExtractPluginOptions,
+            null
+          >(
+            {},
+            (config.tools.cssExtract as CssExtractOptions)?.pluginOptions || {},
+          );
+
+          const cssFilename = getFilename(config, 'css', isProd);
+
+          chain
+            .plugin(CHAIN_ID.PLUGIN.MINI_CSS_EXTRACT)
+            .use(MiniCssExtractPlugin, [
+              {
+                filename: `${cssPath}/${cssFilename}`,
+                chunkFilename: `${cssPath}/async/${cssFilename}`,
+                ignoreOrder: true,
+                ...extractPluginOptions,
+              },
+            ]);
+        }
+
+        // server output
+        if (isServer) {
+          const serverPath = getDistPath(config, 'server');
+          const filename = `${serverPath}/[name].js`;
+
+          chain.output
+            .filename(filename)
+            .chunkFilename(filename)
+            .libraryTarget('commonjs2');
+        }
+      },
+    );
   },
 });

--- a/packages/builder/builder-webpack-provider/src/plugins/progress.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/progress.ts
@@ -5,6 +5,7 @@ const ID_MAP: Record<BuilderTarget, string> = {
   web: 'Client',
   node: 'Server',
   'modern-web': 'Modern',
+  'web-worker': 'WebWorker',
 };
 
 export const PluginProgress = (): BuilderPlugin => ({

--- a/packages/builder/builder-webpack-provider/src/plugins/react.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/react.ts
@@ -1,16 +1,18 @@
 import type { BuilderPlugin } from '../types';
+import { isUsingHMR } from './hmr';
 
 export const PluginReact = (): BuilderPlugin => ({
   name: 'builder-plugin-react',
 
   setup(api) {
-    api.modifyWebpackChain(async (chain, { CHAIN_ID, isProd, isServer }) => {
+    api.modifyWebpackChain(async (chain, utils) => {
       const config = api.getNormalizedConfig();
 
-      if (isProd || isServer || config.dev.hmr === false) {
+      if (!isUsingHMR(config, utils)) {
         return;
       }
 
+      const { CHAIN_ID } = utils;
       const { default: ReactFastRefreshPlugin } = await import(
         '@pmmmwh/react-refresh-webpack-plugin'
       );

--- a/packages/builder/builder-webpack-provider/src/plugins/splitChunks.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/splitChunks.ts
@@ -187,9 +187,19 @@ export function PluginSplitChunks(): BuilderPlugin {
   return {
     name: 'builder-plugin-split-chunks',
     setup(api) {
-      api.modifyWebpackChain((chain, { isServer }) => {
-        if (isServer) {
+      api.modifyWebpackChain((chain, { isServer, isWebWorker }) => {
+        if (isServer || isWebWorker) {
           chain.optimization.splitChunks(false);
+
+          // web worker does not support dynamic imports, dynamicImportMode need set to eager
+          if (isWebWorker) {
+            chain.module.parser.merge({
+              javascript: {
+                dynamicImportMode: 'eager',
+              },
+            });
+          }
+
           return;
         }
 

--- a/packages/builder/builder-webpack-provider/src/plugins/target.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/target.ts
@@ -8,16 +8,18 @@ export const PluginTarget = (): BuilderPlugin => ({
     api.modifyWebpackChain(async (chain, { target }) => {
       if (target === 'node') {
         chain.target('node');
-      } else {
-        const browserslist = await getBrowserslist(api.context.rootPath);
+        return;
+      }
 
-        if (browserslist) {
-          chain.merge({ target: ['web', 'browserslist'] });
-        } else if (target === 'modern-web') {
-          chain.merge({ target: ['web', 'es6'] });
-        } else {
-          chain.merge({ target: ['web', 'es5'] });
-        }
+      const browserslist = await getBrowserslist(api.context.rootPath);
+      const basicTarget = target === 'web-worker' ? 'webworker' : 'web';
+
+      if (browserslist) {
+        chain.merge({ target: [basicTarget, 'browserslist'] });
+      } else if (target === 'modern-web') {
+        chain.merge({ target: [basicTarget, 'es6'] });
+      } else {
+        chain.merge({ target: [basicTarget, 'es5'] });
       }
     });
   },

--- a/packages/builder/builder-webpack-provider/src/types/hooks.ts
+++ b/packages/builder/builder-webpack-provider/src/types/hooks.ts
@@ -10,6 +10,7 @@ export type ModifyWebpackUtils = {
   target: BuilderTarget;
   webpack: typeof import('webpack');
   isServer: boolean;
+  isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
   getCompiledPath: (name: string) => string;
 };

--- a/packages/builder/builder-webpack-provider/tests/plugins/css.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/css.test.ts
@@ -103,9 +103,43 @@ describe('plugins/css', () => {
     expect(includeMiniCssExtractLoader).toBe(false);
   });
 
+  it('should not apply mini-css-extract-plugin when target is web-worker', async () => {
+    const builder = await createStubBuilder({
+      target: ['web-worker'],
+      plugins: [PluginCss()],
+      builderConfig: {},
+    });
+
+    const includeMiniCssExtractLoader = await builder.matchWebpackLoader(
+      'mini-css-extract-plugin',
+      'index.css',
+    );
+
+    expect(includeMiniCssExtractLoader).toBe(false);
+  });
+
   it('should not apply style-loader when target is node', async () => {
     const builder = await createStubBuilder({
       target: ['node'],
+      plugins: [PluginCss()],
+      builderConfig: {
+        tools: {
+          styleLoader: {},
+        },
+      },
+    });
+
+    const includeStyleLoader = await builder.matchWebpackLoader(
+      'style-loader',
+      'index.css',
+    );
+
+    expect(includeStyleLoader).toBe(false);
+  });
+
+  it('should not apply style-loader when target is web-worker', async () => {
+    const builder = await createStubBuilder({
+      target: ['web-worker'],
       plugins: [PluginCss()],
       builderConfig: {
         tools: {

--- a/packages/builder/builder-webpack-provider/tests/plugins/html.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/html.test.ts
@@ -2,7 +2,7 @@ import { expect, describe, it } from 'vitest';
 import { getTemplatePath, PluginHtml } from '../../src/plugins/html';
 import { PluginEntry } from '../../src/plugins/entry';
 import { createStubBuilder } from '../../src/stub';
-import { BuilderConfig } from '../../src/types';
+import type { BuilderConfig, NormalizedConfig } from '../../src/types';
 
 describe('plugins/html', () => {
   it('should register html plugin correctly', async () => {
@@ -16,6 +16,28 @@ describe('plugins/html', () => {
 
     expect(await builder.matchWebpackPlugin('HtmlWebpackPlugin')).toBeTruthy();
     expect(config).toMatchSnapshot();
+  });
+
+  it('should not register html plugin when target is node', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginEntry(), PluginHtml()],
+      target: 'node',
+      entry: {
+        main: './src/main.ts',
+      },
+    });
+    expect(await builder.matchWebpackPlugin('HtmlWebpackPlugin')).toBeFalsy();
+  });
+
+  it('should not register html plugin when target is web-worker', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginEntry(), PluginHtml()],
+      target: 'web-worker',
+      entry: {
+        main: './src/main.ts',
+      },
+    });
+    expect(await builder.matchWebpackPlugin('HtmlWebpackPlugin')).toBeFalsy();
   });
 
   it('should register crossorigin plugin when using html.crossorigin', async () => {
@@ -148,7 +170,7 @@ describe('plugins/html', () => {
     ['main', 'foo', { templateByEntries: { main: 'foo' } }],
     ['other', 'bar', { template: 'bar', templateByEntries: { main: 'foo' } }],
   ])(`should get template path for %s`, async (entry, expected, html) => {
-    const templ = getTemplatePath(entry, { html });
-    expect(templ).toEqual(expected);
+    const templatePath = getTemplatePath(entry, { html } as NormalizedConfig);
+    expect(templatePath).toEqual(expected);
   });
 });

--- a/packages/builder/builder-webpack-provider/tests/plugins/inlineChunk.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/inlineChunk.test.ts
@@ -81,4 +81,18 @@ describe('plugins/inlineChunk', () => {
       await builder.matchWebpackPlugin('InlineChunkHtmlPlugin'),
     ).toBeFalsy();
   });
+
+  it('should not apply InlineChunkHtmlPlugin when target is web-worker', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginEntry(), PluginHtml(), PluginInlineChunk()],
+      entry: {
+        main: './src/main.ts',
+      },
+      target: 'web-worker',
+    });
+
+    expect(
+      await builder.matchWebpackPlugin('InlineChunkHtmlPlugin'),
+    ).toBeFalsy();
+  });
 });

--- a/packages/builder/builder-webpack-provider/tests/plugins/react.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/react.test.ts
@@ -54,4 +54,13 @@ describe('plugins/react', () => {
 
     expect(await builder.matchWebpackPlugin('ReactRefreshPlugin')).toBeFalsy();
   });
+
+  it('should not apply react refresh when target is web-worker', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginReact()],
+      target: 'web-worker',
+    });
+
+    expect(await builder.matchWebpackPlugin('ReactRefreshPlugin')).toBeFalsy();
+  });
 });

--- a/packages/builder/builder-webpack-provider/tests/plugins/target.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/target.test.ts
@@ -25,6 +25,11 @@ describe('plugins/target', () => {
       browserslist: null,
       expected: { target: ['web', 'es5'] },
     },
+    {
+      target: 'web-worker',
+      browserslist: null,
+      expected: { target: ['webworker', 'es5'] },
+    },
   ];
 
   it.each(cases)('%j', async item => {

--- a/tests/integration/webpack-builder/scripts/shared.ts
+++ b/tests/integration/webpack-builder/scripts/shared.ts
@@ -18,7 +18,7 @@ export const createBuilder = async () => {
     entry: {
       main: join(process.cwd(), 'src', 'index.ts'),
     },
-    target: ['node'],
+    target: ['web'],
     configPath: __filename,
   });
 

--- a/website/builder/src/en/api/builder-core.md
+++ b/website/builder/src/en/api/builder-core.md
@@ -59,7 +59,7 @@ The second parameter of `createBuilder` is a options object, you can pass in the
 ```ts
 type BuilderEntry = Record<string, string | string[]>;
 
-type BuilderTarget = 'web' | 'node' | 'modern-web';
+type BuilderTarget = 'web' | 'node' | 'modern-web' | 'web-worker';
 
 type CreateBuilderOptions = {
   cwd?: string;
@@ -85,6 +85,7 @@ Description:
 - `web`: Build for browsers.
 - `modern-web`: Build for modern browsers.
 - `node`: Build for SSR scenarios.
+- `web-worker`：Build for Web Worker.
 
 When target is an array containing multiple values, Builder will perform multiple builds at the same time.
 

--- a/website/builder/src/zh/api/builder-core.md
+++ b/website/builder/src/zh/api/builder-core.md
@@ -59,7 +59,7 @@ const builder = await createBuilder(provider, {
 ```ts
 type BuilderEntry = Record<string, string | string[]>;
 
-type BuilderTarget = 'web' | 'node' | 'modern-web';
+type BuilderTarget = 'web' | 'node' | 'modern-web' | 'web-worker';
 
 type CreateBuilderOptions = {
   cwd?: string;
@@ -85,6 +85,7 @@ target 表示构建产物类型，可以设置为以下值：
 - `web`: 用于浏览器的产物
 - `modern-web`：用于现代浏览器的产物
 - `node`: 用于 SSR 场景的产物
+- `web-worker`：用于 Web Worker 环境的产物
 
 当 target 为包含多个值的数组时，会并行构建并生成多份不同的产物。比如同时构建浏览器产物和 SSR 产物：
 


### PR DESCRIPTION
# PR Details

## Description

Builder support `web-worker` target.

Compared with `web` target, the web-worker outputs are:

- Only emit single bundle, not support dynamic import.
- No need to generate CSS/HTML files.
- No need to enable HMR.

```js
const builder = await createBuilder(provider, {
  target: ['web-worker'],
});
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
