### PR TITLE
fix: clear distDirectory in prepare hook & inject data load plugin

### DIFF
--- a/.changeset/neat-jobs-design.md
+++ b/.changeset/neat-jobs-design.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: clear distDirectory in prepare hook & inject data load plugin to server

--- a/.changeset/neat-jobs-design.md
+++ b/.changeset/neat-jobs-design.md
@@ -2,4 +2,5 @@
 '@modern-js/app-tools': patch
 ---
 
-fix: clear distDirectory in prepare hook & inject data load plugin to server
+fix: clear distDirectory in prepare hook & inject data loader plugin to server
+fix: 在 prepare hook 中清理 dist 目录，并且向 server 中注入 data loader plugin

--- a/packages/solutions/app-tools/src/builder/createOutputConfig.ts
+++ b/packages/solutions/app-tools/src/builder/createOutputConfig.ts
@@ -67,6 +67,8 @@ export function createOutputConfig(
     enableInlineScripts,
     enableInlineStyles,
     polyfill,
+    // We need to do this in the app-tools prepare hook because some files will be generated into the dist directory in the analyze process
+    cleanDistPath: false,
     disableFilenameHash: disableAssetsCache,
     enableLatestDecorators,
     filename: {

--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -1,10 +1,5 @@
 import { PluginAPI, ResolvedConfigContext } from '@modern-js/core';
-import {
-  logger,
-  emptyDir,
-  isUseSSRBundle,
-  printBuildError,
-} from '@modern-js/utils';
+import { logger, isUseSSRBundle, printBuildError } from '@modern-js/utils';
 import { BuilderTarget } from '@modern-js/builder';
 import { generateRoutes } from '../utils/routes';
 import { buildServerConfig, emitResolvedConfig } from '../utils/config';
@@ -23,7 +18,6 @@ export const build = async (
 
   if (apiOnly) {
     const { appDirectory, distDirectory, serverConfigFile } = appContext;
-    await emptyDir(distDirectory);
     await hookRunners.beforeBuild();
 
     await buildServerConfig({
@@ -43,7 +37,6 @@ export const build = async (
   ResolvedConfigContext.set(resolvedConfig);
 
   const { distDirectory, appDirectory, serverConfigFile } = appContext;
-  await emptyDir(distDirectory);
 
   await buildServerConfig({
     appDirectory,

--- a/packages/solutions/app-tools/src/commands/start.ts
+++ b/packages/solutions/app-tools/src/commands/start.ts
@@ -3,6 +3,7 @@ import type { PluginAPI } from '@modern-js/core';
 import server from '@modern-js/prod-server';
 import { printInstructions } from '../utils/printInstructions';
 import type { AppHooks } from '../hooks';
+import { injectDataLoaderPlugin } from '../utils/createServer';
 
 export const start = async (api: PluginAPI<AppHooks>) => {
   const appContext = api.useAppContext();
@@ -20,7 +21,7 @@ export const start = async (api: PluginAPI<AppHooks>) => {
     pwd: appDirectory,
     config: userConfig,
     serverConfigFile,
-    internalPlugins: appContext.serverInternalPlugins,
+    internalPlugins: injectDataLoaderPlugin(appContext.serverInternalPlugins),
     apiOnly,
   });
 

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { defineConfig, cli, CliPlugin } from '@modern-js/core';
 import LintPlugin from '@modern-js/plugin-jarvis';
-import { cleanRequireCache, fs, Import } from '@modern-js/utils';
+import { cleanRequireCache, emptyDir, Import } from '@modern-js/utils';
 import AnalyzePlugin from './analyze';
 import { hooks, AppHooks } from './hooks';
 import { i18n, localeKeys } from './locale';
@@ -150,11 +150,11 @@ export default (): CliPlugin<AppHooks> => ({
       },
 
       async prepare() {
-        const appContext = api.useAppContext();
-        try {
-          fs.emptydirSync(appContext.distDirectory);
-        } catch (error) {
-          // FIXME:
+        const args = process.argv.slice(2);
+        const command = args[0];
+        if (command === 'dev' || command === 'build') {
+          const appContext = api.useAppContext();
+          await emptyDir(appContext.distDirectory);
         }
       },
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Clean up the dist directory in the prepare hook because some files are generated in the prepare hook into the dist directory.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
