### PR TITLE
fix(builder): failed to print correct file sizes

### DIFF
--- a/.changeset/plenty-islands-boil.md
+++ b/.changeset/plenty-islands-boil.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): failed to print correct file sizes
+
+fix(builder): 修复无法正确输出构建产物体积的问题

--- a/packages/builder/builder-webpack-provider/src/core/build.ts
+++ b/packages/builder/builder-webpack-provider/src/core/build.ts
@@ -14,9 +14,6 @@ export type BuildExecuter = (
 
 export const webpackBuild: BuildExecuter = async compiler => {
   return new Promise<{ stats: Stats | MultiStats }>((resolve, reject) => {
-    logger.log();
-    logger.info(`building for production...\n`);
-
     compiler.run((err, stats) => {
       // When using run or watch, call close and wait for it to finish before calling run or watch again.
       // Concurrent compilations will corrupt the output files.

--- a/packages/builder/builder-webpack-provider/tests/plugins/fileSize.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/fileSize.test.ts
@@ -1,10 +1,5 @@
-import { chalk } from '@modern-js/utils';
 import { expect, describe, it } from 'vitest';
-import {
-  filterAsset,
-  getDiffLabel,
-  removeFileNameHash,
-} from '@/plugins/fileSize';
+import { filterAsset } from '@/plugins/fileSize';
 
 describe('plugins/fileSize', () => {
   it('#filterAsset - should filter asset correctly', () => {
@@ -12,30 +7,6 @@ describe('plugins/fileSize', () => {
     expect(filterAsset('dist/a.css')).toBeTruthy();
     expect(filterAsset('dist/a.js.map')).toBeFalsy();
     expect(filterAsset('dist/b.css.map')).toBeFalsy();
-    expect(filterAsset('dist/a.png')).toBeFalsy();
-  });
-
-  it('#removeFileNameHash - should remove hash from file name correctly', () => {
-    expect(removeFileNameHash('/dist', '/dist/main.8f1d8fa8.js')).toEqual(
-      'main.js',
-    );
-    expect(removeFileNameHash('/dist', '/dist/main.8f1d8fa8.css')).toEqual(
-      'main.css',
-    );
-  });
-
-  it('#getDiffLabel - should return correct label', () => {
-    expect(getDiffLabel(1000, 100, num => `${num / 1000}kb`)).toEqual(
-      chalk.yellow('+0.9kb'),
-    );
-    expect(getDiffLabel(100, 1000, num => `${num / 1000}kb`)).toEqual(
-      chalk.green('-0.9kb'),
-    );
-    expect(getDiffLabel(100000, 100, num => `${num / 1000}kb`)).toEqual(
-      chalk.red('+99.9kb'),
-    );
-    expect(getDiffLabel(1000, 1000, num => `${num / 1000}kb`)).toEqual(
-      chalk.green(''),
-    );
+    expect(filterAsset('dist/a.png')).toBeTruthy();
   });
 });


### PR DESCRIPTION
# PR Details

## Description

- Fix some assets are not included in the assets list, should adjust some options of `stats.toJson` method.
- Fix the size diff is not accurate, we can not remove file name hash correctly, some files may not contain a hash. So this feature is removed now, It is useless in most cases.
- Added different color for labels when size increases.
- Removed the `building for production...` log because we want let the upper framework to do this. Some frameworks may call `builder.build` multiple times.

<img width="628" alt="截屏2022-10-25 19 42 02" src="https://user-images.githubusercontent.com/7237365/197767023-4e567495-18d4-4651-a3cb-1b9a7a13bade.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
