### PR TITLE
Release v2.0.0-beta.0

### DIFF
--- a/packages/builder/builder-doc/package.json
+++ b/packages/builder/builder-doc/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
@@ -90,7 +90,7 @@
     "@svgr/webpack": "6.2.1",
     "caniuse-lite": "^1.0.30001332",
     "css-minimizer-webpack-plugin": "4.0.0",
-    "cssnano": "5.1.13",
+    "cssnano": "^5.1.12",
     "fork-ts-checker-webpack-plugin": "7.2.13",
     "html-webpack-plugin": "5.5.0",
     "mini-css-extract-plugin": "2.4.5",
@@ -114,7 +114,7 @@
     "typescript": "^4"
   },
   "peerDependencies": {
-    "@modern-js/e2e": "workspace:^1.21.2"
+    "@modern-js/e2e": "workspace:^2.0.0-beta.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/e2e": {

--- a/packages/builder/builder/package.json
+++ b/packages/builder/builder/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-esbuild/package.json
+++ b/packages/builder/plugin-esbuild/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-node-polyfill/package.json
+++ b/packages/builder/plugin-node-polyfill/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-swc/package.json
+++ b/packages/builder/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/builder-plugin-swc",
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "description": "SWC plugin for builder in Modern.js",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/cli/babel-preset-app/CHANGELOG.md
+++ b/packages/cli/babel-preset-app/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @modern-js/babel-preset-app
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- decfcd989: fix(babel-preset-app): remove useless plugin-transform-destructuring
+
+  fix(babel-preset-app): 移除多余的 plugin-transform-destructuring 插件
+
+- Updated dependencies [27c0151e8]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/babel-preset-base@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/babel-preset-app/package.json
+++ b/packages/cli/babel-preset-app/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/babel-preset-base/CHANGELOG.md
+++ b/packages/cli/babel-preset-base/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @modern-js/babel-preset-base
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 27c0151e8: refactor: remove @babel/plugin-proposal-function-bind
+
+  refactor: 移除 @babel/plugin-proposal-function-bind
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/babel-preset-base/package.json
+++ b/packages/cli/babel-preset-base/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/cli/babel-preset-lib/CHANGELOG.md
+++ b/packages/cli/babel-preset-lib/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @modern-js/babel-preset-lib
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [27c0151e8]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/babel-preset-base@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/babel-preset-lib/package.json
+++ b/packages/cli/babel-preset-lib/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/babel-preset-module/CHANGELOG.md
+++ b/packages/cli/babel-preset-module/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @modern-js/babel-preset-module
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/babel-preset-lib@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/babel-preset-module/package.json
+++ b/packages/cli/babel-preset-module/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/core/CHANGELOG.md
+++ b/packages/cli/core/CHANGELOG.md
@@ -1,5 +1,52 @@
 # @modern-js/core
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Minor Changes
+
+- c9e800d39: feat: support React18 streaming SSR
+  feat: 支持 React18 流式 SSR
+- edd1cfb1a: feat: modernjs Access builder compiler
+  feat: modernjs 接入 builder 构建
+- d5a31df78: refactor: remove unbundle configs and types
+
+  refactor: 移除 unbundle 相关的配置项和类型定义
+
+### Patch Changes
+
+- 85edee8: feat(app-tools): support tools.htmlPlugin config
+
+  feat(app-tools): 支持 tools.htmlPlugin 配置项
+
+- b8bbe036c: feat: change type logic
+  feat: 修改类型相关的逻辑
+- 8b8e1bb57: feat: support nested routes
+  feat: 支持嵌套路由
+- 3bbea92b2: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- 14b712d: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [a2509bf]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/node-bundle-require@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/plugin@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/cli/plugin-bff/CHANGELOG.md
+++ b/packages/cli/plugin-bff/CHANGELOG.md
@@ -1,5 +1,34 @@
 # @modern-js/plugin-bff
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 8ff2cf4: fix: bff api loader should run before babel loader
+  fix: bff 一体化调用的 loader 应该在 babel loader 前执行
+- Updated dependencies [9b915e0c1]
+- Updated dependencies [a2509bf]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [a8642da]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/server-utils@2.0.0-beta.0
+  - @modern-js/bff-core@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/create-request@2.0.0-beta.0
+  - @modern-js/babel-compiler@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/plugin-bff/package.json
+++ b/packages/cli/plugin-bff/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-changeset/CHANGELOG.md
+++ b/packages/cli/plugin-changeset/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @modern-js/plugin-changeset
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/plugin-i18n@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/plugin-changeset/package.json
+++ b/packages/cli/plugin-changeset/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-data-loader/package.json
+++ b/packages/cli/plugin-data-loader/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.0",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-i18n/CHANGELOG.md
+++ b/packages/cli/plugin-i18n/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @modern-js/plugin-i18n
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/plugin-i18n/package.json
+++ b/packages/cli/plugin-i18n/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-jarvis/CHANGELOG.md
+++ b/packages/cli/plugin-jarvis/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @modern-js/plugin-jarvis
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/eslint-config@2.0.0-beta.0
+  - @modern-js-app/eslint-config@2.0.0-beta.0
+  - @modern-js/tsconfig@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/plugin-jarvis/package.json
+++ b/packages/cli/plugin-jarvis/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-proxy/CHANGELOG.md
+++ b/packages/cli/plugin-proxy/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @modern-js/plugin-proxy
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/plugin-proxy/package.json
+++ b/packages/cli/plugin-proxy/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-ssg/CHANGELOG.md
+++ b/packages/cli/plugin-ssg/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @modern-js/plugin-ssg
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- cc971eabf: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 8b8e1bb57: feat: support nested routes
+  feat: 支持嵌套路由
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/plugin-ssg/package.json
+++ b/packages/cli/plugin-ssg/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-storybook/CHANGELOG.md
+++ b/packages/cli/plugin-storybook/CHANGELOG.md
@@ -1,5 +1,48 @@
 # @modern-js/plugin-storybook
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Minor Changes
+
+- 0bb776858: feat: change Hooks logic
+  feat: 修改 Hooks 逻辑
+- f0ee9120d: feat: change dev menu log
+  feat: 修改 dev 菜单展示的内容
+
+### Patch Changes
+
+- a2509bf: feat: bump esbuild from 0.14.38 to 0.15.7
+
+  feat: 将 esbuild 从 0.14.38 版本升级至 0.15.7 版本
+
+- Updated dependencies [b18fa8f]
+- Updated dependencies [c9e800d39]
+- Updated dependencies [fe17f51]
+- Updated dependencies [a2509bf]
+- Updated dependencies [4369648ae]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [6bda14ed7]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [60d5378]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [8b8e1bb57]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [fcace5b5b]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/runtime@2.0.0-beta.0
+  - @modern-js/plugin-router-legacy@2.0.0-beta.0
+  - @modern-js/webpack@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/plugin-storybook/package.json
+++ b/packages/cli/plugin-storybook/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -83,8 +83,8 @@
     "webpack-chain": "^6.5.1"
   },
   "peerDependencies": {
-    "@modern-js/runtime": "workspace:^1.21.1",
-    "@modern-js/plugin-router-legacy": "workspace:^1.21.1",
+    "@modern-js/runtime": "workspace:^2.0.0-beta.0",
+    "@modern-js/plugin-router-legacy": "workspace:^2.0.0-beta.0",
     "react": ">=18"
   },
   "peerDependenciesMeta": {

--- a/packages/cli/plugin-tailwind/CHANGELOG.md
+++ b/packages/cli/plugin-tailwind/CHANGELOG.md
@@ -1,5 +1,34 @@
 # @modern-js/plugin-tailwindcss
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [b18fa8f]
+- Updated dependencies [c9e800d39]
+- Updated dependencies [a2509bf]
+- Updated dependencies [4369648ae]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [6bda14ed7]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [60d5378]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [8b8e1bb57]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [fcace5b5b]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/runtime@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/plugin-tailwind/package.json
+++ b/packages/cli/plugin-tailwind/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "tailwindcss": "^2.0.4",
-    "@modern-js/runtime": "workspace:^1.21.2"
+    "@modern-js/runtime": "workspace:^2.0.0-beta.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/runtime": {

--- a/packages/cli/webpack/CHANGELOG.md
+++ b/packages/cli/webpack/CHANGELOG.md
@@ -1,5 +1,32 @@
 # @modern-js/webpack
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Minor Changes
+
+- edd1cfb1a: feat: modernjs Access builder compiler
+  feat: modernjs 接入 builder 构建
+
+### Patch Changes
+
+- Updated dependencies [decfcd989]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/babel-preset-app@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/cli/webpack/package.json
+++ b/packages/cli/webpack/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/generator/generator-cases/CHANGELOG.md
+++ b/packages/generator/generator-cases/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @modern-js/generator-cases
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [dda38c9]
+  - @modern-js/generator-common@3.0.0-beta.0
+
 ## 2.4.7
 
 ### Patch Changes

--- a/packages/generator/generator-cases/package.json
+++ b/packages/generator/generator-cases/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/generator-common/CHANGELOG.md
+++ b/packages/generator/generator-common/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @modern-js/generator-common
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [dda38c9]
+  - @modern-js/plugin-i18n@2.0.0-beta.0
+
 ## 2.4.7
 
 ### Patch Changes

--- a/packages/generator/generator-common/package.json
+++ b/packages/generator/generator-common/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/generator-plugin/CHANGELOG.md
+++ b/packages/generator/generator-plugin/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @modern-js/generator-plugin
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/plugin-i18n@2.0.0-beta.0
+  - @modern-js/generator-common@3.0.0-beta.0
+  - @modern-js/generator-utils@3.0.0-beta.0
+  - @modern-js/new-action@2.0.0-beta.0
+
 ## 2.4.7
 
 ### Patch Changes

--- a/packages/generator/generator-plugin/package.json
+++ b/packages/generator/generator-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/generator-plugin",
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/generator-utils/CHANGELOG.md
+++ b/packages/generator/generator-utils/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @modern-js/generator-utils
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/plugin-i18n@2.0.0-beta.0
+  - @modern-js/generator-common@3.0.0-beta.0
+
 ## 2.4.7
 
 ### Patch Changes

--- a/packages/generator/generator-utils/package.json
+++ b/packages/generator/generator-utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/generators/base-generator/CHANGELOG.md
+++ b/packages/generator/generators/base-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/base-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/base-generator/package.json
+++ b/packages/generator/generators/base-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./src/index.ts",

--- a/packages/generator/generators/bff-generator/CHANGELOG.md
+++ b/packages/generator/generators/bff-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/bff-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/bff-generator/package.json
+++ b/packages/generator/generators/bff-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./src/index.ts",

--- a/packages/generator/generators/changeset-generator/CHANGELOG.md
+++ b/packages/generator/generators/changeset-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/changeset-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/changeset-generator/package.json
+++ b/packages/generator/generators/changeset-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/dependence-generator/CHANGELOG.md
+++ b/packages/generator/generators/dependence-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/dependence-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/dependence-generator/package.json
+++ b/packages/generator/generators/dependence-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/entry-generator/CHANGELOG.md
+++ b/packages/generator/generators/entry-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/entry-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/entry-generator/package.json
+++ b/packages/generator/generators/entry-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/eslint-generator/CHANGELOG.md
+++ b/packages/generator/generators/eslint-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/eslint-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/eslint-generator/package.json
+++ b/packages/generator/generators/eslint-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/generator-generator/CHANGELOG.md
+++ b/packages/generator/generators/generator-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/generator-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/generator-generator/package.json
+++ b/packages/generator/generators/generator-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/module-generator/CHANGELOG.md
+++ b/packages/generator/generators/module-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/module-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ### Patch Changes

--- a/packages/generator/generators/module-generator/package.json
+++ b/packages/generator/generators/module-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/monorepo-generator/CHANGELOG.md
+++ b/packages/generator/generators/monorepo-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/monorepo-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ### Patch Changes

--- a/packages/generator/generators/monorepo-generator/package.json
+++ b/packages/generator/generators/monorepo-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/mwa-generator/CHANGELOG.md
+++ b/packages/generator/generators/mwa-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/mwa-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ### Patch Changes

--- a/packages/generator/generators/mwa-generator/package.json
+++ b/packages/generator/generators/mwa-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/packages-generator/package.json
+++ b/packages/generator/generators/packages-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/repo-generator/CHANGELOG.md
+++ b/packages/generator/generators/repo-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/repo-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/repo-generator/package.json
+++ b/packages/generator/generators/repo-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/router-legacy-generator/package.json
+++ b/packages/generator/generators/router-legacy-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/server-generator/CHANGELOG.md
+++ b/packages/generator/generators/server-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/server-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/server-generator/package.json
+++ b/packages/generator/generators/server-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./src/index.ts",

--- a/packages/generator/generators/ssg-generator/CHANGELOG.md
+++ b/packages/generator/generators/ssg-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/ssg-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/ssg-generator/package.json
+++ b/packages/generator/generators/ssg-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/storybook-generator/CHANGELOG.md
+++ b/packages/generator/generators/storybook-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/storybook-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/storybook-generator/package.json
+++ b/packages/generator/generators/storybook-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/tailwindcss-generator/CHANGELOG.md
+++ b/packages/generator/generators/tailwindcss-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/tailwindcss-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/tailwindcss-generator/package.json
+++ b/packages/generator/generators/tailwindcss-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/test-generator/CHANGELOG.md
+++ b/packages/generator/generators/test-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/test-generator
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/generators/test-generator/package.json
+++ b/packages/generator/generators/test-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/upgrade-generator/package.json
+++ b/packages/generator/generators/upgrade-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/new-action/CHANGELOG.md
+++ b/packages/generator/new-action/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @modern-js/new-action
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/generator-common@3.0.0-beta.0
+  - @modern-js/generator-utils@3.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/generator/new-action/package.json
+++ b/packages/generator/new-action/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/plugins/generator-plugin/CHANGELOG.md
+++ b/packages/generator/plugins/generator-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/generator-plugin-plugin
 
+## 3.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
 ## 2.4.7
 
 ## 2.4.6

--- a/packages/generator/plugins/generator-plugin/package.json
+++ b/packages/generator/plugins/generator-plugin/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.7",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/review/eslint-config-app/CHANGELOG.md
+++ b/packages/review/eslint-config-app/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js-app/eslint-config
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [decfcd989]
+- Updated dependencies [dda38c9]
+  - @modern-js/babel-preset-app@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/review/eslint-config-app/package.json
+++ b/packages/review/eslint-config-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js-app/eslint-config",
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "description": "The meta-framework suite designed from scratch for frontend-focused modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/review/eslint-config/CHANGELOG.md
+++ b/packages/review/eslint-config/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @modern-js/eslint-config
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [dda38c9]
+  - @modern-js-app/eslint-config@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/review/eslint-config/package.json
+++ b/packages/review/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/eslint-config",
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "description": "The meta-framework suite designed from scratch for frontend-focused modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/review/tsconfig/CHANGELOG.md
+++ b/packages/review/tsconfig/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/tsconfig
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
 ## 1.21.2
 
 ## 1.21.1

--- a/packages/review/tsconfig/package.json
+++ b/packages/review/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/tsconfig",
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "description": "The meta-framework suite designed from scratch for frontend-focused modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/runtime/plugin-garfish/CHANGELOG.md
+++ b/packages/runtime/plugin-garfish/CHANGELOG.md
@@ -1,5 +1,34 @@
 # @modern-js/plugin-garfish
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [b18fa8f]
+- Updated dependencies [c9e800d39]
+- Updated dependencies [a2509bf]
+- Updated dependencies [4369648ae]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [6bda14ed7]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [60d5378]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [8b8e1bb57]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [fcace5b5b]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/runtime@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "typesVersions": {
@@ -66,7 +66,7 @@
     "react-loadable": "^5.5.0"
   },
   "peerDependencies": {
-    "@modern-js/runtime": "workspace:^1.21.2"
+    "@modern-js/runtime": "workspace:^2.0.0-beta.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/runtime": {

--- a/packages/runtime/plugin-router-legacy/package.json
+++ b/packages/runtime/plugin-router-legacy/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/runtime/plugin-runtime/CHANGELOG.md
+++ b/packages/runtime/plugin-runtime/CHANGELOG.md
@@ -1,5 +1,57 @@
 # @modern-js/runtime
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Minor Changes
+
+- c9e800d39: feat: support React18 streaming SSR
+  feat: 支持 React18 流式 SSR
+- 543be95: feat: compile server loader and support handle loader request
+  feat: 编译 server loader 并支持处理 loader 的请求
+
+### Patch Changes
+
+- b18fa8f: feat: remove @loadable/component in streaming ssr
+  feat: 移除 streaming ssr 中的 @loadable/component 逻辑
+- a2509bf: feat: bump esbuild from 0.14.38 to 0.15.7
+
+  feat: 将 esbuild 从 0.14.38 版本升级至 0.15.7 版本
+
+- 4369648ae: fix: fix html template of streaming ssr
+  fix: 修复流式渲染的 html 模版
+- 6bda14ed7: feat: refactor router with react-router@6.4
+
+  feat: 使用 react-router@6.4 重构路由模块
+
+- 60d5378: fix: function extname should not return array
+  fix: 函数 extname 不应该返回一个数组
+- 8b8e1bb57: feat: support nested routes
+  feat: 支持嵌套路由
+- 3bbea92b2: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- fcace5b5b: fix: remove overmuch `@modernjs/utils` dependency import in ssr runtime & SSR hydrate error
+  fix: 去除 ssr 运行时过多的 `@modernjs/utils` 依赖引入 & SSR hydrate 错误
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [6bda14ed7]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [102d32e4b]
+- Updated dependencies [8b8e1bb57]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/types@2.0.0-beta.0
+  - @modern-js/plugin@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "engines": {
     "node": ">=14.17.6"
   },

--- a/packages/runtime/plugin-testing/CHANGELOG.md
+++ b/packages/runtime/plugin-testing/CHANGELOG.md
@@ -1,5 +1,48 @@
 # @modern-js/plugin-testing
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- cc971eabf: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 14b712d: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [b18fa8f]
+- Updated dependencies [c9e800d39]
+- Updated dependencies [15bf09d9c]
+- Updated dependencies [a2509bf]
+- Updated dependencies [decfcd989]
+- Updated dependencies [4369648ae]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [6bda14ed7]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [60d5378]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [102d32e4b]
+- Updated dependencies [8b8e1bb57]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [73cd29dd9]
+- Updated dependencies [fcace5b5b]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/runtime@2.0.0-beta.0
+  - @modern-js/prod-server@2.0.0-beta.0
+  - @modern-js/babel-preset-app@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/plugin@2.0.0-beta.0
+  - @modern-js/babel-compiler@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -127,7 +127,7 @@
   "peerDependencies": {
     "react": ">=17",
     "react-dom": ">=17",
-    "@modern-js/runtime": "workspace:^1.21.2"
+    "@modern-js/runtime": "workspace:^2.0.0-beta.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/runtime": {

--- a/packages/server/bff-core/CHANGELOG.md
+++ b/packages/server/bff-core/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @modern-js/bff-core
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- a2509bf: feat: bump esbuild from 0.14.38 to 0.15.7
+
+  feat: 将 esbuild 从 0.14.38 版本升级至 0.15.7 版本
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/bff-runtime@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/server/bff-core/package.json
+++ b/packages/server/bff-core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/bff-runtime/CHANGELOG.md
+++ b/packages/server/bff-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/bff-runtime
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
 ## 1.21.2
 
 ## 1.21.1

--- a/packages/server/bff-runtime/package.json
+++ b/packages/server/bff-runtime/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/core/CHANGELOG.md
+++ b/packages/server/core/CHANGELOG.md
@@ -1,5 +1,35 @@
 # @modern-js/server-plugin
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Minor Changes
+
+- 543be95: feat: compile server loader and support handle loader request
+  feat: 编译 server loader 并支持处理 loader 的请求
+
+### Patch Changes
+
+- 15bf09d9c: feat: support completely custom server, export render() api for render single page
+  feat: 支持完全自定义 Server，导出 render() 方法用来渲染单个页面
+- cc971eabf: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/plugin@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/create-request/CHANGELOG.md
+++ b/packages/server/create-request/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @modern-js/create-request
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/server/create-request/package.json
+++ b/packages/server/create-request/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-egg/CHANGELOG.md
+++ b/packages/server/plugin-egg/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @modern-js/plugin-egg
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 3bbea92b2: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- Updated dependencies [a2509bf]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/bff-core@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/bff-runtime@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/server/plugin-egg/package.json
+++ b/packages/server/plugin-egg/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-express/CHANGELOG.md
+++ b/packages/server/plugin-express/CHANGELOG.md
@@ -1,5 +1,36 @@
 # @modern-js/plugin-express
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 8d24bed25: fix: compat Hook API in /server namespace
+  fix: 在 @modern-js/runtime/server 命名空间下兼容 Hook API
+- 3bbea92b2: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- Updated dependencies [a2509bf]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [6bda14ed7]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [102d32e4b]
+- Updated dependencies [8b8e1bb57]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/bff-core@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/types@2.0.0-beta.0
+  - @modern-js/bff-runtime@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/server/plugin-express/package.json
+++ b/packages/server/plugin-express/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-koa/CHANGELOG.md
+++ b/packages/server/plugin-koa/CHANGELOG.md
@@ -1,5 +1,36 @@
 # @modern-js/plugin-koa
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 8d24bed25: fix: compat Hook API in /server namespace
+  fix: 在 @modern-js/runtime/server 命名空间下兼容 Hook API
+- 3bbea92b2: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- Updated dependencies [a2509bf]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [6bda14ed7]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [102d32e4b]
+- Updated dependencies [8b8e1bb57]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/bff-core@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/types@2.0.0-beta.0
+  - @modern-js/bff-runtime@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/server/plugin-koa/package.json
+++ b/packages/server/plugin-koa/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-nest/CHANGELOG.md
+++ b/packages/server/plugin-nest/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @modern-js/plugin-nest
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 3bbea92b2: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- Updated dependencies [a2509bf]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/bff-core@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/bff-runtime@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/server/plugin-nest/package.json
+++ b/packages/server/plugin-nest/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/server/plugin-polyfill/CHANGELOG.md
+++ b/packages/server/plugin-polyfill/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @modern-js/plugin-polyfill
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/server/plugin-polyfill/package.json
+++ b/packages/server/plugin-polyfill/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-server/CHANGELOG.md
+++ b/packages/server/plugin-server/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @modern-js/plugin-server
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 3bbea92b2: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- Updated dependencies [9b915e0c1]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [a8642da]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/server-utils@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/babel-compiler@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/server/plugin-server/package.json
+++ b/packages/server/plugin-server/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "types": "./src/server.ts",
   "jsnext:source": "./src/server.ts",
   "main": "./dist/js/node/server.js",

--- a/packages/server/prod-server/CHANGELOG.md
+++ b/packages/server/prod-server/CHANGELOG.md
@@ -1,5 +1,52 @@
 # @modern-js/prod-server
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Minor Changes
+
+- c9e800d39: feat: support React18 streaming SSR
+  feat: 支持 React18 流式 SSR
+- 543be95: feat: compile server loader and support handle loader request
+  feat: 编译 server loader 并支持处理 loader 的请求
+
+### Patch Changes
+
+- 15bf09d9c: feat: support completely custom server, export render() api for render single page
+  feat: 支持完全自定义 Server，导出 render() 方法用来渲染单个页面
+- cc971eabf: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 102d32e4b: feat(server): add `req` and `res` to SSR context
+
+  feat(server): 添加 `req` 和 `res` 到 SSR context 中
+
+- 3bbea92b2: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- 73cd29dd9: fix(server): add favicon fallback handler
+
+  fix(server): 添加 favicon 兜底处理逻辑
+
+- 14b712d: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [15bf09d9c]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/server-core@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/server/prod-server/package.json
+++ b/packages/server/prod-server/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/server/CHANGELOG.md
+++ b/packages/server/server/CHANGELOG.md
@@ -1,5 +1,44 @@
 # @modern-js/server
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 15bf09d9c: feat: support completely custom server, export render() api for render single page
+  feat: 支持完全自定义 Server，导出 render() 方法用来渲染单个页面
+- 61f21d1e7: fix: ignore the entire distPath for pia ssr bundle
+  fix: dist 目录的产物不应该被 ts-node 编译
+- 14b712d: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [9b915e0c1]
+- Updated dependencies [c9e800d39]
+- Updated dependencies [15bf09d9c]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [6bda14ed7]
+- Updated dependencies [a8642da]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [102d32e4b]
+- Updated dependencies [8b8e1bb57]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [73cd29dd9]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/server-utils@2.0.0-beta.0
+  - @modern-js/prod-server@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/types@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/utils/CHANGELOG.md
+++ b/packages/server/utils/CHANGELOG.md
@@ -1,5 +1,38 @@
 # @modern-js/server-utils
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- 9b915e0c1: fix: tsconfig-paths plugin's new node use old node flag
+  fix: tsconfig-paths 插件转换的新节点使用旧节点的 flag
+- a8642da: fix(server-utils): incorrect babel-compiler version
+
+  fix(server-utils): 修复引用错误的 babel-compiler 版本的问题
+
+- 14b712d: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/plugin@2.0.0-beta.0
+  - @modern-js/babel-preset-lib@2.0.0-beta.0
+  - @modern-js/babel-compiler@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/solutions/app-tools/CHANGELOG.md
+++ b/packages/solutions/app-tools/CHANGELOG.md
@@ -1,5 +1,144 @@
 # @modern-js/app-tools
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Minor Changes
+
+- edd1cfb1a: feat: modernjs Access builder compiler
+  feat: modernjs 接入 builder 构建
+- 543be95: feat: compile server loader and support handle loader request
+  feat: 编译 server loader 并支持处理 loader 的请求
+
+### Patch Changes
+
+- c9f912c: feat(app-tools): improve build logs of dev and build command
+
+  feat(app-tools): 优化 dev 和 build 过程中的日志展示
+
+- 103973c: fix: builder tools.webpackChain config args not match the Modernjs tools.webpackChain
+  fix: builder tools.webpackChain 配置传参无法匹配 Modernjs tools.webpackChain
+- 0b2d1ef: fix: repeat register `babel-plugin-lodash`
+  fix: 重复注册 `babel-plugin-lodash`
+- 82cef85: fix: specify builder compiler framework
+  fix: 指明 builder 构建时框架
+- 85edee8: feat(app-tools): support tools.htmlPlugin config
+
+  feat(app-tools): 支持 tools.htmlPlugin 配置项
+
+- dc8eeb9: fix: clear distDirectory in prepare hook & inject data loader plugin to server
+  fix: 在 prepare hook 中清理 dist 目录，并且向 server 中注入 data loader plugin
+- cc971eabf: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 5b9049f: feat: inject async js chunk when streaming ssr
+  feat: streaming ssr 时, 注入 async 类型的 js chunk
+- 6bda14ed7: feat: refactor router with react-router@6.4
+
+  feat: 使用 react-router@6.4 重构路由模块
+
+- d36c6ee: fix(app-tools): failed to run inspect command
+
+  fix(app-tools): 修复运行 inspect 命令失败的问题
+
+- b8bbe036c: feat: change type logic
+  feat: 修改类型相关的逻辑
+- af4422d: feat(builder): complete utils of tools.webpack
+
+  feat(builder): 补全 tools.webpack 提供的 utils 方法
+
+- c258e34: fix: add builder hooks `beforeBuild` params
+  fix: 新增 builder hooks `beforeBuild` 的参数
+- 8b8e1bb57: feat: support nested routes
+  feat: 支持嵌套路由
+- c677bef: fix(app-tools): compat legacy resolve behavior
+
+  fix(app-tools): 兼容旧版本 node_modules 解析逻辑
+
+- 3f7cde5: fix: builder plugin setup can't get config
+  fix: builder 插件在 setup 阶段无法拿到 config
+- 99213e4: fix: process does't exit when exec command
+  fix: 修复执行命令时进程未退出的问题
+- b16fd96: fix: `modern-js/app-tools` pass error config to builder.
+  fix: `modern-js/app-tools` 传递错误的 config 给 builder.
+- 7eefedd: fix: add html-webpack-plugin `__internal__` options, for bottom template
+  fix: 为了 bottom template, 增加 `html-webpack-plugin` `__internal__` 配置项，
+- 14b712d: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [c9f912c]
+- Updated dependencies [95be7cc49]
+- Updated dependencies [e439457a5]
+- Updated dependencies [4d1545f]
+- Updated dependencies [2bc090c08]
+- Updated dependencies [f96a725]
+- Updated dependencies [828f42f9c]
+- Updated dependencies [c745686]
+- Updated dependencies [c9e800d39]
+- Updated dependencies [0ff846f]
+- Updated dependencies [57077b2]
+- Updated dependencies [287f29899]
+- Updated dependencies [15bf09d9c]
+- Updated dependencies [423188db7]
+- Updated dependencies [fd2d652]
+- Updated dependencies [0c2d8dae3]
+- Updated dependencies [85edee8]
+- Updated dependencies [a2509bf]
+- Updated dependencies [399887579]
+- Updated dependencies [399887579]
+- Updated dependencies [ba86b8b]
+- Updated dependencies [61f21d1e7]
+- Updated dependencies [2ae58176f]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [5d67c26]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [18360a38d]
+- Updated dependencies [6bda14ed7]
+- Updated dependencies [0b314e694]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [af4422d]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [102d32e4b]
+- Updated dependencies [c258e34]
+- Updated dependencies [7248342e4]
+- Updated dependencies [568eab1e4]
+- Updated dependencies [8b8e1bb57]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [ae71096d4]
+- Updated dependencies [73cd29dd9]
+- Updated dependencies [a23010138]
+- Updated dependencies [75d1b2657]
+- Updated dependencies [8a6d45f]
+- Updated dependencies [90e2879]
+- Updated dependencies [f727e5c6c]
+- Updated dependencies [5e3cecd52]
+- Updated dependencies [abf3421]
+- Updated dependencies [da2d1fc3c]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/builder-webpack-provider@2.0.0-beta.0
+  - @modern-js/builder-shared@2.0.0-beta.0
+  - @modern-js/core@2.0.0-beta.0
+  - @modern-js/prod-server@2.0.0-beta.0
+  - @modern-js/builder-plugin-esbuild@2.0.0-beta.0
+  - @modern-js/server@2.0.0-beta.0
+  - @modern-js/node-bundle-require@2.0.0-beta.0
+  - @modern-js/builder-plugin-node-polyfill@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/types@2.0.0-beta.0
+  - @modern-js/plugin@2.0.0-beta.0
+  - @modern-js/builder@2.0.0-beta.0
+  - @modern-js/plugin-data-loader@2.0.0-beta.0
+  - @modern-js/plugin-i18n@2.0.0-beta.0
+  - @modern-js/plugin-jarvis@2.0.0-beta.0
+  - @modern-js/new-action@2.0.0-beta.0
+  - @modern-js/upgrade@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/solutions/module-tools-v2/CHANGELOG.md
+++ b/packages/solutions/module-tools-v2/CHANGELOG.md
@@ -1,5 +1,52 @@
 # @modern-js/module-tools
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Minor Changes
+
+- 4fd53b48f: feat: add normalize config logic
+  feat: 添加处理配置的逻辑
+- f0ee9120d: feat: change dev menu log
+  feat: 修改 dev 菜单展示的内容
+- 0bb776858: feat: add ModuleContext
+  feat: 添加 ModuleContext
+- e6bfca6d3: feat: add type define and schema for config
+  feat: 为配置增加类型定义和 schema
+- 54abc88a2: feat: add new and upgrade command
+  feat: 添加 new 和 upgrade 命令
+
+### Patch Changes
+
+- cc971eabf: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 540de1fd5: fix: filename typo, color.ts --> colors.ts
+  fix: 文件名错误，color.ts 修改为 colors.ts
+- 1be4ba1cc: feat: add platform build log
+  feat: 添加 platform 构建的 log 内容
+- Updated dependencies [c9e800d39]
+- Updated dependencies [85edee8]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [8b8e1bb57]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/core@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/plugin@2.0.0-beta.0
+  - @modern-js/plugin-i18n@2.0.0-beta.0
+  - @modern-js/new-action@2.0.0-beta.0
+  - @modern-js/upgrade@2.0.0-beta.0
+
 ## 1.17.0
 
 ### Patch Changes

--- a/packages/solutions/module-tools-v2/package.json
+++ b/packages/solutions/module-tools-v2/package.json
@@ -12,7 +12,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.17.0",
+  "version": "2.0.0-beta.0",
   "bin": {
     "modern": "./bin/modern.js"
   },

--- a/packages/solutions/module-tools/CHANGELOG.md
+++ b/packages/solutions/module-tools/CHANGELOG.md
@@ -1,5 +1,44 @@
 # @modern-js/module-tools
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- b8bbe036c: feat: export Hooks type
+  feat: 导出 Hooks 类型
+- 14b712d: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [c9e800d39]
+- Updated dependencies [85edee8]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [8b8e1bb57]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/core@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/plugin@2.0.0-beta.0
+  - @modern-js/babel-preset-module@2.0.0-beta.0
+  - @modern-js/plugin-changeset@2.0.0-beta.0
+  - @modern-js/plugin-i18n@2.0.0-beta.0
+  - @modern-js/plugin-jarvis@2.0.0-beta.0
+  - @modern-js/new-action@2.0.0-beta.0
+  - @modern-js/babel-compiler@2.0.0-beta.0
+  - @modern-js/style-compiler@2.0.0-beta.0
+  - @modern-js/upgrade@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "bin": {
     "modern": "./bin/modern.js"
   },

--- a/packages/solutions/monorepo-tools/CHANGELOG.md
+++ b/packages/solutions/monorepo-tools/CHANGELOG.md
@@ -1,5 +1,35 @@
 # @modern-js/monorepo-tools
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [c9e800d39]
+- Updated dependencies [85edee8]
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [8b8e1bb57]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/core@2.0.0-beta.0
+  - @modern-js/utils@2.0.0-beta.0
+  - @modern-js/plugin@2.0.0-beta.0
+  - @modern-js/plugin-changeset@2.0.0-beta.0
+  - @modern-js/plugin-i18n@2.0.0-beta.0
+  - @modern-js/plugin-jarvis@2.0.0-beta.0
+  - @modern-js/new-action@2.0.0-beta.0
+  - @modern-js/upgrade@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/solutions/monorepo-tools/package.json
+++ b/packages/solutions/monorepo-tools/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/toolkit/compiler/babel/CHANGELOG.md
+++ b/packages/toolkit/compiler/babel/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @modern-js/babel-compiler
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/toolkit/compiler/babel/package.json
+++ b/packages/toolkit/compiler/babel/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/toolkit/compiler/style/CHANGELOG.md
+++ b/packages/toolkit/compiler/style/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @modern-js/style-compiler
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/toolkit/compiler/style/package.json
+++ b/packages/toolkit/compiler/style/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/toolkit/create/CHANGELOG.md
+++ b/packages/toolkit/create/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @modern-js/create
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- cc971eabf: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 6b6f180: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/toolkit/create/package.json
+++ b/packages/toolkit/create/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/toolkit/e2e/package.json
+++ b/packages/toolkit/e2e/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@modern-js/e2e",
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "build": "tsc",

--- a/packages/toolkit/main-doc/package.json
+++ b/packages/toolkit/main-doc/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "prepare": "npx ts-node ./scripts/sync.ts"
   },
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/toolkit/node-bundle-require/CHANGELOG.md
+++ b/packages/toolkit/node-bundle-require/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @modern-js/node-bundle-require
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- a2509bf: feat: bump esbuild from 0.14.38 to 0.15.7
+
+  feat: 将 esbuild 从 0.14.38 版本升级至 0.15.7 版本
+
+- Updated dependencies [edd1cfb1a]
+- Updated dependencies [cc971eabf]
+- Updated dependencies [5b9049f]
+- Updated dependencies [b8bbe036c]
+- Updated dependencies [d5a31df78]
+- Updated dependencies [dda38c9]
+- Updated dependencies [3bbea92b2]
+- Updated dependencies [abf3421]
+- Updated dependencies [543be95]
+- Updated dependencies [14b712d]
+  - @modern-js/utils@2.0.0-beta.0
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/toolkit/node-bundle-require/package.json
+++ b/packages/toolkit/node-bundle-require/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/node-bundle-require",
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "description": "The meta-framework suite designed from scratch for frontend-focused modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/toolkit/plugin/CHANGELOG.md
+++ b/packages/toolkit/plugin/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @modern-js/plugin
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- b8bbe036c: feat: change type logic
+  feat: 修改类型相关的逻辑
+
 ## 1.21.2
 
 ### Patch Changes

--- a/packages/toolkit/plugin/package.json
+++ b/packages/toolkit/plugin/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/toolkit/types/CHANGELOG.md
+++ b/packages/toolkit/types/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @modern-js/types
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Patch Changes
+
+- cc971eabf: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 6bda14ed7: feat: refactor router with react-router@6.4
+
+  feat: 使用 react-router@6.4 重构路由模块
+
+- 102d32e4b: feat(server): add `req` and `res` to SSR context
+
+  feat(server): 添加 `req` 和 `res` 到 SSR context 中
+
+- 8b8e1bb57: feat: support nested routes
+  feat: 支持嵌套路由
+- 3bbea92b2: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+
 ## 1.21.2
 
 ## 1.21.1

--- a/packages/toolkit/types/package.json
+++ b/packages/toolkit/types/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "types": "./index.d.ts",
   "exports": {
     ".": "./index.d.ts",

--- a/packages/toolkit/upgrade/package.json
+++ b/packages/toolkit/upgrade/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/toolkit/utils/CHANGELOG.md
+++ b/packages/toolkit/utils/CHANGELOG.md
@@ -1,5 +1,40 @@
 # @modern-js/utils
 
+## 2.0.0-beta.0
+
+### Major Changes
+
+- dda38c9: chore: v2
+
+### Minor Changes
+
+- edd1cfb1a: feat: modernjs Access builder compiler
+  feat: modernjs 接入 builder 构建
+- d5a31df78: refactor: remove unbundle configs and types
+
+  refactor: 移除 unbundle 相关的配置项和类型定义
+
+- 543be95: feat: compile server loader and support handle loader request
+  feat: 编译 server loader 并支持处理 loader 的请求
+
+### Patch Changes
+
+- cc971eabf: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 5b9049f: feat: inject async js chunk when streaming ssr
+  feat: streaming ssr 时, 注入 async 类型的 js chunk
+- b8bbe036c: feat: change type logic
+  feat: 修改类型相关的逻辑
+- 3bbea92b2: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- abf3421: fix(dev-server): isDepsExists add non pkgPath judege
+
+  修复: isDepsExists 方法添加 package.json 不存在的兜底
+
+- 14b712d: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
 ## 1.21.2
 
 ## 1.21.1

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/scripts/build/package.json
+++ b/scripts/build/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/build",
   "private": true,
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "main": "./src/index.js",
   "bin": {
     "modern": "./bin/modern.js",

--- a/scripts/check-changeset/package.json
+++ b/scripts/check-changeset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scripts/check-changeset",
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "private": true,
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/codemod/package.json
+++ b/scripts/codemod/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/codemod",
   "private": true,
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "scripts": {
     "build": "modern build"
   },

--- a/scripts/jest-config/package.json
+++ b/scripts/jest-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/jest-config",
   "private": true,
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "main": "jest.config.js",
   "devDependencies": {
     "@swc/core": "^1.2.220",

--- a/scripts/lint-package-json/package.json
+++ b/scripts/lint-package-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scripts/lint-package-json",
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "private": true,
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/prebundle/package.json
+++ b/scripts/prebundle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/prebundle",
   "private": true,
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "main": "./dist/index.js",
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/vitest-config/package.json
+++ b/scripts/vitest-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/vitest-config",
   "private": true,
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/website/builder/package.json
+++ b/website/builder/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@modern-js/builder-website",
-  "version": "1.21.2",
+  "version": "2.0.0-beta.0",
   "main": "index.js",
   "scripts": {
     "dev": "vuepress dev src --temp .temp",

--- a/website/main/package.json
+++ b/website/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-website",
-  "version": "0.0.0",
+  "version": "2.0.0-beta.0",
   "private": true,
   "scripts": {
     "prepare": "sh scripts/sync.sh",


### PR DESCRIPTION

# Release v2.0.0-beta.0



## Features:

- [#2013](https://github.com/modern-js-dev/modern.js/pull/2013) 

  feat(app-tools): improve build logs of dev and build command

  feat(app-tools): 优化 dev 和 build 过程中的日志展示

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat(builder): add output.disableCssModuleExtension config

  feat(builder): 新增 output.disableCssModuleExtension 配置项

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix: tsconfig-paths plugin's new node use old node flag

  fix: tsconfig-paths 插件转换的新节点使用旧节点的 flag

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  refactor: remove @babel/plugin-proposal-function-bind

  refactor: 移除 @babel/plugin-proposal-function-bind

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat(builder): display user friendly progress percentage

  feat(builder): 展示用户友好的进度条进度

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix: compat Hook API in /server namespace

  fix: 在 @modern-js/runtime/server 命名空间下兼容 Hook API

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix(plugin-swc): failed to remove babel-loader

  fix(plugin-swc): 修复未正确移除 babel-loader 的问题

- [#2086](https://github.com/modern-js-dev/modern.js/pull/2086) 

  feat: remove @loadable/component in streaming ssr

  feat: 移除 streaming ssr 中的 @loadable/component 逻辑

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat(builder): ignore externals when target is web worker

  feat(builder): 构建 web worker 产物时忽略 externals 配置

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  perf(builder): remove CSS contents from web-worker outputs

  perf(builder): 移除 web-worker 产物中的 CSS 内容

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: support React18 streaming SSR

  feat: 支持 React18 流式 SSR

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix(builder): source map of CSS files not work

  fix(builder): 修复 CSS 文件的 source map 不生效的问题

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: support completely custom server, export render() api for render single page

  feat: 支持完全自定义 Server，导出 render() 方法用来渲染单个页面

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix(builder): only apply one tsChecker plugin when multiple targets

  fix(builder): 当同时存在多个 target 时，仅启用一个 tsChecker 插件

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix(builder): failed remove css for node/worker target

  fix(builder): 修复 node/worker 产物时未正确移除 CSS 代码的问题

- [#2037](https://github.com/modern-js-dev/modern.js/pull/2037) 

  feat(app-tools): support tools.htmlPlugin config

  feat(app-tools): 支持 tools.htmlPlugin 配置项

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix(builder): typo in dev.progressBar options, quite should be quiet

  fix(builder): 修复 dev.progressBar 的选项拼写错误, quite 应为 quiet

- [#2072](https://github.com/modern-js-dev/modern.js/pull/2072) 

  feat: refactor legacy router support change router config

  feat: 开启 legacy 路由支持修改 router 配置

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: export Hooks type

  feat: 导出 Hooks 类型

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix(builder): incorrect target label when inspect configs

  fix(builder): 修复 inspect configs 时展示的 target 不正确的问题

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix(babel-preset-app): remove useless plugin-transform-destructuring

  fix(babel-preset-app): 移除多余的 plugin-transform-destructuring 插件

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix: ignore the entire distPath for pia ssr bundle

  fix: dist 目录的产物不应该被 ts-node 编译

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix: fix html template of streaming ssr

  fix: 修复流式渲染的 html 模版

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: change Hooks logic

  feat: 修改 Hooks 逻辑

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat(builder): build method support custom compiler

  feat(builder): build 方法支持传入自定义的 compiler 对象

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: add normalize config logic

  feat: 添加处理配置的逻辑

- [#2108](https://github.com/modern-js-dev/modern.js/pull/2108) 

  fix: fix builder-doc broken link

  fix: 修复 builder-doc 中无法跳转的链接

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: modernjs Access builder compiler

  feat: modernjs 接入 builder 构建

- [#2085](https://github.com/modern-js-dev/modern.js/pull/2085) 

  feat(builder): add output.cssModuleLocalIdentName config

  feat(builder): 新增 output.cssModuleLocalIdentName 配置项

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  refactor: move server plugin load logic in `@modern-js/core`

  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑

- [#2114](https://github.com/modern-js-dev/modern.js/pull/2114) 

  feat: inject async js chunk when streaming ssr

  feat: streaming ssr 时, 注入 async 类型的 js chunk

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat(builder): make preset chunk names more readable

  feat(builder): 优化预设 chunk 命名的可读性

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: refactor router with react-router@6.4

  feat: 使用 react-router@6.4 重构路由模块

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix(builder): failed to print correct file sizes

  fix(builder): 修复无法正确输出构建产物体积的问题

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: change type logic

  feat: 修改类型相关的逻辑

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix: filename typo, color.ts --> colors.ts

  fix: 文件名错误，color.ts 修改为 colors.ts

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: change dev menu log

  feat: 修改 dev 菜单展示的内容

- [#2093](https://github.com/modern-js-dev/modern.js/pull/2093) 

  feat(builder): complete utils of tools.webpack

  feat(builder): 补全 tools.webpack 提供的 utils 方法

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  refactor: remove unbundle configs and types

  refactor: 移除 unbundle 相关的配置项和类型定义

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat(server): add `req` and `res` to SSR context

  feat(server): 添加 `req` 和 `res` 到 SSR context 中

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: add ModuleContext

  feat: 添加 ModuleContext

- [#2048](https://github.com/modern-js-dev/modern.js/pull/2048) 

  fix: add builder hooks `beforeBuild` params

  fix: 新增 builder hooks `beforeBuild` 的参数

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat(builder): move part of config types to shared

  feat(builder): 将一部分公共的 config 类型定义下沉到 shared 中

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat(builder): print progress in non-tty environment

  feat(builder): 在非 tty 环境下输出编译进度

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: support nested routes

  feat: 支持嵌套路由

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: add type define and schema for config

  feat: 为配置增加类型定义和 schema

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: support Hook、Middleware new API

  feat: 支持 Hook、Middleware 的新 API

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat(builder): improve webpack config for node target

  feat(builder): 优化 target 为 node 时的 webpack 配置

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix(server): add favicon fallback handler

  fix(server): 添加 favicon 兜底处理逻辑

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat(builder): add api.getHTMLPaths method

  feat(builder): 新增 api.getHTMLPaths 方法

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix(builder): missing source map of inlined chunks

  fix(builder): 修复 inlined chunks 缺少 source map 文件的问题

- [#2052](https://github.com/modern-js-dev/modern.js/pull/2052) 

  chore(plugin-swc): Update tests, add auto detect module type, add pluginLockCorejsVersion

  chore(plugin-swc): 更新单测，加入自动检测模块类型，加入了core-js和@swc/helpers 路径重写功能

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix: remove overmuch `@modernjs/utils` dependency import in ssr runtime & SSR hydrate error

  fix: 去除 ssr 运行时过多的 `@modernjs/utils` 依赖引入 & SSR hydrate 错误

- [#2106](https://github.com/modern-js-dev/modern.js/pull/2106) 

  chore(builder): move mini-css-extract-plugin type to dev dependencies

  chore(builder): 将 mini-css-extract-plugin 类型定义改为 dev dependencies

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: add new and upgrade command

  feat: 添加new 和 upgrade 命令

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  feat: add platform build log

  feat: 添加 platform 构建的 log 内容

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  perf(builder): Using shorter classname in production to reduce bundle size

  perf(builder): 使用更简短的 CSS modules 类名来减少包体积

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix(builder): skip rem plugin when target is node or web worker

  fix(builder): 当构建 node 或 web worker 产物时跳过 rem 插件

- [#1976](https://github.com/modern-js-dev/modern.js/pull/1976) 

  fix(builder): failed to resolve core-js in some cases

  fix(builder): 修复部分情况下无法找到 core-js 的问题

- [#2003](https://github.com/modern-js-dev/modern.js/pull/2003) 

  feat: compile server loader and support handle loader request

  feat: 编译 server loader 并支持处理 loader 的请求

## Bug Fix:

- [#2021](https://github.com/modern-js-dev/modern.js/pull/2021) 

  fix(builder): incorrect ModuleFilenameHelpers path

  fix(builder): 修复 ModuleFilenameHelpers 路径大小写错误

- [#2009](https://github.com/modern-js-dev/modern.js/pull/2009) 

  fix: builder tools.webpackChain config args not match the Modernjs tools.webpackChain

  fix: builder tools.webpackChain 配置传参无法匹配 Modernjs tools.webpackChain

- [#2033](https://github.com/modern-js-dev/modern.js/pull/2033) 

  fix: bff api loader should run before babel loader

  fix: bff 一体化调用的 loader 应该在 babel loader 前执行

- [#2035](https://github.com/modern-js-dev/modern.js/pull/2035) 

  fix(builder): disable mergeLonghand option of cssnano

  fix(builder): 禁用 cssnano 的 mergeLonghand 选项

- [#2111](https://github.com/modern-js-dev/modern.js/pull/2111) 

  fix: fix js chunk injecting location

  fix: 修复 js chunk 注入位置

- [#2082](https://github.com/modern-js-dev/modern.js/pull/2082) 

  fix(builder-plugin-swc): Fix minify plugin includes css.

  fix(builder-plugin-swc): 修复 minify 插件误将css文件加入minify

- [#2095](https://github.com/modern-js-dev/modern.js/pull/2095) 

  fix(builder): esbuild minimize target should be es2015

  fix(builder): 修复 esbuild 压缩时未默认生成 es2015 产物的问题

- [#2014](https://github.com/modern-js-dev/modern.js/pull/2014) 

  fix: repeat register `babel-plugin-lodash`

  fix: 重复注册 `babel-plugin-lodash`

- [#2071](https://github.com/modern-js-dev/modern.js/pull/2071) 

  fix(builder): should emit fallback asset to static/media dir

  fix(builder): 修复 fallback 后的文件未输出到 static/media 目录的问题

- [#2034](https://github.com/modern-js-dev/modern.js/pull/2034) 

  fix: specify builder compiler framework

  fix: 指明 builder 构建时框架

- [#2116](https://github.com/modern-js-dev/modern.js/pull/2116) 

  fix(builder): inline chunk plugin should not change script inject position

  fix(builder): inline chunk 插件不应该修改 script 插入位置

- [#2092](https://github.com/modern-js-dev/modern.js/pull/2092) 

  fix: change plugin-router-legacy exports field for node environment

  fix: 修改 plugin-router-legacy 的 exports 字段

- [#2016](https://github.com/modern-js-dev/modern.js/pull/2016) 

  feat: bump esbuild from 0.14.38 to 0.15.7

  feat: 将 esbuild 从 0.14.38 版本升级至 0.15.7 版本

- [#2012](https://github.com/modern-js-dev/modern.js/pull/2012) 

  fix(builder): incorrect rules after enabling asset fallback

  fix(builder): 修复开启 asset fallback 后 webpack rules 不正确的问题

- [#2025](https://github.com/modern-js-dev/modern.js/pull/2025) 

  fix: clear distDirectory in prepare hook & inject data loader plugin to server

  fix: 在 prepare hook 中清理 dist 目录，并且向 server 中注入 data loader plugin

- [#2010](https://github.com/modern-js-dev/modern.js/pull/2010) 

  fix(app-tools): failed to run inspect command

  fix(app-tools): 修复运行 inspect 命令失败的问题

- [#2094](https://github.com/modern-js-dev/modern.js/pull/2094) 

  fix(server-utils): incorrect babel-compiler version

  fix(server-utils): 修复引用错误的 babel-compiler 版本的问题

- [#2001](https://github.com/modern-js-dev/modern.js/pull/2001) 

  fix: function extname should not return array

  fix: 函数 extname 不应该返回一个数组

- [#2101](https://github.com/modern-js-dev/modern.js/pull/2101) chore: v2

- [#2024](https://github.com/modern-js-dev/modern.js/pull/2024) 

  fix(app-tools): compat legacy resolve behavior

  fix(app-tools): 兼容旧版本 node_modules 解析逻辑

- [#2062](https://github.com/modern-js-dev/modern.js/pull/2062) 

  fix: builder plugin setup can't get config

  fix: builder 插件在 setup 阶段无法拿到 config

- [#2070](https://github.com/modern-js-dev/modern.js/pull/2070) 

  fix: process does't exit when exec command

  fix: 修复执行命令时进程未退出的问题

- [#2065](https://github.com/modern-js-dev/modern.js/pull/2065) 

  fix(builder): should emit app icon to static/image dir

  fix(builder): 修复 app icon 未被输出到 static/image 目录的问题

- [#2080](https://github.com/modern-js-dev/modern.js/pull/2080) 

  fix: `modern-js/app-tools` pass error config to builder.

  fix: `modern-js/app-tools` 传递错误的 config 给 builder.

- [#2059](https://github.com/modern-js-dev/modern.js/pull/2059) 

  fix: add html-webpack-plugin `__internal__` options, for bottom template

  fix: 为了 bottom template, 增加 `html-webpack-plugin` `__internal__` 配置项，

- [#2011](https://github.com/modern-js-dev/modern.js/pull/2011) 

  fix: generator bundle

  fix: 生成器打包

- [#2110](https://github.com/modern-js-dev/modern.js/pull/2110) 

  fix(dev-server): isDepsExists add non pkgPath judege

  修复: isDepsExists 方法添加 package.json 不存在的兜底

- [#2076](https://github.com/modern-js-dev/modern.js/pull/2076) 

  fix: use consistent alias type and default value across packages

  fix: 在各个包中使用一致的 alias 类型定义和默认值

