### PR TITLE
fix(builder): skip rem plugin when target is node or web worker

### DIFF
--- a/.changeset/witty-bats-film.md
+++ b/.changeset/witty-bats-film.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): skip rem plugin when target is node or web worker
+
+fix(builder): 当构建 node 或 web worker 产物时跳过 rem 插件

--- a/packages/builder/builder-webpack-provider/src/plugins/rem.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/rem.ts
@@ -10,71 +10,73 @@ export const PluginRem = (): BuilderPlugin => ({
   name: 'builder-plugin-rem',
 
   setup(api) {
-    api.modifyWebpackChain(async (chain, { CHAIN_ID }) => {
-      const {
-        output: { convertToRem },
-      } = api.getNormalizedConfig();
+    api.modifyWebpackChain(
+      async (chain, { CHAIN_ID, isServer, isWebWorker }) => {
+        const {
+          output: { convertToRem },
+        } = api.getNormalizedConfig();
 
-      if (!convertToRem) {
-        return;
-      }
+        if (!convertToRem || isServer || isWebWorker) {
+          return;
+        }
 
-      const userOptions = {
-        ...defaultOptions,
-        ...(typeof convertToRem === 'boolean' ? {} : convertToRem),
-      };
+        const userOptions = {
+          ...defaultOptions,
+          ...(typeof convertToRem === 'boolean' ? {} : convertToRem),
+        };
 
-      // handle css
-      const { default: PxToRemPlugin } = (await import(
-        '../../compiled/postcss-pxtorem'
-      )) as {
-        default: (_opts: PxToRemOptions) => any;
-      };
+        // handle css
+        const { default: PxToRemPlugin } = (await import(
+          '../../compiled/postcss-pxtorem'
+        )) as {
+          default: (_opts: PxToRemOptions) => any;
+        };
 
-      const applyRules = [
-        CHAIN_ID.RULE.CSS,
-        CHAIN_ID.RULE.LESS,
-        CHAIN_ID.RULE.SASS,
-      ];
-      const getPxToRemPlugin = () =>
-        PxToRemPlugin({
-          rootValue: userOptions.rootFontSize,
-          unitPrecision: 5,
-          propList: ['*'],
-          ..._.cloneDeep(userOptions.pxtorem || {}),
+        const applyRules = [
+          CHAIN_ID.RULE.CSS,
+          CHAIN_ID.RULE.LESS,
+          CHAIN_ID.RULE.SASS,
+        ];
+        const getPxToRemPlugin = () =>
+          PxToRemPlugin({
+            rootValue: userOptions.rootFontSize,
+            unitPrecision: 5,
+            propList: ['*'],
+            ..._.cloneDeep(userOptions.pxtorem || {}),
+          });
+        // Deep copy options to prevent unexpected behavior.
+        applyRules.forEach(name => {
+          chain.module.rules.has(name) &&
+            chain.module
+              .rule(name)
+              .use(CHAIN_ID.USE.POSTCSS)
+              .tap((options = {}) => ({
+                ...options,
+                postcssOptions: {
+                  ...(options.postcssOptions || {}),
+                  plugins: [
+                    ...(options.postcssOptions?.plugins || []),
+                    getPxToRemPlugin(),
+                  ],
+                },
+              }));
         });
-      // Deep copy options to prevent unexpected behavior.
-      applyRules.forEach(name => {
-        chain.module.rules.has(name) &&
-          chain.module
-            .rule(name)
-            .use(CHAIN_ID.USE.POSTCSS)
-            .tap((options = {}) => ({
-              ...options,
-              postcssOptions: {
-                ...(options.postcssOptions || {}),
-                plugins: [
-                  ...(options.postcssOptions?.plugins || []),
-                  getPxToRemPlugin(),
-                ],
-              },
-            }));
-      });
 
-      // handle runtime (html)
-      if (!userOptions.enableRuntime) {
-        return;
-      }
+        // handle runtime (html)
+        if (!userOptions.enableRuntime) {
+          return;
+        }
 
-      const { AutoSetRootFontSizePlugin } = await import(
-        '../webpackPlugins/AutoSetRootFontSizePlugin'
-      );
+        const { AutoSetRootFontSizePlugin } = await import(
+          '../webpackPlugins/AutoSetRootFontSizePlugin'
+        );
 
-      const entries = Object.keys(chain.entryPoints.entries() || {});
+        const entries = Object.keys(chain.entryPoints.entries() || {});
 
-      chain
-        .plugin(CHAIN_ID.PLUGIN.AUTO_SET_ROOT_SIZE)
-        .use(AutoSetRootFontSizePlugin, [userOptions, entries]);
-    });
+        chain
+          .plugin(CHAIN_ID.PLUGIN.AUTO_SET_ROOT_SIZE)
+          .use(AutoSetRootFontSizePlugin, [userOptions, entries]);
+      },
+    );
   },
 });

--- a/packages/builder/builder-webpack-provider/tests/plugins/rem.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/rem.test.ts
@@ -82,4 +82,36 @@ describe('plugins/rem', () => {
     const config = await builder.unwrapWebpackConfig();
     expect(config).toMatchSnapshot();
   });
+
+  it('should not run rem plugin when target is node', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginCss(), PluginRem()],
+      builderConfig: {
+        output: {
+          convertToRem: true,
+        },
+      },
+      target: ['node'],
+    });
+
+    expect(
+      await builder.matchWebpackPlugin('AutoSetRootFontSizePlugin'),
+    ).toBeFalsy();
+  });
+
+  it('should not run rem plugin when target is web-worker', async () => {
+    const builder = await createStubBuilder({
+      plugins: [PluginCss(), PluginRem()],
+      builderConfig: {
+        output: {
+          convertToRem: true,
+        },
+      },
+      target: ['web-worker'],
+    });
+
+    expect(
+      await builder.matchWebpackPlugin('AutoSetRootFontSizePlugin'),
+    ).toBeFalsy();
+  });
 });


### PR DESCRIPTION
# PR Details

## Description

Skip rem plugin when target is node or web worker, otherwise the compilation will be failed because html plugin is not exist:

<img width="547" alt="截屏2022-10-28 15 09 10" src="https://user-images.githubusercontent.com/7237365/198526782-2f7cebc3-82fd-47a1-9630-db35d391c050.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
