### PR TITLE
feat(builder): build method support custom compiler

### DIFF
--- a/.changeset/lucky-lobsters-tan.md
+++ b/.changeset/lucky-lobsters-tan.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+feat(builder): build method support custom compiler
+
+feat(builder): build 方法支持传入自定义的 compiler 对象

--- a/packages/builder/builder-shared/src/types/provider.ts
+++ b/packages/builder/builder-shared/src/types/provider.ts
@@ -20,6 +20,7 @@ export type StartDevServerOptions = {
 export type BuildOptions = {
   mode?: BuilderMode;
   watch?: boolean;
+  compiler?: Compiler | MultiCompiler;
 };
 
 export type InspectConfigOptions = {

--- a/packages/builder/builder-webpack-provider/src/core/build.ts
+++ b/packages/builder/builder-webpack-provider/src/core/build.ts
@@ -6,24 +6,13 @@ import {
   type BuildOptions,
   type PromiseOrNot,
 } from '@modern-js/builder-shared';
-import type { webpack, Context, WebpackConfig } from '../types';
-import type { Stats, MultiStats } from 'webpack';
+import type { Stats, MultiStats, Compiler, MultiCompiler } from 'webpack';
 
 export type BuildExecuter = (
-  context: Context,
-  configs: webpack.Configuration[],
+  compiler: Compiler | MultiCompiler,
 ) => PromiseOrNot<{ stats: Stats | MultiStats } | void>;
 
-export const webpackBuild = async (
-  context: Context,
-  webpackConfigs: WebpackConfig[],
-) => {
-  const compiler = await createCompiler({
-    watch: false,
-    context,
-    webpackConfigs,
-  });
-
+export const webpackBuild: BuildExecuter = async compiler => {
   return new Promise<{ stats: Stats | MultiStats }>((resolve, reject) => {
     logger.log();
     logger.info(`building for production...\n`);
@@ -53,7 +42,7 @@ export const webpackBuild = async (
 
 export const build = async (
   initOptions: InitConfigsOptions,
-  { mode = 'production', watch }: BuildOptions = {},
+  { mode = 'production', watch, compiler: customCompiler }: BuildOptions = {},
   executer?: BuildExecuter,
 ) => {
   if (!process.env.NODE_ENV) {
@@ -61,24 +50,30 @@ export const build = async (
   }
 
   const { context } = initOptions;
-  const { webpackConfigs } = await initConfigs(initOptions);
 
-  await context.hooks.onBeforeBuildHook.call({
-    bundlerConfigs: webpackConfigs,
-  });
+  let compiler: Compiler | MultiCompiler;
 
-  if (watch) {
-    const compiler = await createCompiler({
+  if (customCompiler) {
+    compiler = customCompiler;
+  } else {
+    const { webpackConfigs } = await initConfigs(initOptions);
+    compiler = await createCompiler({
+      watch,
       context,
       webpackConfigs,
     });
+  }
+
+  await context.hooks.onBeforeBuildHook.call();
+
+  if (watch) {
     compiler.watch({}, err => {
       if (err) {
         logger.error(err);
       }
     });
   } else {
-    const executeResult = await executer?.(context, webpackConfigs);
+    const executeResult = await executer?.(compiler);
     await context.hooks.onAfterBuildHook.call({
       stats: executeResult?.stats,
     });

--- a/packages/builder/builder-webpack-provider/src/core/createCompiler.ts
+++ b/packages/builder/builder-webpack-provider/src/core/createCompiler.ts
@@ -13,7 +13,7 @@ export async function createCompiler({
   webpackConfigs: WebpackConfig[];
 }) {
   debug('create compiler');
-  await context.hooks.onBeforeCreateCompilerHooks.call({
+  await context.hooks.onBeforeCreateCompilerHook.call({
     bundlerConfigs: webpackConfigs,
   });
 
@@ -44,7 +44,7 @@ export async function createCompiler({
     }
   });
 
-  await context.hooks.onAfterCreateCompilerHooks.call({ compiler });
+  await context.hooks.onAfterCreateCompilerHook.call({ compiler });
   debug('create compiler done');
 
   return compiler;

--- a/packages/builder/builder-webpack-provider/src/core/initConfigs.ts
+++ b/packages/builder/builder-webpack-provider/src/core/initConfigs.ts
@@ -66,7 +66,7 @@ export async function initConfigs({
 
     // run inspect later to avoid cleaned by cleanOutput plugin
     context.hooks.onBeforeBuildHook.tap(inspect);
-    context.hooks.onBeforeStartDevServerHooks.tap(inspect);
+    context.hooks.onBeforeStartDevServerHook.tap(inspect);
   }
 
   return {

--- a/packages/builder/builder-webpack-provider/src/core/initHooks.ts
+++ b/packages/builder/builder-webpack-provider/src/core/initHooks.ts
@@ -22,10 +22,10 @@ export function initHooks() {
     modifyWebpackChainHook: createAsyncHook<ModifyWebpackChainFn>(),
     modifyWebpackConfigHook: createAsyncHook<ModifyWebpackConfigFn>(),
     modifyBuilderConfigHook: createAsyncHook<ModifyBuilderConfigFn>(),
-    onAfterCreateCompilerHooks: createAsyncHook<OnAfterCreateCompilerFn>(),
-    onBeforeCreateCompilerHooks: createAsyncHook<OnBeforeCreateCompilerFn>(),
-    onAfterStartDevServerHooks: createAsyncHook<OnAfterStartDevServerFn>(),
-    onBeforeStartDevServerHooks: createAsyncHook<OnBeforeStartDevServerFn>(),
+    onAfterCreateCompilerHook: createAsyncHook<OnAfterCreateCompilerFn>(),
+    onBeforeCreateCompilerHook: createAsyncHook<OnBeforeCreateCompilerFn>(),
+    onAfterStartDevServerHook: createAsyncHook<OnAfterStartDevServerFn>(),
+    onBeforeStartDevServerHook: createAsyncHook<OnBeforeStartDevServerFn>(),
   };
 }
 

--- a/packages/builder/builder-webpack-provider/src/core/initPlugins.ts
+++ b/packages/builder/builder-webpack-provider/src/core/initPlugins.ts
@@ -39,10 +39,10 @@ export async function initPlugins({
     modifyWebpackChain: hooks.modifyWebpackChainHook.tap,
     modifyWebpackConfig: hooks.modifyWebpackConfigHook.tap,
     modifyBuilderConfig: hooks.modifyBuilderConfigHook.tap,
-    onAfterCreateCompiler: hooks.onAfterCreateCompilerHooks.tap,
-    onBeforeCreateCompiler: hooks.onBeforeCreateCompilerHooks.tap,
-    onAfterStartDevServer: hooks.onAfterStartDevServerHooks.tap,
-    onBeforeStartDevServer: hooks.onBeforeStartDevServerHooks.tap,
+    onAfterCreateCompiler: hooks.onAfterCreateCompilerHook.tap,
+    onBeforeCreateCompiler: hooks.onBeforeCreateCompilerHook.tap,
+    onAfterStartDevServer: hooks.onAfterStartDevServerHook.tap,
+    onBeforeStartDevServer: hooks.onBeforeStartDevServerHook.tap,
   };
 
   for (const plugin of pluginStore.plugins) {

--- a/packages/builder/builder-webpack-provider/src/core/startDevServer.ts
+++ b/packages/builder/builder-webpack-provider/src/core/startDevServer.ts
@@ -127,7 +127,7 @@ export async function startDevServer(
 
   const server = await createDevServer(options, port, serverOptions, compiler);
 
-  await options.context.hooks.onBeforeStartDevServerHooks.call();
+  await options.context.hooks.onBeforeStartDevServerHook.call();
 
   debug('listen dev server');
   await server.init();
@@ -148,7 +148,7 @@ export async function startDevServer(
         await printDevServerURLs(urls);
       }
 
-      await options.context.hooks.onAfterStartDevServerHooks.call({ port });
+      await options.context.hooks.onAfterStartDevServerHook.call({ port });
       resolve({
         port,
         urls: urls.map(item => item.url),

--- a/packages/builder/builder-webpack-provider/src/stub/builder.ts
+++ b/packages/builder/builder-webpack-provider/src/stub/builder.ts
@@ -11,6 +11,7 @@ import { getTemplatePath } from '@modern-js/utils';
 import _ from '@modern-js/utils/lodash';
 import assert from 'assert';
 import { PathLike } from 'fs';
+import { initConfigs } from '../core/initConfigs';
 import { URL } from 'url';
 import { Hooks } from '../core/initHooks';
 import {
@@ -150,8 +151,12 @@ export async function createStubBuilder(options?: StubBuilderOptions) {
 
   /** Unwrap webpack configs. */
   const unwrapWebpackConfigs = async () => {
-    const [{ bundlerConfigs }] = await unwrapHook('onBeforeBuildHook');
-    return bundlerConfigs;
+    const { webpackConfigs } = await initConfigs({
+      context,
+      pluginStore,
+      builderOptions,
+    });
+    return webpackConfigs;
   };
 
   /** Unwrap webpack config, it will ensure there's only one config object. */
@@ -163,7 +168,7 @@ export async function createStubBuilder(options?: StubBuilderOptions) {
 
   /** Unwrap webpack compiler instance. */
   const unwrapWebpackCompiler = async () => {
-    const [{ compiler }] = await unwrapHook('onAfterCreateCompilerHooks');
+    const [{ compiler }] = await unwrapHook('onAfterCreateCompilerHook');
     return compiler;
   };
 

--- a/packages/builder/builder-webpack-provider/src/types/hooks.ts
+++ b/packages/builder/builder-webpack-provider/src/types/hooks.ts
@@ -29,9 +29,7 @@ export type ModifyBuilderConfigFn = (
   config: BuilderConfig,
 ) => Promise<BuilderConfig | void> | BuilderConfig | void;
 
-export type OnBeforeBuildFn = (params: {
-  bundlerConfigs: WebpackConfig[];
-}) => Promise<void> | void;
+export type OnBeforeBuildFn = () => Promise<void> | void;
 
 export type OnAfterBuildFn = (params: {
   stats?: Stats | MultiStats;

--- a/packages/builder/builder-webpack-provider/tests/__snapshots__/hooks.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/__snapshots__/hooks.test.ts.snap
@@ -9,9 +9,9 @@ exports[`initHooks > should init hooks correctly 1`] = `
   "modifyWebpackChainHook",
   "modifyWebpackConfigHook",
   "modifyBuilderConfigHook",
-  "onAfterCreateCompilerHooks",
-  "onBeforeCreateCompilerHooks",
-  "onAfterStartDevServerHooks",
-  "onBeforeStartDevServerHooks",
+  "onAfterCreateCompilerHook",
+  "onBeforeCreateCompilerHook",
+  "onAfterStartDevServerHook",
+  "onBeforeStartDevServerHook",
 ]
 `;

--- a/packages/builder/builder-webpack-provider/tests/stub/builder.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/stub/builder.test.ts
@@ -8,7 +8,7 @@ describe('stub-builder', () => {
     const builder = await createStubBuilder();
     const oldConfig = await builder.unwrapWebpackConfig();
     const newConfig = await builder.unwrapWebpackConfig();
-    expect(oldConfig).toBe(newConfig);
+    expect(oldConfig).toStrictEqual(newConfig);
   });
 
   it('lodash memoize should be reset', async () => {
@@ -45,6 +45,8 @@ describe('stub-builder', () => {
         "modifyBuilderConfigHook",
         "modifyWebpackChainHook",
         "modifyWebpackConfigHook",
+        "onBeforeCreateCompilerHook",
+        "onAfterCreateCompilerHook",
         "onBeforeBuildHook",
         "onAfterBuildHook",
       ]

--- a/website/builder/src/en/api/builder-instance.md
+++ b/website/builder/src/en/api/builder-instance.md
@@ -127,6 +127,8 @@ Perform a production build.
 type BuildOptions = {
   mode?: 'development' | 'production';
   watch?: boolean;
+  // custom Compiler object
+  compiler?: Compiler | MultiCompiler;
 };
 
 function Build(options?: BuildOptions): Promise<void>;
@@ -155,6 +157,19 @@ If you need to watch file changes and re-build, you can set the `watch` option t
 ```ts
 await builder.build({
   watch: true,
+});
+```
+
+### Custom Compiler
+
+In some cases, you may want to use a custom compiler:
+
+```ts
+const compiler = webpack({
+  // ...
+});
+await builder.build({
+  compiler,
 });
 ```
 

--- a/website/builder/src/zh/api/builder-instance.md
+++ b/website/builder/src/zh/api/builder-instance.md
@@ -127,6 +127,8 @@ type DevServer = {
 type BuildOptions = {
   mode?: 'development' | 'production';
   watch?: boolean;
+  // 自定义 Compiler 对象
+  compiler?: Compiler | MultiCompiler;
 };
 
 function Build(options?: BuildOptions): Promise<void>;
@@ -155,6 +157,19 @@ await builder.build({
 ```ts
 await builder.build({
   watch: true,
+});
+```
+
+### 自定义 Compiler
+
+个别情况下，你可能希望使用自定义的 compiler：
+
+```ts
+const compiler = webpack({
+  // ...
+});
+await builder.build({
+  compiler,
 });
 ```
 


### PR DESCRIPTION
# PR Details

## Description

1. The build method support custom compiler (same as startDevServer).

```ts
const compiler = webpack({
  // ...
});
await builder.build({
  compiler,
});
```

2. Remove bundlerConfig param of `api.onBeforeBuild`, this param is never used by plugins, and it is not available when custom compiler.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
