### PR TITLE
feat(builder): add api.getHTMLPaths method

### DIFF
--- a/.changeset/stupid-dingos-tell.md
+++ b/.changeset/stupid-dingos-tell.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+feat(builder): add api.getHTMLPaths method
+
+feat(builder): 新增 api.getHTMLPaths 方法

--- a/packages/builder/builder-shared/src/utils.ts
+++ b/packages/builder/builder-shared/src/utils.ts
@@ -19,3 +19,5 @@ export const extendsType =
 
 export const createVirtualModule = (content: string) =>
   `data:text/javascript,${content}`;
+
+export const removeLeadingSlash = (s: string): string => s.replace(/^\/+/, '');

--- a/packages/builder/builder-webpack-provider/src/core/initPlugins.ts
+++ b/packages/builder/builder-webpack-provider/src/core/initPlugins.ts
@@ -4,6 +4,7 @@ import {
   createPublicContext,
   type PluginStore,
 } from '@modern-js/builder-shared';
+import { getHTMLPathByEntry } from '../shared';
 import type { Context, BuilderPluginAPI } from '../types';
 
 export async function initPlugins({
@@ -18,6 +19,7 @@ export async function initPlugins({
   const publicContext = createPublicContext(context);
 
   const getBuilderConfig = () => context.config;
+
   const getNormalizedConfig = () => {
     if (!context.normalizedConfig) {
       throw new Error('Normalized config is not ready.');
@@ -25,8 +27,19 @@ export async function initPlugins({
     return context.normalizedConfig;
   };
 
+  const getHTMLPaths = () => {
+    return Object.keys(context.entry).reduce<Record<string, string>>(
+      (prev, key) => {
+        prev[key] = getHTMLPathByEntry(key, getNormalizedConfig());
+        return prev;
+      },
+      {},
+    );
+  };
+
   const pluginAPI: BuilderPluginAPI = {
     context: publicContext,
+    getHTMLPaths,
     getBuilderConfig,
     getNormalizedConfig,
     isPluginExists: pluginStore.isPluginExists,

--- a/packages/builder/builder-webpack-provider/src/plugins/html.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/html.ts
@@ -4,7 +4,6 @@ import {
   DEFAULT_MOUNT_ID,
   type BuilderTarget,
 } from '@modern-js/builder-shared';
-import { getDistPath } from '../shared';
 import type {
   BuilderPlugin,
   WebpackConfig,
@@ -19,16 +18,6 @@ type RoutesInfo = {
   entryName: string;
   entryPath: string;
 };
-
-async function getFilename(entryName: string, config: NormalizedConfig) {
-  const { removeLeadingSlash } = await import('@modern-js/utils');
-  const htmlPath = getDistPath(config, 'html');
-  const filename = config.html.disableHtmlFolder
-    ? `${entryName}.html`
-    : `${entryName}/index.html`;
-
-  return removeLeadingSlash(`${htmlPath}/${filename}`);
-}
 
 function getMinify(isProd: boolean, config: NormalizedConfig) {
   if (config.output.disableMinimize || !isProd) {
@@ -170,6 +159,7 @@ export const PluginHtml = (): BuilderPlugin => ({
       const assetPrefix = removeTailSlash(chain.output.get('publicPath') || '');
       const entries = chain.entryPoints.entries();
       const entryNames = Object.keys(chain.entryPoints.entries());
+      const htmlPaths = api.getHTMLPaths();
 
       await Promise.all(
         entryNames.map(async (entryName, index) => {
@@ -179,7 +169,7 @@ export const PluginHtml = (): BuilderPlugin => ({
           const chunks = await getChunks(entryName, entryValue);
           const inject = getInject(entryName, config);
           const favicon = getFavicon(entryName, config);
-          const filename = await getFilename(entryName, config);
+          const filename = htmlPaths[entryName];
           const template = getTemplatePath(entryName, config);
           const templateParameters = await getTemplateParameters(
             entryName,

--- a/packages/builder/builder-webpack-provider/src/shared/fs.ts
+++ b/packages/builder/builder-webpack-provider/src/shared/fs.ts
@@ -1,5 +1,9 @@
 import { join } from 'path';
-import type { DistPathConfig, FilenameConfig } from '@modern-js/builder-shared';
+import {
+  DistPathConfig,
+  FilenameConfig,
+  removeLeadingSlash,
+} from '@modern-js/builder-shared';
 import type { NormalizedConfig } from '../types';
 
 export const getCompiledPath = (packageName: string) =>
@@ -43,3 +47,15 @@ export const getFilename = (
       throw new Error(`unknown key ${type} in "output.filename"`);
   }
 };
+
+export function getHTMLPathByEntry(
+  entryName: string,
+  config: NormalizedConfig,
+) {
+  const htmlPath = getDistPath(config, 'html');
+  const filename = config.html.disableHtmlFolder
+    ? `${entryName}.html`
+    : `${entryName}/index.html`;
+
+  return removeLeadingSlash(`${htmlPath}/${filename}`);
+}

--- a/packages/builder/builder-webpack-provider/src/types/plugin.ts
+++ b/packages/builder/builder-webpack-provider/src/types/plugin.ts
@@ -21,6 +21,11 @@ import type {
 export type BuilderPluginAPI = {
   context: Readonly<BuilderContext>;
   isPluginExists: PluginStore['isPluginExists'];
+  /**
+   * Get the relative paths of generated HTML files.
+   * The key is entry name and the value is path.
+   */
+  getHTMLPaths: () => Record<string, string>;
   getBuilderConfig: () => Readonly<BuilderConfig>;
   getNormalizedConfig: () => Readonly<NormalizedConfig>;
 

--- a/packages/builder/builder-webpack-provider/tests/shared/utils.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/shared/utils.test.ts
@@ -1,7 +1,7 @@
 import webpack from 'webpack';
 import { expect, describe, it } from 'vitest';
-import { stringifyConfig } from '@/shared';
-import type { BuilderConfig, WebpackConfig } from '@/types';
+import { stringifyConfig, getHTMLPathByEntry } from '@/shared';
+import type { BuilderConfig, NormalizedConfig, WebpackConfig } from '@/types';
 
 describe('stringifyConfig', () => {
   it('should stringify webpack config correctly', async () => {
@@ -42,5 +42,37 @@ describe('stringifyConfig', () => {
     };
 
     expect(await stringifyConfig(builderConfig)).toMatchSnapshot();
+  });
+});
+
+describe('getHTMLPathByEntry', () => {
+  it('should use distPath.html as the folder', async () => {
+    const htmlPath = getHTMLPathByEntry('main', {
+      output: {
+        distPath: {
+          html: 'my-html',
+        },
+      },
+      html: {
+        disableHtmlFolder: false,
+      },
+    } as NormalizedConfig);
+
+    expect(htmlPath).toEqual('my-html/main/index.html');
+  });
+
+  it('should allow to disable html folder', async () => {
+    const htmlPath = getHTMLPathByEntry('main', {
+      output: {
+        distPath: {
+          html: 'html',
+        },
+      },
+      html: {
+        disableHtmlFolder: true,
+      },
+    } as NormalizedConfig);
+
+    expect(htmlPath).toEqual('html/main.html');
   });
 });


### PR DESCRIPTION
# PR Details

## Description

Add new api.getHTMLPaths method.

Usage:

```js
const PluginFoo = (): BuilderPlugin => ({
  setup(api) {
    api.modifyWebpackChain(() => {
      const htmlPaths = api.getHTMLPaths();
      console.log(htmlPaths); // { main: 'html/main/index.html' };
    });
  }
);
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
