### PR TITLE
feat(builder): ignore externals when target is web worker

### DIFF
--- a/.changeset/cool-balloons-buy.md
+++ b/.changeset/cool-balloons-buy.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-doc': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+feat(builder): ignore externals when target is web worker
+
+feat(builder): 构建 web worker 产物时忽略 externals 配置

--- a/packages/builder/builder-doc/en/config/output/externals.md
+++ b/packages/builder/builder-doc/en/config/output/externals.md
@@ -19,3 +19,7 @@ export default {
   },
 };
 ```
+
+:::tip
+When the build target is Web Worker, externals will not take effect. This is because the Worker environment can not access global variables.
+:::

--- a/packages/builder/builder-doc/zh/config/output/externals.md
+++ b/packages/builder/builder-doc/zh/config/output/externals.md
@@ -1,5 +1,4 @@
 - Type : `string | object | function | RegExp`
-
 - Default: `undefined`
 
 在构建时，防止将代码中某些 `import` 的依赖包打包到 bundle 中，而是在运行时再去从外部获取这些依赖。
@@ -19,3 +18,7 @@ export default {
   },
 };
 ```
+
+:::tip
+当构建 Web Worker 产物时，externals 将不会生效。这是因为 Worker 环境不支持通过访问全局变量。
+:::

--- a/packages/builder/builder-webpack-provider/src/plugins/externals.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/externals.ts
@@ -5,8 +5,22 @@ export function PluginExternals(): BuilderPlugin {
     name: 'builder-plugin-externals',
     setup(api) {
       api.modifyWebpackChain(chain => {
-        const externalOptions = api.getNormalizedConfig().output.externals;
-        externalOptions && chain.externals(externalOptions);
+        const { externals } = api.getNormalizedConfig().output;
+        if (externals) {
+          chain.externals(externals);
+        }
+      });
+
+      api.onBeforeCreateCompiler(({ bundlerConfigs }) => {
+        bundlerConfigs.forEach(config => {
+          const isWebWorker = Array.isArray(config.target)
+            ? config.target.includes('webworker')
+            : config.target === 'webworker';
+
+          if (isWebWorker && config.externals) {
+            delete config.externals;
+          }
+        });
       });
     },
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3572,6 +3572,31 @@ importers:
       '@types/react-dom': 18.0.6
       typescript: 4.7.4
 
+  tests/e2e/webpack-builder/externals:
+    specifiers:
+      '@modern-js/builder': workspace:*
+      '@modern-js/builder-webpack-provider': workspace:*
+      '@modern-js/e2e': workspace:*
+      '@types/node': ^14
+      '@types/react': ^18
+      '@types/react-dom': ^18
+      got: ^11.8.3
+      react: ^17.0.1
+      react-dom: ^17.0.1
+      typescript: ^4
+    dependencies:
+      got: 11.8.5
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    devDependencies:
+      '@modern-js/builder': link:../../../../packages/builder/builder
+      '@modern-js/builder-webpack-provider': link:../../../../packages/builder/builder-webpack-provider
+      '@modern-js/e2e': link:../../../../packages/toolkit/e2e
+      '@types/node': 14.18.21
+      '@types/react': 18.0.21
+      '@types/react-dom': 18.0.6
+      typescript: 4.7.4
+
   tests/e2e/webpack-builder/ignore-css:
     specifiers:
       '@modern-js/builder': workspace:*
@@ -13508,10 +13533,8 @@ packages:
     dependencies:
       ajv: 6.12.6
 
-  /ajv-formats/2.1.1_ajv@8.11.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -29633,7 +29656,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1_ajv@8.11.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scmp/2.1.0:

--- a/tests/e2e/webpack-builder/externals/.eslintrc.js
+++ b/tests/e2e/webpack-builder/externals/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  root: true,
+  extends: ['@modern-js'],
+  ignorePatterns: ['src/**/*'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.json'],
+  },
+};

--- a/tests/e2e/webpack-builder/externals/index.test.ts
+++ b/tests/e2e/webpack-builder/externals/index.test.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { createStubBuilder } from '@modern-js/builder-webpack-provider/stub';
+
+test('should external react correctly', async () => {
+  const builder = await createStubBuilder({
+    webpack: true,
+    entry: { index: path.resolve('./src/index.js') },
+    builderConfig: {
+      output: {
+        externals: {
+          react: 'MyReact',
+        },
+      },
+    },
+  });
+  const files = await builder.unwrapOutputJSON();
+
+  const content = files[Object.keys(files).find(file => file.endsWith('.js'))!];
+  expect(content.includes('MyReact')).toBeTruthy();
+});
+
+test('should not external dependencies when target is web worker', async () => {
+  const builder = await createStubBuilder({
+    webpack: true,
+    target: 'web-worker',
+    entry: { index: path.resolve('./src/index.js') },
+    builderConfig: {
+      output: {
+        externals: {
+          react: 'MyReact',
+        },
+      },
+    },
+  });
+  const files = await builder.unwrapOutputJSON();
+
+  const content = files[Object.keys(files).find(file => file.endsWith('.js'))!];
+  expect(content.includes('MyReact')).toBeFalsy();
+});

--- a/tests/e2e/webpack-builder/externals/package.json
+++ b/tests/e2e/webpack-builder/externals/package.json
@@ -1,0 +1,24 @@
+{
+  "private": true,
+  "name": "@e2e/webpack-builder-externals",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "node ./scripts/dev.js",
+    "build": "node ./scripts/build.js",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "got": "^11.8.3",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
+  },
+  "devDependencies": {
+    "@modern-js/e2e": "workspace:*",
+    "@modern-js/builder": "workspace:*",
+    "@modern-js/builder-webpack-provider": "workspace:*",
+    "@types/node": "^14",
+    "@types/react": "^17",
+    "@types/react-dom": "^17",
+    "typescript": "^4"
+  }
+}

--- a/tests/e2e/webpack-builder/externals/src/index.js
+++ b/tests/e2e/webpack-builder/externals/src/index.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+console.log(React);

--- a/tests/e2e/webpack-builder/externals/tsconfig.json
+++ b/tests/e2e/webpack-builder/externals/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": ["src", "scripts", "*.test.ts"]
+}


### PR DESCRIPTION
# PR Details

## Description

When the build target is Web Worker, externals will not take effect. This is because the Worker environment can not access global variables. So we should ignore the externals config of webpack config.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
