### PR TITLE
 fix(builder): typo in dev.progressBar options

### DIFF
--- a/.changeset/honest-tips-begin.md
+++ b/.changeset/honest-tips-begin.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): typo in dev.progressBar options, quite should be quiet
+
+fix(builder): 修复 dev.progressBar 的选项拼写错误, quite 应为 quiet

--- a/.changeset/late-fireants-boil.md
+++ b/.changeset/late-fireants-boil.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): incorrect target label when inspect configs
+
+fix(builder): 修复 inspect configs 时展示的 target 不正确的问题

--- a/packages/builder/builder-shared/src/getBrowserslist.ts
+++ b/packages/builder/builder-shared/src/getBrowserslist.ts
@@ -1,3 +1,6 @@
+import { DEFAULT_BROWSERSLIST } from './constants';
+import type { BuilderTarget, SharedBuilderConfig } from './types';
+
 // using cache to avoid multiple calls to loadConfig
 const browsersListCache = new Map<string, string[]>();
 
@@ -17,4 +20,17 @@ export async function getBrowserslist(path: string) {
   }
 
   return null;
+}
+
+export async function getBrowserslistWithDefault(
+  path: string,
+  config: SharedBuilderConfig,
+  target: BuilderTarget,
+) {
+  if (config?.output?.overrideBrowserslist) {
+    return config.output.overrideBrowserslist;
+  }
+
+  const result = await getBrowserslist(path);
+  return result || DEFAULT_BROWSERSLIST[target];
 }

--- a/packages/builder/builder-shared/src/types/config/dev.ts
+++ b/packages/builder/builder-shared/src/types/config/dev.ts
@@ -2,8 +2,8 @@ import type { DevServerHttpsOptions } from '@modern-js/types';
 
 export type ProgressBarConfig = {
   id?: string;
-  quite?: boolean;
-  quiteOnDev?: boolean;
+  quiet?: boolean;
+  quietOnDev?: boolean;
 };
 
 export interface SharedDevConfig {
@@ -14,3 +14,5 @@ export interface SharedDevConfig {
   assetPrefix?: string | boolean;
   progressBar?: boolean | ProgressBarConfig;
 }
+
+export type NormalizedSharedDevConfig = Required<SharedDevConfig>;

--- a/packages/builder/builder-shared/tests/getBrowserslist.test.ts
+++ b/packages/builder/builder-shared/tests/getBrowserslist.test.ts
@@ -1,0 +1,35 @@
+import { expect, describe, it } from 'vitest';
+import { DEFAULT_BROWSERSLIST } from '../src';
+import { getBrowserslistWithDefault } from '../src/getBrowserslist';
+
+describe('getBrowserslistWithDefault', () => {
+  it('should get default browserslist correctly', async () => {
+    expect(await getBrowserslistWithDefault(__dirname, {}, 'web')).toEqual(
+      DEFAULT_BROWSERSLIST.web,
+    );
+    expect(await getBrowserslistWithDefault(__dirname, {}, 'node')).toEqual(
+      DEFAULT_BROWSERSLIST.node,
+    );
+    expect(
+      await getBrowserslistWithDefault(__dirname, {}, 'modern-web'),
+    ).toEqual(DEFAULT_BROWSERSLIST['modern-web']);
+    expect(
+      await getBrowserslistWithDefault(__dirname, {}, 'web-worker'),
+    ).toEqual(DEFAULT_BROWSERSLIST['web-worker']);
+  });
+
+  it('should override browserslist when using overrideBrowserslist config', async () => {
+    const override = ['Android >= 4.4', 'iOS >= 8'];
+    expect(
+      await getBrowserslistWithDefault(
+        __dirname,
+        {
+          output: {
+            overrideBrowserslist: override,
+          },
+        },
+        'web',
+      ),
+    ).toEqual(override);
+  });
+});

--- a/packages/builder/builder-webpack-provider/src/core/inspectConfig.ts
+++ b/packages/builder/builder-webpack-provider/src/core/inspectConfig.ts
@@ -29,6 +29,7 @@ async function writeConfigFiles({
     outputPath = join(context.rootPath, outputPath);
   }
 
+  const { target } = builderOptions;
   const files = [
     {
       path: join(outputPath, 'builder.config.js'),
@@ -36,11 +37,11 @@ async function writeConfigFiles({
       content: builderConfig,
     },
     ...bundlerConfigs.map((content, index) => {
-      const target = builderOptions.target[index];
-      const outputFile = `webpack.config.${target}.js`;
+      const suffix = Array.isArray(target) ? target[index] : `target-${index}`;
+      const outputFile = `webpack.config.${suffix}.js`;
       return {
         path: join(outputPath, outputFile),
-        label: `Webpack Config (${target})`,
+        label: `Webpack Config (${suffix})`,
         content,
       };
     }),

--- a/packages/builder/builder-webpack-provider/src/plugins/babel.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/babel.ts
@@ -8,9 +8,9 @@ import {
   JS_REGEX,
   TS_REGEX,
   mergeRegex,
+  getBrowserslistWithDefault,
   type BuilderContext,
 } from '@modern-js/builder-shared';
-import { getBrowserslistWithDefault } from '../shared';
 
 import type { WebpackChain, BuilderPlugin, NormalizedConfig } from '../types';
 

--- a/packages/builder/builder-webpack-provider/src/plugins/css.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/css.ts
@@ -1,9 +1,9 @@
 import {
   CSS_REGEX,
+  getBrowserslistWithDefault,
   type BuilderTarget,
   type BuilderContext,
 } from '@modern-js/builder-shared';
-import { getBrowserslistWithDefault } from '../shared';
 import type {
   WebpackChain,
   BuilderPlugin,

--- a/packages/builder/builder-webpack-provider/src/plugins/progress.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/progress.ts
@@ -5,7 +5,7 @@ const ID_MAP: Record<BuilderTarget, string> = {
   web: 'Client',
   node: 'Server',
   'modern-web': 'Modern',
-  'web-worker': 'WebWorker',
+  'web-worker': 'Web Worker',
 };
 
 export const PluginProgress = (): BuilderPlugin => ({

--- a/packages/builder/builder-webpack-provider/src/plugins/svg.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/svg.ts
@@ -1,11 +1,6 @@
 import { join } from 'path';
 import { JS_REGEX, TS_REGEX, SVG_REGEX } from '@modern-js/builder-shared';
-import {
-  getDistPath,
-  getFilename,
-  getDataUrlLimit,
-  getDataUrlCondition,
-} from '../shared';
+import { getDistPath, getFilename, getDataUrlCondition } from '../shared';
 import type { BuilderPlugin } from '../types';
 
 export const PluginSvg = (): BuilderPlugin => {
@@ -80,7 +75,7 @@ export const PluginSvg = (): BuilderPlugin => {
                 .use(CHAIN_ID.USE.URL)
                 .loader(getCompiledPath('url-loader'))
                 .options({
-                  limit: getDataUrlLimit(config, 'svg'),
+                  limit: config.output.dataUriLimit.svg,
                   name: outputName,
                 }),
             );

--- a/packages/builder/builder-webpack-provider/src/shared/utils.ts
+++ b/packages/builder/builder-webpack-provider/src/shared/utils.ts
@@ -1,42 +1,12 @@
-import {
-  getBrowserslist,
-  DEFAULT_BROWSERSLIST,
-  type BuilderTarget,
-} from '@modern-js/builder-shared';
 import { URLSearchParams } from 'url';
 
 import type { Buffer } from 'buffer';
 import type { SomeJSONSchema } from '@modern-js/utils/ajv/json-schema';
 import type { DataUriLimit } from '@modern-js/builder-shared';
-import type { BuilderConfig, NormalizedConfig } from '../types';
-
-export async function getBrowserslistWithDefault(
-  path: string,
-  config: BuilderConfig,
-  target: BuilderTarget,
-) {
-  if (config?.output?.overrideBrowserslist) {
-    return config.output.overrideBrowserslist;
-  }
-
-  const result = await getBrowserslist(path);
-  return result || DEFAULT_BROWSERSLIST[target];
-}
+import type { NormalizedConfig } from '../types';
 
 /** Preserving the details of schema by generic types. */
 export const defineSchema = <T extends SomeJSONSchema>(schema: T): T => schema;
-
-export const getDataUrlLimit = (
-  config: NormalizedConfig,
-  type: keyof DataUriLimit,
-) => {
-  const { dataUriLimit } = config.output;
-  const ret = dataUriLimit[type];
-  if (typeof ret !== 'number') {
-    throw new Error(`unknown key ${type} in "output.dataUriLimit"`);
-  }
-  return ret;
-};
 
 export function getDataUrlCondition(
   config: NormalizedConfig,
@@ -64,7 +34,7 @@ export function getDataUrlCondition(
       }
     }
 
-    return source.length <= getDataUrlLimit(config, type);
+    return source.length <= config.output.dataUriLimit[type];
   };
 }
 

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
@@ -25,7 +25,7 @@ export class ProgressPlugin extends webpack.ProgressPlugin {
       quietOnDev = false,
       clearOnDone = false,
     } = options;
-    const isQuite =
+    const isQuiet =
       quiet || (quietOnDev && process.env.NODE_ENV === 'development');
 
     super({
@@ -38,7 +38,7 @@ export class ProgressPlugin extends webpack.ProgressPlugin {
       dependenciesCount: 10000,
       percentBy: null,
       handler: (percentage, message) => {
-        if (!isQuite && process.stdout.isTTY) {
+        if (!isQuiet && process.stdout.isTTY) {
           const done = percentage === 1;
           bus.update({
             id,


### PR DESCRIPTION
# PR Details

## Description

- Fix typo in `dev.progressBar` options, quite should be quiet
- Fix incorrect target label when inspect configs.
- Move the `getBrowserslistWithDefault` method to `builder-shared`.
- Remove the `getDataUrlLimit` method because it is useless yet.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
