### PR TITLE
fix(builder): esbuild minimize target should be es2015

### DIFF
--- a/.changeset/fast-rats-share.md
+++ b/.changeset/fast-rats-share.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-esbuild': patch
+---
+
+fix(builder): esbuild minimize target should be es2015
+
+fix(builder): 修复 esbuild 压缩时未默认生成 es2015 产物的问题

--- a/packages/builder/plugin-esbuild/tests/__snapshots__/index.test.ts.snap
+++ b/packages/builder/plugin-esbuild/tests/__snapshots__/index.test.ts.snap
@@ -39,6 +39,7 @@ exports[`plugins/esbuild > should set esbuild minimizer in production 1`] = `
           "css": true,
           "legalComments": "inline",
           "minify": true,
+          "target": "es2015",
         },
         "transform": [Function],
       },

--- a/website/builder/src/en/guide/advanced/build-performance.md
+++ b/website/builder/src/en/guide/advanced/build-performance.md
@@ -32,25 +32,29 @@ nvm default 16
 node -v
 ```
 
+### Using esbuild
+
+[esbuild](https://esbuild.github.io/) is a front-end build tool based on Golang. It has the functions of bundling, compiling and minimizing JavaScript code. Compared with traditional tools, the performance is significantly improved. When minimizing code, compared to webpack's built-in terser minimizer, esbuild has dozens of times better performance.
+
+Builder provides esbuild plugin that allow you to use esbuild instead of babel-loader, ts-loader and terser for transformation and minification process. See [esbuild plugin](/plugins/plugin-esbuild.html) for details.
+
 ### Reduce duplicate dependencies
 
 In real projects, there will be some third-party dependencies installed with multiple versions. Duplicate dependencies can lead to larger bundles and slower builds.
 
-We can automatically eliminate duplicate dependencies through some tools in the community, such as [yarn-deduplicate](https://github.com/scinos/yarn-deduplicate).
+We can detect or eliminate duplicate dependencies with some community tools.
+
+If you are using `pnpm`, you can use [pnpm-deduplicate](https://github.com/ocavue/pnpm-deduplicate) to analyze all duplicate dependencies, then update dependencies or declare [pnpm overrides](https://pnpm.io/package_json#pnpmoverrides) to merge duplicated dependencies.
+
+```bash
+npx pnpm-deduplicate --list
+```
+
+If you are using `yarn`, you can use [yarn-deduplicate](https://github.com/scinos/yarn-deduplicate) to automatically merge duplicated dependencies:
 
 ```bash
 npx yarn-deduplicate && yarn
 ```
-
-If you are using `pnpm`, consider reducing duplicate dependencies by **regenerating the lock file**,
-
-```bash
-rm -rf ./node_modules pnpm-lock.yaml && pnpm install
-```
-
-:::tip
-Deleting the lock file will automatically upgrade the dependency version in the project to the latest version under the semver scope, please test it thoroughly.
-:::
 
 ### Use lightweight libraries
 

--- a/website/builder/src/en/plugins/plugin-esbuild.md
+++ b/website/builder/src/en/plugins/plugin-esbuild.md
@@ -57,6 +57,43 @@ This config is used to enable JavaScript/TypeScript transformation, which will r
 
 If you want to modify the options, you can check the [esbuild-loader documentation](https://github.com/privatenumber/esbuild-loader#loader).
 
+#### Set the target environment
+
+Use the `target` option to set the target environment for transformation. `target` can be set directly to the JavaScript language version, such as `es6`, `es2020`; it can also be set to several target environments, each target environment is an environment name followed by a version number, such as `['chrome58', 'edge16' ,'firefox57']`.
+
+The following environments are supported:
+
+- chrome
+- edge
+- firefox
+- ie
+- ios
+- node
+- opera
+- safari
+
+```ts
+builder.addPlugins([
+  PluginEsbuild({
+    loader: {
+      target: 'chrome61',
+    },
+  }),
+]);
+```
+
+#### Disable transformation
+
+Set `loader` to `false` to disable esbuild transformation, and Builder will continue to use Babel to transform the code.
+
+```ts
+builder.addPlugins([
+  PluginEsbuild({
+    loader: false,
+  }),
+]);
+```
+
 ### minimize
 
 - **Type**:
@@ -74,9 +111,35 @@ const defaultOptions = {
 };
 ```
 
-This option is used to enable code minification for JavaScript and CSS.
+This option is used to enable minification for JavaScript and CSS.
 
 If you want to modify the options, you can check the [esbuild-loader documentation](https://github.com/privatenumber/esbuild-loader#minifyplugin).
+
+#### Set the target environment
+
+Use the `target` option to set the target environment for minification.
+
+```ts
+builder.addPlugins([
+  PluginEsbuild({
+    minimize: {
+      target: 'chrome61',
+    },
+  }),
+]);
+```
+
+#### Disable minification
+
+Set `minimize` to `false` to disable esbuild minification, and Builder will continue to use Terser to minify the code.
+
+```ts
+builder.addPlugins([
+  PluginEsbuild({
+    minimize: false,
+  }),
+]);
+```
 
 ## Limitations
 

--- a/website/builder/src/en/plugins/plugin-esbuild.md
+++ b/website/builder/src/en/plugins/plugin-esbuild.md
@@ -1,8 +1,10 @@
 # Esbuild Plugin
 
-> ESBuild is a front-end build tool based on Golang. It has the functions of bundling, compiling and minifing JavaScript code. Compared with traditional tools, the performance is improved by 10~100 times.
+:::tip About esbuild
+[esbuild](https://esbuild.github.io/) is a front-end build tool based on Golang. It has the functions of bundling, compiling and minimizing JavaScript code. Compared with traditional tools, the performance is significantly improved. When minimizing code, compared to webpack's built-in terser minimizer, esbuild has dozens of times better performance.
+:::
 
-Builder provides ESBuild plugin that allow you to use ESBuild instead of babel-loader, ts-loader and terser for transformation and minification process.
+Builder provides esbuild plugin that allow you to use esbuild instead of babel-loader, ts-loader and terser for transformation and minification process.
 
 ## Install
 
@@ -11,15 +13,17 @@ You can install the plugin with the following command:
 ```bash
 # npm
 npm install @modern-js/builder-plugin-esbuild -D
+
 # yarn
 yarn add @modern-js/builder-plugin-esbuild -D
+
 # pnpm
 pnpm install @modern-js/builder-plugin-esbuild -D
 ```
 
 ## Register
 
-You can register the plugin  in Builder:
+You can register the plugin in Builder to enable esbuild features:
 
 ```js
 import { PluginEsbuild } from '@modern-js/builder-plugin-esbuild';
@@ -32,53 +36,93 @@ builder.addPlugins([PluginEsbuild()]);
 
 The default config of the plugin is as follows:
 
-```js
-{
-  loader: {},
-  minimize: {},
-}
+```ts
+const defaultOptions = {
+  loader: {
+    target: 'es2015',
+    charset: builderConfig.output.charset,
+  },
+  minimize: {
+    css: true,
+    target: 'es2015',
+  },
+};
 ```
 
 The functions of JS(X)/TS(X) transformation and code minification are automatically enabled. Of course, you can also customize the behavior of the plugin through following config.
 
 ### loader
 
-- **Type**: `undefined | false | ` { javascript?: boolean | [LoaderOptions](https://github.com/privatenumber/esbuild-loader#loader); typescript?: boolean | [LoaderOptions](https://github.com/privatenumber/esbuild-loader#loader); }
-- **Default**: `{}`
+- **Type**:
 
-This config is used to enable JavaScript/TypeScript transformation, which will replace babel-loader and ts-loader with esbuild-loader. The transformation of JavaScript(JSX) and TypeScript(TSX) can be controlled separately.
+```ts
+type LoaderOptions = EsbuildLoaderOptions | false | undefined;
+```
+
+- **Default**:
+
+```ts
+const defaultOptions = {
+  target: 'es2015',
+  charset: builderConfig.output.charset,
+};
+```
+
+This config is used to enable JavaScript/TypeScript transformation, which will replace babel-loader and ts-loader with esbuild-loader.
+
+If you want to modify the options, you can check the [esbuild-loader documentation](https://github.com/privatenumber/esbuild-loader#loader).
 
 ### minimize
 
-- **Type**: `undefined | false | ` [MinifyPlugin.Options](https://github.com/privatenumber/esbuild-loader#minifyplugin)
-- **Default**: `true`
+- **Type**:
 
-When set to `true`, the default config will be applied, which is:
+```ts
+type MinimizeOptions = EsbuildMinifyOptions | false | undefined;
+```
 
-```typescript
-const DEFAULT_MINIFY_OPTIONS = {
+- **Default**:
+
+```ts
+const defaultOptions = {
+  css: true,
   target: 'es2015',
 };
 ```
 
-If you need to modify the minify parameters, you can check the [official documentation](https://github.com/privatenumber/esbuildloader#minifyplugin).
+This option is used to enable code minification for JavaScript and CSS.
+
+If you want to modify the options, you can check the [esbuild-loader documentation](https://github.com/privatenumber/esbuild-loader#minifyplugin).
 
 ## Limitations
 
-Although ESBuild can significantly improve the build performance of existing webpack projects, it still has certain limitations that require special attention.
+Although esbuild can significantly improve the build performance of existing webpack projects, it still has certain limitations that require special attention.
 
-As a compiler(i.e. `loader` capability), ESBuild can only support ES2015 (ie ES6) syntax. If the production environment needs to downgrade to ES5 and below syntax, **please close ESBuild** in the production environment. In addition, since the bottom layer of the plugin uses ESBuild's `Transform API`, it does not support ESBuild plugins to customize the compilation process. Therefore, the syntax transformation function of the original Babel plugins such as `babel-plugin-import` is not available after ESBuild is turned on.
+### Compatibility
 
-As a code minify tool (i.e. `minimize` capability), ESBuild can minify the code in production environment, but only supports ES2015 or above syntax (because the compression process needs to recognize the code AST and perform syntax conversion). You can specify the target syntax version by following config:
+As a compiler (i.e. `loader` capability), esbuild can only support ES2015 (ie ES6) syntax. If the production environment needs to downgrade to ES5 and below syntax, **please close esbuild** in the production environment.
+
+As a code minify tool (i.e. `minimize` capability), esbuild can minify the code in production environment, but only supports ES2015 or above syntax (because the compression process needs to recognize the code AST and perform syntax conversion). You can specify the target syntax version by following config:
 
 ```js
-builder.addPlugins([PluginEsbuild({
-  minimize: {
-    target: 'es2015',
-  },
-})]);
+builder.addPlugins([
+  PluginEsbuild({
+    minimize: {
+      target: 'es2015',
+    },
+  }),
+]);
 ```
 
 :::danger Caution
-Projects that need to be compatible with ES5 and below syntax in the production environment need to be careful to turn on the minimize config!
+Projects that need to be compatible with ES5 and below syntax in the production environment need to be careful to turn on the minimize config.
 :::
+
+### Not support Babel plugins
+
+As a compiler, since the bottom layer of the plugin uses esbuild's `Transform API`, it does not support esbuild plugins to customize the compilation process. Therefore, the syntax transformation function of the original Babel plugins such as `babel-plugin-import` is not available after esbuild is turned on.
+
+### Bundle Size
+
+Although the compression speed of esbuild is faster, the compression ratio of esbuild is lower than that of terser, so the bundle size will increase, please use it according to the scenes. Generally speaking, esbuild is more suitable for scenes that are not sensitive to bundle size.
+
+You can refer to [minification-benchmarks](https://github.com/privatenumber/minification-benchmarks) for a detailed comparison between minimizers.

--- a/website/builder/src/en/plugins/plugin-esbuild.md
+++ b/website/builder/src/en/plugins/plugin-esbuild.md
@@ -167,7 +167,7 @@ Projects that need to be compatible with ES5 and below syntax in the production 
 
 ### Not support Babel plugins
 
-As a compiler, since the bottom layer of the plugin uses esbuild's `Transform API`, it does not support esbuild plugins to customize the compilation process. Therefore, the syntax transformation function of the original Babel plugins such as `babel-plugin-import` is not available after esbuild is turned on.
+As a compiler, the syntax transformation function of the original Babel plugins such as `babel-plugin-import` is not available after esbuild is turned on. And since the bottom layer of the plugin uses esbuild's `Transform API`, it does not support esbuild plugins to customize the compilation process.
 
 ### Bundle Size
 

--- a/website/builder/src/en/plugins/plugin-esbuild.md
+++ b/website/builder/src/en/plugins/plugin-esbuild.md
@@ -34,22 +34,7 @@ builder.addPlugins([PluginEsbuild()]);
 
 ## Configuration
 
-The default config of the plugin is as follows:
-
-```ts
-const defaultOptions = {
-  loader: {
-    target: 'es2015',
-    charset: builderConfig.output.charset,
-  },
-  minimize: {
-    css: true,
-    target: 'es2015',
-  },
-};
-```
-
-The functions of JS(X)/TS(X) transformation and code minification are automatically enabled. Of course, you can also customize the behavior of the plugin through following config.
+The plugin will enable code transformation and minification by default. You can also customize the behavior of the plugin through configuration.
 
 ### loader
 

--- a/website/builder/src/zh/guide/advanced/build-performance.md
+++ b/website/builder/src/zh/guide/advanced/build-performance.md
@@ -32,25 +32,29 @@ nvm default 16
 node -v
 ```
 
+### 使用 esbuild 编译
+
+[esbuild](https://esbuild.github.io/) 是一款基于 Golang 开发的前端构建工具，具有打包、编译和压缩 JavaScript 代码的功能，相比传统的打包编译工具，esbuild 在性能上有显著提升。
+
+Builder 提供了 esbuild 插件，让你能使用 esbuild 代替 babel-loader、ts-loader 和 terser 等库进行代码编译和压缩。详见 [esbuild 插件](/plugins/plugin-esbuild.html)。
+
 ### 减少重复依赖
 
 在业务项目中，会存在某些第三方依赖被安装了多个版本的现象。重复依赖会导致包体积变大、构建速度变慢。
 
-我们可以通过社区中的一些工具来自动消除重复依赖，比如 [yarn-deduplicate](https://github.com/scinos/yarn-deduplicate)。
+我们可以通过社区中的一些工具来检测或消除重复依赖。
+
+如果你在使用 `pnpm`，可以使用 [pnpm-deduplicate](https://github.com/ocavue/pnpm-deduplicate) 来分析出所有的重复依赖，并通过升级依赖或声明 [pnpm overrides](https://pnpm.io/package_json#pnpmoverrides) 进行版本合并。
+
+```bash
+npx pnpm-deduplicate --list
+```
+
+如果你在使用 `yarn`，可以使用 [yarn-deduplicate](https://github.com/scinos/yarn-deduplicate) 来自动合并重复依赖：
 
 ```bash
 npx yarn-deduplicate && yarn
 ```
-
-如果你在使用 `pnpm`，可以考虑通过**重新生成 lock 文件**来减少重复依赖，
-
-```bash
-rm -rf ./node_modules pnpm-lock.yaml && pnpm install
-```
-
-:::tip
-删除 lock 文件会使项目中的依赖版本自动升级到 semver 范围下的最新版，请进行充分的测试。
-:::
 
 ### 使用更轻量的库
 

--- a/website/builder/src/zh/plugins/plugin-esbuild.md
+++ b/website/builder/src/zh/plugins/plugin-esbuild.md
@@ -34,22 +34,7 @@ builder.addPlugins([PluginEsbuild()]);
 
 ## 配置插件
 
-插件的默认配置如下:
-
-```ts
-const defaultOptions = {
-  loader: {
-    target: 'es2015',
-    charset: builderConfig.output.charset,
-  },
-  minimize: {
-    css: true,
-    target: 'es2015',
-  },
-};
-```
-
-即自动开启 JS(X)/TS(X) 和代码压缩的功能。当然，你也可以通过配置来自定义插件的行为。
+插件默认会开启代码转译和代码压缩的功能，你也可以通过配置来自定义插件的行为。
 
 ### loader
 

--- a/website/builder/src/zh/plugins/plugin-esbuild.md
+++ b/website/builder/src/zh/plugins/plugin-esbuild.md
@@ -57,6 +57,43 @@ const defaultOptions = {
 
 如果你需要修改转译参数，可以查看 [esbuild-loader 文档](https://github.com/privatenumber/esbuild-loader#loader)。
 
+#### 修改目标环境
+
+通过 `target` 选项来修改代码转译的目标环境。`target` 可以直接设置为 JavaScript 语言版本，比如 `es6`，`es2020`；也可以设置为若干个目标环境，每个目标环境都是一个环境名称后跟一个版本号，比如 `['chrome58', 'edge16' ,'firefox57']`。
+
+支持设置以下环境：
+
+- chrome
+- edge
+- firefox
+- ie
+- ios
+- node
+- opera
+- safari
+
+```ts
+builder.addPlugins([
+  PluginEsbuild({
+    loader: {
+      target: 'chrome61',
+    },
+  }),
+]);
+```
+
+#### 关闭代码转译
+
+将 `loader` 设置为 `false` 来关闭 esbuild 代码转译，此时 Builder 会继续使用 Babel 来进行代码转译。
+
+```ts
+builder.addPlugins([
+  PluginEsbuild({
+    loader: false,
+  }),
+]);
+```
+
 ### minimize
 
 - **Type**:
@@ -77,6 +114,32 @@ const defaultOptions = {
 这个选项用于启用 JavaScript 和 CSS 的代码压缩。
 
 如果你需要修改压缩参数，可以查看 [esbuild-loader 文档](https://github.com/privatenumber/esbuild-loader#minifyplugin)。
+
+#### 修改目标环境
+
+通过 `target` 选项来修改代码压缩的目标环境。
+
+```ts
+builder.addPlugins([
+  PluginEsbuild({
+    minimize: {
+      target: 'chrome61',
+    },
+  }),
+]);
+```
+
+#### 关闭代码压缩
+
+将 `minimize` 设置为 `false` 来关闭 esbuild 代码压缩，此时 Builder 会继续使用 Terser 进行代码压缩。
+
+```ts
+builder.addPlugins([
+  PluginEsbuild({
+    minimize: false,
+  }),
+]);
+```
 
 ## esbuild 局限性
 

--- a/website/builder/src/zh/plugins/plugin-esbuild.md
+++ b/website/builder/src/zh/plugins/plugin-esbuild.md
@@ -147,9 +147,9 @@ builder.addPlugins([
 
 ### 兼容性
 
-作为代码转译工具（即 `loader` 能力），esbuild 仅能支持到 ES2015（即 ES6）语法，如果生产环境需要降级到 ES5 及以下的语法，**请在生产环境关闭 esbuild**。
+使用 esbuild 进行代码转译时（即 `loader` 能力），esbuild 仅能支持到 ES2015（即 ES6）语法，如果生产环境需要降级到 ES5 及以下的语法，**请在生产环境关闭 esbuild**。
 
-作为代码压缩工具（即 `minimize` 能力），esbuild 可以在生产环境中进行压缩和混淆，但也仅能支持 ES2015 及以上的语法(因为压缩过程需要识别代码 AST 并进行语法转换)。你可以通过如下的配置指定目标语法版本:
+使用 esbuild 进行代码压缩时（即 `minimize` 能力），esbuild 可以在生产环境中进行压缩和混淆，但也仅能支持 ES2015 及以上的语法(因为压缩过程需要识别代码 AST 并进行语法转换)。你可以通过如下的配置指定目标语法版本:
 
 ```ts
 builder.addPlugins([
@@ -167,7 +167,7 @@ builder.addPlugins([
 
 ### 不支持 Babel 插件
 
-作为代码转译工具时，由于 Builder 底层使用的是 esbuild 的 `Transform API`，并不支持 esbuild 插件来进行自定义编译过程，因此，诸如 `babel-plugin-import` 等原有 Babel 插件的语法编译功能在开启 esbuild 后无法使用。
+使用 esbuild 进行代码转译时，诸如 `babel-plugin-import` 等原有 Babel 插件的语法编译功能在开启 esbuild 后无法使用。并且由于 Builder 底层使用的是 esbuild 的 `Transform API`，因此不支持使用额外 esbuild 插件来进行自定义编译过程。
 
 ### 产物体积
 

--- a/website/builder/src/zh/plugins/plugin-esbuild.md
+++ b/website/builder/src/zh/plugins/plugin-esbuild.md
@@ -1,8 +1,10 @@
-# ESBuild 插件
+# Esbuild 插件
 
-> ESBuild 是一款基于 Golang 开发的前端构建工具，具有打包、编译和压缩 JavaScript 代码的功能，相比传统的打包编译工具性能提升 10~100 倍。
+:::tip esbuild 介绍
+[esbuild](https://esbuild.github.io/) 是一款基于 Golang 开发的前端构建工具，具有打包、编译和压缩 JavaScript 代码的功能，相比传统的打包编译工具，esbuild 在性能上有显著提升。在代码压缩方面，相比 webpack 内置的 terser 压缩器，esbuild 在性能上有数十倍的提升。
+:::
 
-Builder 提供了 ESBuild 接入插件，让你能使用 ESBuild 代替 babel-loader、ts-loader 和 terser 等库进行代码编译和压缩。
+Builder 提供了 esbuild 插件，让你能使用 esbuild 代替 babel-loader、ts-loader 和 terser 等库进行代码编译和压缩。
 
 ## 安装插件
 
@@ -11,15 +13,17 @@ Builder 提供了 ESBuild 接入插件，让你能使用 ESBuild 代替 babel-lo
 ```bash
 # npm
 npm install @modern-js/builder-plugin-esbuild -D
+
 # yarn
 yarn add @modern-js/builder-plugin-esbuild -D
+
 # pnpm
 pnpm install @modern-js/builder-plugin-esbuild -D
 ```
 
 ## 注册插件
 
-你可以在 Builder 中注册插件，以便 Builder 接入 ESBuild 的功能:
+你可以在 Builder 中注册插件来启用 esbuild 相关功能:
 
 ```js
 import { PluginEsbuild } from '@modern-js/builder-plugin-esbuild';
@@ -32,55 +36,93 @@ builder.addPlugins([PluginEsbuild()]);
 
 插件的默认配置如下:
 
-```js
-{
-  loader: {},
-  minimize: {},
-}
+```ts
+const defaultOptions = {
+  loader: {
+    target: 'es2015',
+    charset: builderConfig.output.charset,
+  },
+  minimize: {
+    css: true,
+    target: 'es2015',
+  },
+};
 ```
 
 即自动开启 JS(X)/TS(X) 和代码压缩的功能。当然，你也可以通过配置来自定义插件的行为。
 
 ### loader
 
-- **Type**: `undefined | false | ` { javascript?: boolean | [LoaderOptions](https://github.com/privatenumber/esbuild-loader#loader); typescript?: boolean | [LoaderOptions](https://github.com/privatenumber/esbuild-loader#loader); }
-- **Default**: `{}`
+- **Type**:
 
-这个选项用于启用 JavaScript/TypeScript 的转译，启用时将会使用 esbuild-loader 替换 babel-loader 和 ts-loader。JavaScript 和 TypeScript 的转译可以分开控制。
+```ts
+type LoaderOptions = EsbuildLoaderOptions | false | undefined;
+```
+
+- **Default**:
+
+```ts
+const defaultOptions = {
+  target: 'es2015',
+  charset: builderConfig.output.charset,
+};
+```
+
+这个选项用于启用 JavaScript 和 TypeScript 的转译，启用时将会使用 esbuild-loader 替换 babel-loader 和 ts-loader。
+
+如果你需要修改转译参数，可以查看 [esbuild-loader 文档](https://github.com/privatenumber/esbuild-loader#loader)。
 
 ### minimize
 
-- **Type**: `undefined | false | ` [MinifyPlugin.Options](https://github.com/privatenumber/esbuild-loader#minifyplugin)
-- **Default**: `true`
+- **Type**:
 
-当设置为 `true` 时，将应用默认配置，默认配置为：
+```ts
+type MinimizeOptions = EsbuildMinifyOptions | false | undefined;
+```
 
-```typescript
-const DEFAULT_MINIFY_OPTIONS = {
+- **Default**:
+
+```ts
+const defaultOptions = {
+  css: true,
   target: 'es2015',
 };
 ```
 
-如果你需要修改压缩参数，可以查看[官方文档](https://github.com/privatenumber/esbuild-loader#minifyplugin)。
+这个选项用于启用 JavaScript 和 CSS 的代码压缩。
 
-## 限制条件
+如果你需要修改压缩参数，可以查看 [esbuild-loader 文档](https://github.com/privatenumber/esbuild-loader#minifyplugin)。
 
-虽然 ESBuild 能给现有的 webpack 项目带来明显的构建性能提升，但这两个工具在接入 Builder 时还存在一定的局限性，需要大家在接入的时候格外注意。
+## esbuild 局限性
 
-### ESBuild 限制
+虽然 esbuild 能给现有的 webpack 项目带来明显的构建性能提升，但这个工具在接入 Builder 时还存在一定的局限性，需要大家在接入的时候格外注意。
 
-作为代码转译工具(即 `loader` 能力)，ESBuild 仅能支持到 ES2015(即 ES6) 语法，如果生产环境需要降级到 ES5 及以下的语法，**请在生产环境关闭 ESBuild**。另外，由于 Builder 底层使用的是 ESBuild 的`Transform API`，并不支持 ESBuild 插件来进行自定义编译过程，因此，诸如 `babel-plugin-import` 等原有 Babel 插件的语法编译功能在开启 ESBuild 后无法使用。
+### 兼容性
 
-作为代码压缩工具(即 `minimize` 能力)，ESBuild 可以在生产环境中进行压缩和混淆，但也仅能支持 ES2015 及以上的语法(因为压缩过程需要识别代码 AST 并进行语法转换)。你可以通过如下的配置指定目标语法版本:
+作为代码转译工具（即 `loader` 能力），esbuild 仅能支持到 ES2015（即 ES6）语法，如果生产环境需要降级到 ES5 及以下的语法，**请在生产环境关闭 esbuild**。
+
+作为代码压缩工具（即 `minimize` 能力），esbuild 可以在生产环境中进行压缩和混淆，但也仅能支持 ES2015 及以上的语法(因为压缩过程需要识别代码 AST 并进行语法转换)。你可以通过如下的配置指定目标语法版本:
 
 ```ts
-builder.addPlugins([PluginEsbuild({
-  minimize: {
-    target: 'es2015',
-  },
-})]);
+builder.addPlugins([
+  PluginEsbuild({
+    minimize: {
+      target: 'es2015',
+    },
+  }),
+]);
 ```
 
 :::danger 注意
-生产环境需要兼容 ES5 及以下语法的项目需要谨慎开启 minimize 能力!
+生产环境需要兼容 ES5 及以下语法的项目，请谨慎开启 minimize 能力。
 :::
+
+### 不支持 Babel 插件
+
+作为代码转译工具时，由于 Builder 底层使用的是 esbuild 的 `Transform API`，并不支持 esbuild 插件来进行自定义编译过程，因此，诸如 `babel-plugin-import` 等原有 Babel 插件的语法编译功能在开启 esbuild 后无法使用。
+
+### 产物体积
+
+使用 esbuild 压缩虽然带来了构建效率上的提升，但 esbuild 的压缩比例是低于 terser 的，因此**构建产物的体积会增大**，请根据业务情况酌情使用。通常来说，esbuild 比较适合中后台等对体积不敏感的场景。
+
+对于压缩工具之间的详细对比，可以参考 [minification-benchmarks](https://github.com/privatenumber/minification-benchmarks)。


### PR DESCRIPTION
# PR Details

## Description

- esbuild minimize target should be es2015, the default target of esbuild-loader MinifyPlugin is `esnext`
- update document of esbuild plugin, add some details.

![image](https://user-images.githubusercontent.com/7237365/201813213-ee0cea33-9af4-48f3-9c2c-791046afbd48.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
