### PR TITLE
fix: builder tools.webpackChain config args not match the Modernjs tools.webpackChain

### DIFF
--- a/.changeset/cyan-windows-bake.md
+++ b/.changeset/cyan-windows-bake.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: builder tools.webpackChain config args not match the Modernjs tools.webpackChain
+fix: builder tools.webpackChain 配置传参无法匹配 Modernjs tools.webpackChain

--- a/packages/solutions/app-tools/src/builder/createToolsConfig.ts
+++ b/packages/solutions/app-tools/src/builder/createToolsConfig.ts
@@ -1,3 +1,4 @@
+import type { BuilderTarget } from '@modern-js/builder-shared';
 import type {
   BuilderConfig,
   WebpackConfig,
@@ -65,6 +66,22 @@ export function createToolsConfig(
   };
 }
 
+export function builderTargetToModernBundleName(target: BuilderTarget) {
+  const targetToNameMap: {
+    [target in BuilderTarget]?: 'client' | 'server' | 'modern';
+  } = {
+    'modern-web': 'modern',
+    node: 'server',
+    web: 'client',
+  };
+  if (!targetToNameMap[target]) {
+    throw new Error(
+      `The build target '${target}' that are not supported by the framework`,
+    );
+  }
+  return targetToNameMap[target];
+}
+
 type BuilderToolConfig = Required<BuilderConfig>['tools'];
 
 function createBuilderWebpack(
@@ -103,7 +120,7 @@ function createBuilderWebpack(
         return applyOptionsChain<WebpackConfig, any>(config, webpack, {
           env: utils.env,
           webpack: utils.webpack,
-          name: utils.target,
+          name: builderTargetToModernBundleName(utils.target),
           addRules,
           prependPlugins,
           appendPlugins,
@@ -118,7 +135,12 @@ function createBuilderWebpackChain(
 ): BuilderToolConfig['webpackChain'] {
   return webpackChain
     ? (chain: WebpackChain, utils) =>
-        applyOptionsChain<any, any>(chain, webpackChain, utils)
+        applyOptionsChain<any, any>(chain, webpackChain, {
+          env: utils.env,
+          name: builderTargetToModernBundleName(utils.target),
+          webpack: utils.webpack,
+          CHAIN_ID: utils.CHAIN_ID,
+        })
     : undefined;
 }
 

--- a/packages/solutions/app-tools/src/builder/createToolsConfig.ts
+++ b/packages/solutions/app-tools/src/builder/createToolsConfig.ts
@@ -135,11 +135,13 @@ function createBuilderWebpackChain(
 ): BuilderToolConfig['webpackChain'] {
   return webpackChain
     ? (chain: WebpackChain, utils) =>
-        applyOptionsChain<any, any>(chain, webpackChain, {
+        applyOptionsChain<any, unknown>(chain, webpackChain, {
           env: utils.env,
           name: builderTargetToModernBundleName(utils.target),
           webpack: utils.webpack,
           CHAIN_ID: utils.CHAIN_ID,
+          // TODO: builder will add HtmlWebpackPlugin Instance in utils(modifyWebpackUtils)
+          // HtmlWebpackPlugin: utils.HtmlWebpackPlugin,
         })
     : undefined;
 }

--- a/packages/solutions/app-tools/tests/builder/createToolsConfig.test.ts
+++ b/packages/solutions/app-tools/tests/builder/createToolsConfig.test.ts
@@ -1,4 +1,8 @@
-import { createBuilderTsChecker } from '../../src/builder/createToolsConfig';
+import type { BuilderTarget } from '@modern-js/builder-shared';
+import {
+  createBuilderTsChecker,
+  builderTargetToModernBundleName,
+} from '../../src/builder/createToolsConfig';
 
 describe('test create Builder TsChecker Config', () => {
   it('should disableTsChecker', () => {
@@ -31,3 +35,21 @@ describe('test create Builder TsChecker Config', () => {
 });
 
 // TODO: other test
+
+describe('test builderTargetToModernBundleName', () => {
+  it('should transform success', () => {
+    const targets: BuilderTarget[] = ['web', 'node', 'modern-web'];
+    const expect_names = ['client', 'server', 'modern'];
+    const names = targets.map(target =>
+      builderTargetToModernBundleName(target),
+    );
+    expect(names).toEqual(expect_names);
+  });
+
+  it('should throw a error', () => {
+    const target: BuilderTarget = 'web-worker';
+    expect(() => {
+      builderTargetToModernBundleName(target);
+    }).toThrow(new RegExp(target));
+  });
+});


### PR DESCRIPTION
builder tools.webpackChain config args not match the Modernjs tools.webpackChain

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
