### PR TITLE
feat: support completely custom server

### DIFF
--- a/.changeset/fresh-terms-drum.md
+++ b/.changeset/fresh-terms-drum.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/server-core': patch
+'@modern-js/prod-server': patch
+'@modern-js/server': patch
+---
+
+feat: support completely custom server, export render() api for render single page
+feat: 支持完全自定义 Server，导出 render() 方法用来渲染单个页面

--- a/packages/server/core/src/plugin.ts
+++ b/packages/server/core/src/plugin.ts
@@ -26,14 +26,14 @@ import type { Options } from 'http-proxy-middleware';
 /** The subset of NormalizedConfig, which really need in server */
 export type ServerOptions = {
   output: Pick<NormalizedConfig['output'], 'path' | 'assetPrefix'>;
-  source: Pick<NormalizedConfig['source'], 'alias' | 'envVars' | 'globalVars'>;
-  tools: {
+  source?: Pick<NormalizedConfig['source'], 'alias' | 'envVars' | 'globalVars'>;
+  tools?: {
     babel: NormalizedConfig['tools']['babel'];
   };
-  server: NormalizedConfig['server'];
-  runtime: NormalizedConfig['runtime'];
-  bff: NormalizedConfig['bff'];
-  plugins: NormalizedConfig['plugins'];
+  server?: NormalizedConfig['server'];
+  runtime?: NormalizedConfig['runtime'];
+  bff?: NormalizedConfig['bff'];
+  plugins?: NormalizedConfig['plugins'];
 };
 
 // collect all middleware register in server plugins

--- a/packages/server/core/src/plugin.ts
+++ b/packages/server/core/src/plugin.ts
@@ -26,14 +26,14 @@ import type { Options } from 'http-proxy-middleware';
 /** The subset of NormalizedConfig, which really need in server */
 export type ServerOptions = {
   output: Pick<NormalizedConfig['output'], 'path' | 'assetPrefix'>;
-  source?: Pick<NormalizedConfig['source'], 'alias' | 'envVars' | 'globalVars'>;
-  tools?: {
+  source: Pick<NormalizedConfig['source'], 'alias' | 'envVars' | 'globalVars'>;
+  tools: {
     babel: NormalizedConfig['tools']['babel'];
   };
-  server?: NormalizedConfig['server'];
-  runtime?: NormalizedConfig['runtime'];
-  bff?: NormalizedConfig['bff'];
-  plugins?: NormalizedConfig['plugins'];
+  server: NormalizedConfig['server'];
+  runtime: NormalizedConfig['runtime'];
+  bff: NormalizedConfig['bff'];
+  plugins: NormalizedConfig['plugins'];
 };
 
 // collect all middleware register in server plugins

--- a/packages/server/prod-server/src/server/index.ts
+++ b/packages/server/prod-server/src/server/index.ts
@@ -183,6 +183,10 @@ export class Server {
     };
   }
 
+  public async render(req: IncomingMessage, res: ServerResponse, url?: string) {
+    return this.server.render(req, res, url);
+  }
+
   private async createHookRunner() {
     // clear server manager every create time
     serverManager.clear();

--- a/packages/server/prod-server/src/server/modern-server.ts
+++ b/packages/server/prod-server/src/server/modern-server.ts
@@ -219,6 +219,25 @@ export class ModernServer implements ModernServerInterface {
     return this.requestHandler.bind(this);
   }
 
+  public async render(req: IncomingMessage, res: ServerResponse, url?: string) {
+    req.logger = this.logger;
+    req.metrics = this.metrics;
+    const context = createContext(req, res);
+    const matched = this.router.match(url || context.path);
+    if (!matched) {
+      return null;
+    }
+
+    const route = matched.generate(context.url);
+    const result = await this.handleWeb(context, route);
+
+    if (!result) {
+      return null;
+    }
+
+    return result.content.toString();
+  }
+
   public async createHTTPServer(
     handler: (
       req: IncomingMessage,

--- a/packages/server/prod-server/src/type.ts
+++ b/packages/server/prod-server/src/type.ts
@@ -21,6 +21,7 @@ declare module 'http' {
 
 export type ModernServerOptions = {
   pwd: string;
+  // Todo 整理下这里用的 config，尽量少用
   config: ServerOptions;
   plugins?: ServerPlugin[];
   internalPlugins?: InternalPlugins;
@@ -81,6 +82,12 @@ export interface ModernServerInterface {
       next?: () => void,
     ) => void,
   ) => Promise<Server>;
+
+  render: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    url?: string,
+  ) => Promise<string | null>;
 }
 
 export type ServerConstructor = (

--- a/packages/server/prod-server/tests/fixtures/completely-custom/package.json
+++ b/packages/server/prod-server/tests/fixtures/completely-custom/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "prod-server-pure",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "modern dev",
+    "build": "modern build",
+    "start": "modern start",
+    "new": "modern new",
+    "lint": "modern lint",
+    "deploy": "modern deploy"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "modernConfig": {
+    "runtime": {
+      "router": true,
+      "state": true
+    }
+  }
+}

--- a/packages/server/prod-server/tests/fixtures/completely-custom/test-dist/bundles/main.js
+++ b/packages/server/prod-server/tests/fixtures/completely-custom/test-dist/bundles/main.js
@@ -1,0 +1,5 @@
+const { SERVER_RENDER_FUNCTION_NAME } = require('@modern-js/utils');
+
+module.exports = {
+  [SERVER_RENDER_FUNCTION_NAME]: () => '<div>Modern.js Custom Server</div>',
+};

--- a/packages/server/prod-server/tests/fixtures/completely-custom/test-dist/html/main/index.html
+++ b/packages/server/prod-server/tests/fixtures/completely-custom/test-dist/html/main/index.html
@@ -1,0 +1,36 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no, viewport-fit=cover, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<meta http-equiv="x-ua-compatible" content="ie=edge">
+<meta name="renderer" content="webkit">
+<meta name="layoutmode" content="standard">
+<meta name="imagemode" content="force">
+<meta name="wap-font-scale" content="no">
+<meta name="format-detection" content="telephone=no">
+  <title></title>
+
+  
+
+  <script>
+    window.__assetPrefix__ = '';
+  </script>
+  
+<script defer src="/static/js/runtime-main.js"></script><script defer src="/static/js/vendors-node_modules_pnpm_babel_runtime_7_16_7_node_modules_babel_runtime_regenerator_index_j-7f9278.js"></script><script defer src="/static/js/main.js"></script></head>
+
+<body>
+  <!--<?- chunksMap.css ?>-->
+  <noscript>
+    We're sorry but react app doesn't work properly without JavaScript enabled. Please enable it to continue.
+  </noscript>
+  <div id="root"><!--<?- html ?>--></div>
+  
+  <!--<?- chunksMap.js ?>-->
+  <!--<?- SSRDataScript ?>-->
+  
+</body>
+
+</html>

--- a/packages/server/prod-server/tests/fixtures/completely-custom/test-dist/route.json
+++ b/packages/server/prod-server/tests/fixtures/completely-custom/test-dist/route.json
@@ -1,0 +1,31 @@
+{
+  "routes": [
+    {
+      "urlPath": "/home",
+      "entryName": "main",
+      "entryPath": "html/main/index.html",
+      "isSPA": true,
+      "isSSR": true,
+      "enableModernMode": false,
+      "bundle": "bundles/main.js"
+    },
+    {
+      "urlPath": "/500",
+      "entryName": "500",
+      "entryPath": "html/main/index.html",
+      "isSPA": true,
+      "isSSR": true,
+      "enableModernMode": false,
+      "bundle": "bundles/main.js"
+    },
+    {
+      "urlPath": "/404",
+      "entryName": "500",
+      "entryPath": "html/main/index.html",
+      "isSPA": true,
+      "isSSR": true,
+      "enableModernMode": false,
+      "bundle": "bundles/main.js"
+    }
+  ]
+}

--- a/packages/server/prod-server/tests/fixtures/completely-custom/tsconfig.json
+++ b/packages/server/prod-server/tests/fixtures/completely-custom/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "paths": {
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": ["src", "shared", "config"]
+}

--- a/packages/server/prod-server/tests/server.test.ts
+++ b/packages/server/prod-server/tests/server.test.ts
@@ -235,6 +235,47 @@ describe('test server', () => {
       });
       expect(html).toMatch('This page could not be found.');
     });
+
+    test('should render() api work correctly', async () => {
+      const server = await createServer({
+        config: {
+          ...(defaultsConfig as any),
+          output: {
+            path: 'dist',
+          },
+        },
+        pwd: path.join(__dirname, './fixtures/completely-custom'),
+      });
+
+      const req = httpMocks.createRequest({
+        url: '/home',
+        headers: {
+          host: 'modernjs.com',
+        },
+        eventEmitter: Readable,
+        method: 'GET',
+      });
+      const res = httpMocks.createResponse({ eventEmitter: EventEmitter });
+      const html = await server.render(req, res, '/home');
+      expect(html).toMatch('Modern.js Custom Server');
+
+      const htmlMatchPath = await server.render(req, res);
+      expect(htmlMatchPath).toMatch('Modern.js Custom Server');
+
+      const notFound = await server.render(req, res, '/not-found');
+      expect(notFound).toBeNull();
+
+      const reqNotFound = httpMocks.createRequest({
+        url: '/not-found',
+        headers: {
+          host: 'modernjs.com',
+        },
+        eventEmitter: Readable,
+        method: 'GET',
+      });
+      const notFound1 = await server.render(reqNotFound, res);
+      expect(notFound1).toBeNull();
+    });
   });
 
   describe('should split server work correctly', () => {

--- a/packages/server/prod-server/tests/server.test.ts
+++ b/packages/server/prod-server/tests/server.test.ts
@@ -241,7 +241,7 @@ describe('test server', () => {
         config: {
           ...(defaultsConfig as any),
           output: {
-            path: 'dist',
+            path: 'test-dist',
           },
         },
         pwd: path.join(__dirname, './fixtures/completely-custom'),

--- a/packages/server/server/src/dev-tools/register/index.ts
+++ b/packages/server/server/src/dev-tools/register/index.ts
@@ -72,9 +72,9 @@ export const enableRegister = (
       projectRoot,
       {
         ...config.source,
-        babelConfig: config.tools.babel,
+        babelConfig: config.tools?.babel,
         server: {
-          compiler: config.server.compiler,
+          compiler: config.server?.compiler,
         },
       },
       {

--- a/packages/server/server/src/server/dev-server.ts
+++ b/packages/server/server/src/server/dev-server.ts
@@ -318,7 +318,7 @@ export class ModernDevServer extends ModernServer {
       `${SHARED_DIR}/**/*`,
     ];
 
-    const watchOptions = mergeWatchOptions(this.conf.server.watchOptions);
+    const watchOptions = mergeWatchOptions(this.conf.server?.watchOptions);
 
     const defaultWatchedPaths = defaultWatched.map(p =>
       path.normalize(path.join(pwd, p)),


### PR DESCRIPTION
# PR Details

By default, Modern.js includes its own server with start command. 

If you have an existing backend, you can still use it with Modern.js like this.

```js
const { createServer } = require('http');
const server = require('@modern-js/prod-server').default;

async function main() {
  const app = await server({
    pwd: process.cwd(),
    config: {
      output: {
        path: './dist',
      },
    },
  });

  const handler = app.getRequestHandler();
  createServer(async (req, res) => {
    if (req.url === '/') {
      const html = await app.render(req, res);
      res.end(html);
    } else {
      await handler(req, res);
    }
  }).listen(8080, () => {
    console.log('listen custom server in 3000');
  });
}

main();
```

we may support this feature for development env soon.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
