### PR TITLE
fix(builder): failed remove css for node/worker target

### DIFF
--- a/.changeset/fuzzy-humans-jump.md
+++ b/.changeset/fuzzy-humans-jump.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): failed remove css for node/worker target
+
+fix(builder): 修复 node/worker 产物时未正确移除 CSS 代码的问题

--- a/packages/builder/builder-webpack-provider/src/plugins/css.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/css.ts
@@ -1,9 +1,12 @@
+import path from 'path';
+import assert from 'assert';
 import {
   CSS_REGEX,
   type BuilderTarget,
   type BuilderContext,
 } from '@modern-js/builder-shared';
 import { getBrowserslistWithDefault } from '../shared';
+
 import type {
   WebpackChain,
   BuilderPlugin,
@@ -13,8 +16,6 @@ import type {
   NormalizedConfig,
   StyleLoaderOptions,
 } from '../types';
-
-import assert from 'assert';
 import type { AcceptedPlugin, ProcessOptions } from 'postcss';
 
 export const isUseCssExtract = (
@@ -25,6 +26,28 @@ export const isUseCssExtract = (
   !config.tools.styleLoader &&
   target !== 'node' &&
   target !== 'web-worker';
+
+// If the target is 'node' or 'web-worker' and the modules option of css-loader is enabled,
+// we must enable exportOnlyLocals to only exports the modules identifier mappings.
+// Otherwise, the compiled CSS code may contain invalid code, such as `new URL`.
+// https://github.com/webpack-contrib/css-loader#exportonlylocals
+export const normalizeCssLoaderOptions = (
+  options: CSSLoaderOptions,
+  exportOnlyLocals: boolean,
+) => {
+  if (options.modules && exportOnlyLocals) {
+    let { modules } = options;
+    if (modules === true) {
+      modules = { exportOnlyLocals: true };
+    } else if (typeof modules === 'string') {
+      modules = { mode: modules, exportOnlyLocals: true };
+    } else {
+      modules.exportOnlyLocals = true;
+    }
+    options.modules = modules;
+  }
+  return options;
+};
 
 export async function applyBaseCSSRule(
   rule: WebpackChain.Rule,
@@ -119,22 +142,6 @@ export async function applyBaseCSSRule(
     {},
     config.tools.styleLoader,
   );
-  const cssLoaderOptions = applyOptionsChain<CSSLoaderOptions, null>(
-    {
-      importLoaders: 1,
-      modules: {
-        auto: true,
-        exportLocalsConvention: 'camelCase',
-        localIdentName: isProd
-          ? '[hash:base64]'
-          : '[path][name]__[local]--[hash:base64:5]',
-        exportOnlyLocals: isServer || isWebWorker,
-      },
-      sourceMap: enableSourceMap,
-    },
-    config.tools.cssLoader,
-  );
-  const postcssLoaderOptions = getPostcssConfig();
 
   // 3. Create webpack rule
   // Order: style-loader/mini-css-extract -> css-loader -> postcss-loader
@@ -163,7 +170,31 @@ export async function applyBaseCSSRule(
         .loader(getCompiledPath('css-modules-typescript-loader'))
         .end();
     }
+  } else {
+    rule
+      .use(CHAIN_ID.USE.IGNORE_CSS)
+      .loader(path.resolve(__dirname, '../webpackLoaders/ignoreCssLoader'))
+      .end();
   }
+
+  const mergedCssLoaderOptions = applyOptionsChain<CSSLoaderOptions, null>(
+    {
+      importLoaders: 1,
+      modules: {
+        auto: true,
+        exportLocalsConvention: 'camelCase',
+        localIdentName: isProd
+          ? '[hash:base64]'
+          : '[path][name]__[local]--[hash:base64:5]',
+      },
+      sourceMap: enableSourceMap,
+    },
+    config.tools.cssLoader,
+  );
+  const cssLoaderOptions = normalizeCssLoaderOptions(
+    mergedCssLoaderOptions,
+    isServer || isWebWorker,
+  );
 
   rule
     .use(CHAIN_ID.USE.CSS)
@@ -172,6 +203,7 @@ export async function applyBaseCSSRule(
     .end();
 
   if (!isServer && !isWebWorker) {
+    const postcssLoaderOptions = getPostcssConfig();
     rule
       .use(CHAIN_ID.USE.POSTCSS)
       .loader(getCompiledPath('postcss-loader'))

--- a/packages/builder/builder-webpack-provider/src/webpackLoaders/ignoreCssLoader.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackLoaders/ignoreCssLoader.ts
@@ -1,0 +1,15 @@
+import type { webpack } from '../types';
+
+export default function (this: webpack.LoaderContext<unknown>, source: string) {
+  this?.cacheable(true);
+
+  // if the source code include '___CSS_LOADER_EXPORT___'
+  // It is not a CSS modules file because exportOnlyLocals is enabled,
+  // so we don't need to preserve it.
+  if (source.includes('___CSS_LOADER_EXPORT___')) {
+    return '';
+  }
+
+  // Preserve css modules export for SSR.
+  return source;
+}

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/css.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/css.test.ts.snap
@@ -9,6 +9,9 @@ exports[`plugins/css > should not apply postcss-loader when target is node 1`] =
         "test": /\\\\\\.css\\$/,
         "use": [
           {
+            "loader": "<ROOT>/packages/builder/builder-webpack-provider/src/webpackLoaders/ignoreCssLoader",
+          },
+          {
             "loader": "<ROOT>/packages/builder/builder-webpack-provider/compiled/css-loader",
             "options": {
               "importLoaders": 1,
@@ -46,7 +49,6 @@ exports[`plugins/css > should override browserslist of autoprefixer when using o
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
-                "exportOnlyLocals": false,
                 "localIdentName": "[path][name]__[local]--[hash:base64:5]",
               },
               "sourceMap": false,

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/rem.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/rem.test.ts.snap
@@ -18,7 +18,6 @@ exports[`plugins/rem > should not run htmlPlugin with enableRuntime is false 1`]
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
-                "exportOnlyLocals": false,
                 "localIdentName": "[path][name]__[local]--[hash:base64:5]",
               },
               "sourceMap": false,
@@ -90,7 +89,6 @@ exports[`plugins/rem > should not run rem plugin when false 1`] = `
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
-                "exportOnlyLocals": false,
                 "localIdentName": "[path][name]__[local]--[hash:base64:5]",
               },
               "sourceMap": false,
@@ -156,7 +154,6 @@ exports[`plugins/rem > should not run rem plugin without config 1`] = `
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
-                "exportOnlyLocals": false,
                 "localIdentName": "[path][name]__[local]--[hash:base64:5]",
               },
               "sourceMap": false,
@@ -222,7 +219,6 @@ exports[`plugins/rem > should run rem plugin with custom config 1`] = `
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
-                "exportOnlyLocals": false,
                 "localIdentName": "[path][name]__[local]--[hash:base64:5]",
               },
               "sourceMap": false,
@@ -316,7 +312,6 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
-                "exportOnlyLocals": false,
                 "localIdentName": "[path][name]__[local]--[hash:base64:5]",
               },
               "sourceMap": false,
@@ -379,7 +374,6 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
-                "exportOnlyLocals": false,
                 "localIdentName": "[path][name]__[local]--[hash:base64:5]",
               },
               "sourceMap": false,
@@ -452,7 +446,6 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
-                "exportOnlyLocals": false,
                 "localIdentName": "[path][name]__[local]--[hash:base64:5]",
               },
               "sourceMap": false,

--- a/packages/builder/builder-webpack-provider/tests/plugins/css.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/css.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { PluginCss } from '../../src/plugins/css';
+import { PluginCss, normalizeCssLoaderOptions } from '../../src/plugins/css';
 import { PluginSass } from '../../src/plugins/sass';
 import { PluginLess } from '../../src/plugins/less';
 import { createStubBuilder } from '../../src/stub';
@@ -183,5 +183,39 @@ describe('plugins/css', () => {
     const config = await builder.unwrapWebpackConfig();
 
     expect(config).toMatchSnapshot();
+  });
+});
+
+describe('normalizeCssLoaderOptions', () => {
+  it('should enable exportOnlyLocals correctly', () => {
+    expect(normalizeCssLoaderOptions({ modules: false }, true)).toEqual({
+      modules: false,
+    });
+
+    expect(normalizeCssLoaderOptions({ modules: true }, true)).toEqual({
+      modules: {
+        exportOnlyLocals: true,
+      },
+    });
+
+    expect(normalizeCssLoaderOptions({ modules: true }, false)).toEqual({
+      modules: true,
+    });
+
+    expect(normalizeCssLoaderOptions({ modules: 'local' }, true)).toEqual({
+      modules: {
+        mode: 'local',
+        exportOnlyLocals: true,
+      },
+    });
+
+    expect(
+      normalizeCssLoaderOptions({ modules: { auto: true } }, true),
+    ).toEqual({
+      modules: {
+        auto: true,
+        exportOnlyLocals: true,
+      },
+    });
   });
 });

--- a/packages/toolkit/utils/src/chainId.ts
+++ b/packages/toolkit/utils/src/chainId.ts
@@ -91,6 +91,8 @@ export const CHAIN_ID = {
     POSTCSS: 'postcss',
     /** markdown-loader */
     MARKDOWN: 'markdown',
+    /** ignore-css-loader */
+    IGNORE_CSS: 'ignore-css',
     /** css-modules-typescript-loader */
     CSS_MODULES_TS: 'css-modules-typescript',
     /** mini-css-extract-plugin.loader */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3543,6 +3543,31 @@ importers:
       '@types/react-dom': 18.0.6
       typescript: 4.7.4
 
+  tests/e2e/webpack-builder/ignore-css:
+    specifiers:
+      '@modern-js/builder': workspace:*
+      '@modern-js/builder-webpack-provider': workspace:*
+      '@modern-js/e2e': workspace:*
+      '@types/node': ^14
+      '@types/react': ^18
+      '@types/react-dom': ^18
+      got: ^11.8.3
+      react: ^17.0.1
+      react-dom: ^17.0.1
+      typescript: ^4
+    dependencies:
+      got: 11.8.5
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    devDependencies:
+      '@modern-js/builder': link:../../../../packages/builder/builder
+      '@modern-js/builder-webpack-provider': link:../../../../packages/builder/builder-webpack-provider
+      '@modern-js/e2e': link:../../../../packages/toolkit/e2e
+      '@types/node': 14.18.21
+      '@types/react': 18.0.21
+      '@types/react-dom': 18.0.6
+      typescript: 4.7.4
+
   tests/e2e/webpack-builder/inline-chunk:
     specifiers:
       '@modern-js/builder-shared': workspace:*
@@ -7926,6 +7951,17 @@ packages:
     dev: false
     optional: true
 
+  /@modern-js/swc-plugins-freebsd-x64/0.0.2:
+    resolution: {integrity: sha512-AUxGz17f3/bJ3PaO/RdJF5YFkcriudqlkN2biYjD0vmnsOOaT+dCfc9Ms8yEkXrHYzkndhCyNMSjORmYsvaYbg==}
+    engines: {node: '>=14.17.6'}
+    requiresBuild: true
+    peerDependencies:
+      react: ^17
+    dependencies:
+      '@babel/runtime': 7.18.6
+    dev: false
+    optional: true
+
   /@modern-js/swc-plugins-linux-arm-gnueabihf/0.0.2:
     resolution: {integrity: sha512-oHBungTNKvHBYOyDPKZrWNOoNszb3+3pvmgcZxBH1PSni192tM1VLkJgusH1yE1W3SITFd/832SubzEzGYWuZA==}
     engines: {node: '>= 14.18'}
@@ -8004,6 +8040,7 @@ packages:
     optionalDependencies:
       '@modern-js/swc-plugins-darwin-arm64': 0.0.2
       '@modern-js/swc-plugins-darwin-x64': 0.0.2
+      '@modern-js/swc-plugins-freebsd-x64': 0.0.2
       '@modern-js/swc-plugins-linux-arm-gnueabihf': 0.0.2
       '@modern-js/swc-plugins-linux-arm64-gnu': 0.0.2
       '@modern-js/swc-plugins-linux-arm64-musl': 0.0.2
@@ -8012,6 +8049,8 @@ packages:
       '@modern-js/swc-plugins-win32-arm64-msvc': 0.0.2
       '@modern-js/swc-plugins-win32-ia32-msvc': 0.0.2
       '@modern-js/swc-plugins-win32-x64-msvc': 0.0.2
+    transitivePeerDependencies:
+      - react
     dev: false
 
   /@modern-js/utils/1.20.1:
@@ -12623,8 +12662,10 @@ packages:
     dependencies:
       ajv: 6.12.6
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -28751,7 +28792,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scmp/2.1.0:

--- a/tests/e2e/webpack-builder/ignore-css/.eslintrc.js
+++ b/tests/e2e/webpack-builder/ignore-css/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  root: true,
+  extends: ['@modern-js'],
+  ignorePatterns: ['src/**/*'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.json'],
+  },
+};

--- a/tests/e2e/webpack-builder/ignore-css/package.json
+++ b/tests/e2e/webpack-builder/ignore-css/package.json
@@ -1,0 +1,24 @@
+{
+  "private": true,
+  "name": "@e2e/webpack-builder-ignore-css",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "node ./scripts/dev.js",
+    "build": "node ./scripts/build.js",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "got": "^11.8.3",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
+  },
+  "devDependencies": {
+    "@modern-js/e2e": "workspace:*",
+    "@modern-js/builder": "workspace:*",
+    "@modern-js/builder-webpack-provider": "workspace:*",
+    "@types/node": "^14",
+    "@types/react": "^17",
+    "@types/react-dom": "^17",
+    "typescript": "^4"
+  }
+}

--- a/tests/e2e/webpack-builder/ignore-css/removeCss.test.ts
+++ b/tests/e2e/webpack-builder/ignore-css/removeCss.test.ts
@@ -1,0 +1,37 @@
+import path from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { createStubBuilder } from '@modern-js/builder-webpack-provider/stub';
+
+test('should ignore css content when build node target', async () => {
+  const builder = await createStubBuilder({
+    webpack: true,
+    target: 'node',
+    entry: { index: path.resolve('./src/index.js') },
+  });
+  const files = await builder.unwrapOutputJSON();
+
+  const content = files[Object.keys(files).find(file => file.endsWith('.js'))!];
+
+  // preserve css modules mapping
+  expect(content.includes('"title-class":')).toBeTruthy();
+  // remove css content
+  expect(content.includes('.title-class')).toBeFalsy();
+  expect(content.includes('.header-class')).toBeFalsy();
+});
+
+test('should ignore css content when build web-worker target', async () => {
+  const builder = await createStubBuilder({
+    webpack: true,
+    target: 'web-worker',
+    entry: { index: path.resolve('./src/index.js') },
+  });
+  const files = await builder.unwrapOutputJSON();
+
+  const content = files[Object.keys(files).find(file => file.endsWith('.js'))!];
+
+  // preserve css modules mapping
+  expect(content.includes('"title-class":')).toBeTruthy();
+  // remove css content
+  expect(content.includes('.title-class')).toBeFalsy();
+  expect(content.includes('.header-class')).toBeFalsy();
+});

--- a/tests/e2e/webpack-builder/ignore-css/src/a.css
+++ b/tests/e2e/webpack-builder/ignore-css/src/a.css
@@ -1,0 +1,3 @@
+.header-class {
+  color: red;
+}

--- a/tests/e2e/webpack-builder/ignore-css/src/b.module.scss
+++ b/tests/e2e/webpack-builder/ignore-css/src/b.module.scss
@@ -1,0 +1,3 @@
+.title-class {
+  font-size: 14px;
+}

--- a/tests/e2e/webpack-builder/ignore-css/src/index.js
+++ b/tests/e2e/webpack-builder/ignore-css/src/index.js
@@ -1,0 +1,4 @@
+import './a.css';
+import style from './b.module.scss';
+
+console.log(style);

--- a/tests/e2e/webpack-builder/ignore-css/tsconfig.json
+++ b/tests/e2e/webpack-builder/ignore-css/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": ["src", "scripts", "*.test.ts", "removeCss.test.ts"]
+}


### PR DESCRIPTION
# PR Details

## Description

Fix failed remove css for node/worker target.

Builder used to use the `exportOnlyLocals` option of css-loader to remove the css content, but the `exportOnlyLocals` can only work with `.module.css` files, and the normal `.css` files is not processed, so I added a `ignore-css-loader` to remove css from normal `.css` files.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
