### PR TITLE
feat(builder): make preset chunk names more readable

### DIFF
--- a/.changeset/olive-lies-agree.md
+++ b/.changeset/olive-lies-agree.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+feat(builder): make preset chunk names more readable
+
+feat(builder): 优化预设 chunk 命名的可读性

--- a/packages/builder/builder-webpack-provider/src/plugins/splitChunks.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/splitChunks.ts
@@ -40,7 +40,7 @@ interface SplitChunksContext {
 function getUserDefinedCacheGroups(forceSplitting: Array<RegExp>): CacheGroup {
   const cacheGroups: CacheGroup = {};
   forceSplitting.forEach((reg, index) => {
-    const key = `User_Force_Split_Group_${index}`;
+    const key = `force-split-${index}`;
 
     cacheGroups[key] = {
       test: reg,
@@ -56,20 +56,20 @@ function getUserDefinedCacheGroups(forceSplitting: Array<RegExp>): CacheGroup {
 function splitByExperience(ctx: SplitChunksContext): SplitChunks {
   const { override, userDefinedCacheGroups, defaultConfig } = ctx;
   const experienceCacheGroup: CacheGroup = {};
-  const SPLIT_EXPERIENCE_LIST = [
-    /[\\/]react|react-dom[\\/]/,
-    /[\\/]react-router|react-router-dom|history[\\/]/,
-    /[\\/]@ies\/semi[\\/]/,
-    /[\\/]antd[\\/]/,
-    /[\\/]@arco-design[\\/]/,
-    /[\\/]@douyinfe\/semi[\\/]/,
-    /[\\/]@babel\/runtime|@babel\/runtime-corejs2|@babel\/runtime-corejs3[\\/]/,
-    /[\\/]lodash|lodash-es[\\/]/,
-    /[\\/]core-js[\\/]/,
-  ];
+  const SPLIT_EXPERIENCE_LIST = {
+    react: /[\\/]react|react-dom[\\/]/,
+    router: /[\\/]react-router|react-router-dom|history[\\/]/,
+    antd: /[\\/]antd[\\/]/,
+    semi: /[\\/]@ies\/semi|@douyinfe\/semi[\\/]/,
+    arco: /[\\/]@arco-design[\\/]/,
+    babel:
+      /[\\/]@babel\/runtime|@babel\/runtime-corejs2|@babel\/runtime-corejs3[\\/]/,
+    lodash: /[\\/]lodash|lodash-es[\\/]/,
+    corejs: /[\\/]core-js[\\/]/,
+  };
 
-  SPLIT_EXPERIENCE_LIST.forEach((test: RegExp, index: number) => {
-    const key = `pre-defined-chunk-${index}`;
+  Object.entries(SPLIT_EXPERIENCE_LIST).forEach(([name, test]) => {
+    const key = `lib-${name}`;
 
     experienceCacheGroup[key] = {
       test,

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/splitChunks.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/splitChunks.test.ts.snap
@@ -24,10 +24,10 @@ exports[`plugins/splitChunks > should set custom config 1`] = `
     },
     "splitChunks": {
       "cacheGroups": {
-        "User_Force_Split_Group_0": {
+        "force-split-0": {
           "chunks": "all",
           "enforce": true,
-          "name": "User_Force_Split_Group_0",
+          "name": "force-split-0",
           "test": /react/,
         },
       },
@@ -78,59 +78,53 @@ exports[`plugins/splitChunks > should set split-by-experience config 1`] = `
     },
     "splitChunks": {
       "cacheGroups": {
-        "pre-defined-chunk-0": {
-          "name": "pre-defined-chunk-0",
-          "priority": 0,
-          "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]react\\|react-dom\\[\\\\\\\\/\\]/,
-        },
-        "pre-defined-chunk-1": {
-          "name": "pre-defined-chunk-1",
-          "priority": 0,
-          "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]react-router\\|react-router-dom\\|history\\[\\\\\\\\/\\]/,
-        },
-        "pre-defined-chunk-2": {
-          "name": "pre-defined-chunk-2",
-          "priority": 0,
-          "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]@ies\\\\/semi\\[\\\\\\\\/\\]/,
-        },
-        "pre-defined-chunk-3": {
-          "name": "pre-defined-chunk-3",
+        "lib-antd": {
+          "name": "lib-antd",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]antd\\[\\\\\\\\/\\]/,
         },
-        "pre-defined-chunk-4": {
-          "name": "pre-defined-chunk-4",
+        "lib-arco": {
+          "name": "lib-arco",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]@arco-design\\[\\\\\\\\/\\]/,
         },
-        "pre-defined-chunk-5": {
-          "name": "pre-defined-chunk-5",
-          "priority": 0,
-          "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]@douyinfe\\\\/semi\\[\\\\\\\\/\\]/,
-        },
-        "pre-defined-chunk-6": {
-          "name": "pre-defined-chunk-6",
+        "lib-babel": {
+          "name": "lib-babel",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]@babel\\\\/runtime\\|@babel\\\\/runtime-corejs2\\|@babel\\\\/runtime-corejs3\\[\\\\\\\\/\\]/,
         },
-        "pre-defined-chunk-7": {
-          "name": "pre-defined-chunk-7",
+        "lib-corejs": {
+          "name": "lib-corejs",
+          "priority": 0,
+          "reuseExistingChunk": true,
+          "test": /\\[\\\\\\\\/\\]core-js\\[\\\\\\\\/\\]/,
+        },
+        "lib-lodash": {
+          "name": "lib-lodash",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]lodash\\|lodash-es\\[\\\\\\\\/\\]/,
         },
-        "pre-defined-chunk-8": {
-          "name": "pre-defined-chunk-8",
+        "lib-react": {
+          "name": "lib-react",
           "priority": 0,
           "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]core-js\\[\\\\\\\\/\\]/,
+          "test": /\\[\\\\\\\\/\\]react\\|react-dom\\[\\\\\\\\/\\]/,
+        },
+        "lib-router": {
+          "name": "lib-router",
+          "priority": 0,
+          "reuseExistingChunk": true,
+          "test": /\\[\\\\\\\\/\\]react-router\\|react-router-dom\\|history\\[\\\\\\\\/\\]/,
+        },
+        "lib-semi": {
+          "name": "lib-semi",
+          "priority": 0,
+          "reuseExistingChunk": true,
+          "test": /\\[\\\\\\\\/\\]@ies\\\\/semi\\|@douyinfe\\\\/semi\\[\\\\\\\\/\\]/,
         },
       },
       "chunks": "all",


### PR DESCRIPTION
# PR Details

## Description

Make preset chunk names more readable, `pre-defiened-chunk-0.xxxxxx.js` -> `lib-react.xxxxxx.js`.

This change can let developers easily known the content of chunk by file name.

<img width="628" alt="截屏2022-10-25 19 42 02" src="https://user-images.githubusercontent.com/7237365/197767067-d5986597-9ff7-46b4-9257-b564a624ce2c.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
