### PR TITLE
feat(builder): display user friendly progress percentage

### DIFF
--- a/.changeset/bright-llamas-yawn.md
+++ b/.changeset/bright-llamas-yawn.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+feat(builder): display user friendly progress percentage
+
+feat(builder): 展示用户友好的进度条进度

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
@@ -1,5 +1,5 @@
 import webpack from 'webpack';
-import { bus } from './helpers/bus';
+import { bus, createFriendlyPercentage } from './helpers';
 import prettyTime from '../../../compiled/pretty-time';
 import type { Props } from './helpers/type';
 
@@ -27,6 +27,7 @@ export class ProgressPlugin extends webpack.ProgressPlugin {
     } = options;
     const isQuite =
       quiet || (quietOnDev && process.env.NODE_ENV === 'development');
+    const friendlyPercentage = createFriendlyPercentage();
 
     super({
       activeModules: false,
@@ -39,7 +40,10 @@ export class ProgressPlugin extends webpack.ProgressPlugin {
       percentBy: null,
       handler: (percentage, message) => {
         if (!isQuite && process.stdout.isTTY) {
+          // eslint-disable-next-line no-param-reassign
+          percentage = friendlyPercentage(percentage);
           const done = percentage === 1;
+
           bus.update({
             id,
             current: percentage * 100,

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/index.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './bus';
 export * from './bar';
 export * from './type';
+export * from './percentage';

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/percentage.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/percentage.ts
@@ -1,0 +1,35 @@
+/**
+ * Make the progress percentage more user friendly.
+ * The original percentage may pause at certain number for a long time,
+ * or decrease in some cases, which will confuse the user.
+ * So we format the percentage number and display a more smooth percentage.
+ */
+export const createFriendlyPercentage = () => {
+  let prevPercentage = 0;
+
+  return (percentage: number) => {
+    if (percentage === 0 || percentage === 1) {
+      prevPercentage = 0;
+      return percentage;
+    }
+
+    if (percentage <= prevPercentage) {
+      let step = 0;
+      if (prevPercentage < 0.3) {
+        step = 0.001;
+      } else if (prevPercentage < 0.6) {
+        step = 0.002;
+      } else if (prevPercentage < 0.8) {
+        step = 0.004;
+      } else if (prevPercentage < 0.99) {
+        step = 0.002;
+      }
+
+      prevPercentage += step;
+      return prevPercentage;
+    }
+
+    prevPercentage = percentage;
+    return percentage;
+  };
+};

--- a/packages/builder/builder-webpack-provider/tests/plugins/progress.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/progress.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createStubBuilder } from '@/stub';
 import { PluginProgress } from '@/plugins/progress';
+import { createFriendlyPercentage } from '@/webpackPlugins/ProgressPlugin/helpers';
 
 describe('plugins/progress', () => {
   it('should register webpackbar by default', async () => {
@@ -24,5 +25,22 @@ describe('plugins/progress', () => {
 
     const matched = await builder.matchWebpackPlugin('ProgressPlugin');
     expect(matched).toBeFalsy();
+  });
+});
+
+describe('createFriendlyPercentage', () => {
+  it('should format percentage correctly', () => {
+    const friendlyPercentage = createFriendlyPercentage();
+
+    expect(friendlyPercentage(0)).toBe(0);
+    expect(friendlyPercentage(0.01)).toBe(0.01);
+    expect(friendlyPercentage(0.01)).toBe(0.011);
+    expect(friendlyPercentage(0.4)).toBe(0.4);
+    expect(friendlyPercentage(0.7)).toBe(0.7);
+    expect(friendlyPercentage(0.7)).toBe(0.704);
+    expect(friendlyPercentage(0.9)).toBe(0.9);
+    expect(friendlyPercentage(0.9)).toBe(0.902);
+    expect(friendlyPercentage(1)).toBe(1);
+    expect(friendlyPercentage(0)).toBe(0);
   });
 });


### PR DESCRIPTION
# PR Details

## Description

Make the progress percentage more user friendly. The original percentage may pause at certain number for a long time, or decrease in some cases, which will confuse the user. So we format the percentage number and display a more smooth percentage.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
