### PR TITLE
feat: support hoist node linker

### DIFF
--- a/.changeset/honest-news-explode.md
+++ b/.changeset/honest-news-explode.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix: support node-linker=hoist

--- a/.changeset/honest-news-explode.md
+++ b/.changeset/honest-news-explode.md
@@ -3,3 +3,5 @@
 ---
 
 fix: support node-linker=hoist
+
+fix: 支持 node-linker=hoist

--- a/packages/solutions/module-tools/src/features/build/bundleless/generator-dts/utils.ts
+++ b/packages/solutions/module-tools/src/features/build/bundleless/generator-dts/utils.ts
@@ -124,8 +124,9 @@ export const resolveAlias = (
 };
 
 export const getTscBinPath = (appDirectory: string) => {
+  const { root } = path.parse(appDirectory)
   let currentDirectory = appDirectory
-  while (currentDirectory !== '/') {
+  while (currentDirectory !== root) {
     const tscBinFile = path.join(currentDirectory, './node_modules/.bin/tsc');
     if (fs.existsSync(tscBinFile)) {
       return tscBinFile

--- a/packages/solutions/module-tools/src/features/build/bundleless/generator-dts/utils.ts
+++ b/packages/solutions/module-tools/src/features/build/bundleless/generator-dts/utils.ts
@@ -124,13 +124,16 @@ export const resolveAlias = (
 };
 
 export const getTscBinPath = (appDirectory: string) => {
-  const tscBinFile = path.join(appDirectory, './node_modules/.bin/tsc');
-
-  if (!fs.existsSync(tscBinFile)) {
-    throw new Error(
-      'Failed to excute the `tsc` command, please check if `typescript` is installed correctly in the current directory.',
-    );
+  let currentDirectory = appDirectory
+  while (currentDirectory !== '/') {
+    const tscBinFile = path.join(currentDirectory, './node_modules/.bin/tsc');
+    if (fs.existsSync(tscBinFile)) {
+      return tscBinFile
+    }
+    currentDirectory = path.dirname(currentDirectory)
   }
 
-  return tscBinFile;
+  throw new Error(
+    'Failed to excute the `tsc` command, please check if `typescript` is installed correctly in the current directory.',
+  );
 };

--- a/packages/solutions/module-tools/src/features/build/bundleless/generator-dts/utils.ts
+++ b/packages/solutions/module-tools/src/features/build/bundleless/generator-dts/utils.ts
@@ -124,14 +124,14 @@ export const resolveAlias = (
 };
 
 export const getTscBinPath = (appDirectory: string) => {
-  const { root } = path.parse(appDirectory)
-  let currentDirectory = appDirectory
+  const { root } = path.parse(appDirectory);
+  let currentDirectory = appDirectory;
   while (currentDirectory !== root) {
     const tscBinFile = path.join(currentDirectory, './node_modules/.bin/tsc');
     if (fs.existsSync(tscBinFile)) {
-      return tscBinFile
+      return tscBinFile;
     }
-    currentDirectory = path.dirname(currentDirectory)
+    currentDirectory = path.dirname(currentDirectory);
   }
 
   throw new Error(


### PR DESCRIPTION
# Support `node-linker=hoist` in .npmrc

<!--- Provide a general summary of your changes in the Title above -->

## Description

In some projects (eg. React Native), we must enable the `node-linker=hoist`, but Modern.js only search for the `tsc` inside the current workspace to build.

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/modern-js-dev/modern.js/issues/1985

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

https://pnpm.io/npmrc#node-linker

Modern.js can't build correctly if it's used together in React Native projects.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Change related code in [demo repository](https://github.com/Means88/node-linker-demo) and run `build`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] **No** My change requires a change to the documentation. 
- [ ] **No Need** I have updated the documentation accordingly. 
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Tested manually, but don't know how to write the test in this case.