### PR TITLE
fix: new testing reference type

### DIFF
--- a/.changeset/early-carrots-do.md
+++ b/.changeset/early-carrots-do.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/generator-common': patch
+---
+
+fix: new testing reference type
+
+fix: 修复开启测试功能 reference 类型

--- a/packages/generator/generator-common/src/newAction/mwa/index.ts
+++ b/packages/generator/generator-common/src/newAction/mwa/index.ts
@@ -101,6 +101,7 @@ export const MWAActionFunctionsAppendTypeContent: Partial<
   Record<ActionFunction, string>
 > = {
   [ActionFunction.MicroFrontend]: `/// <reference types='@modern-js/plugin-garfish/types' />`,
+  [ActionFunction.Test]: `/// <reference types='@modern-js/plugin-testing/types' />`,
 };
 
 export const MWANewActionGenerators: Record<


### PR DESCRIPTION
# PR Details

when run new command in mwa project, generator should add `/// <reference types='@modern-js/plugin-testing/types' />` to `src/modern-app-env.d.ts`.
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
