### PR TITLE
fix(builder): adjust default split chunk group

### DIFF
--- a/.changeset/popular-steaks-dress.md
+++ b/.changeset/popular-steaks-dress.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): adjust default split chunk group
+
+fix(builder): 调整默认的 split chunk 分组

--- a/packages/builder/builder-webpack-provider/src/plugins/splitChunks.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/splitChunks.ts
@@ -62,10 +62,8 @@ function splitByExperience(ctx: SplitChunksContext): SplitChunks {
     antd: /[\\/]antd[\\/]/,
     semi: /[\\/]@ies\/semi|@douyinfe\/semi[\\/]/,
     arco: /[\\/]@arco-design[\\/]/,
-    babel:
-      /[\\/]@babel\/runtime|@babel\/runtime-corejs2|@babel\/runtime-corejs3[\\/]/,
     lodash: /[\\/]lodash|lodash-es[\\/]/,
-    corejs: /[\\/]core-js[\\/]/,
+    polyfill: /[\\/]core-js|@babel\/runtime[\\/]/,
   };
 
   Object.entries(SPLIT_EXPERIENCE_LIST).forEach(([name, test]) => {

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/splitChunks.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/splitChunks.test.ts.snap
@@ -90,23 +90,17 @@ exports[`plugins/splitChunks > should set split-by-experience config 1`] = `
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]@arco-design\\[\\\\\\\\/\\]/,
         },
-        "lib-babel": {
-          "name": "lib-babel",
-          "priority": 0,
-          "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]@babel\\\\/runtime\\|@babel\\\\/runtime-corejs2\\|@babel\\\\/runtime-corejs3\\[\\\\\\\\/\\]/,
-        },
-        "lib-corejs": {
-          "name": "lib-corejs",
-          "priority": 0,
-          "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]core-js\\[\\\\\\\\/\\]/,
-        },
         "lib-lodash": {
           "name": "lib-lodash",
           "priority": 0,
           "reuseExistingChunk": true,
           "test": /\\[\\\\\\\\/\\]lodash\\|lodash-es\\[\\\\\\\\/\\]/,
+        },
+        "lib-polyfill": {
+          "name": "lib-polyfill",
+          "priority": 0,
+          "reuseExistingChunk": true,
+          "test": /\\[\\\\\\\\/\\]core-js\\|@babel\\\\/runtime\\[\\\\\\\\/\\]/,
         },
         "lib-react": {
           "name": "lib-react",

--- a/website/builder/src/en/guide/advanced/split-chunk.md
+++ b/website/builder/src/en/guide/advanced/split-chunk.md
@@ -24,11 +24,10 @@ Based on past experience, built-in split groups include:
 
 - React (react, react-dom)
 - Router (react-router, react-router-dom, history)
+- Polyfill (core-js, @babel/runtime)
 - Semi (@ies/semi, @douyinfe/semi-ui)
 - Arco (@arco-design/web-react)
-- Babel Runtime (@babel/runtime, @babel/runtime-corejs2, @babel/runtime-corejs3)
 - Lodash (lodash, lodash-es)
-- CoreJS (core-js)
 
 This strategy groups commonly used packages and then splits them into separate chunks. Generally, the number of chunks is not large, which is suitable for most applications and is also our recommended  strategy.
 

--- a/website/builder/src/zh/guide/advanced/split-chunk.md
+++ b/website/builder/src/zh/guide/advanced/split-chunk.md
@@ -23,13 +23,12 @@ Builder 中包括如下的拆包策略：
 
 根据以往的经验，内置的拆分组包括：
 
-- React (react、react-dom)
-- Router (react-router、react-router-dom、history)
-- Semi (@ies/semi、@douyinfe/semi-ui)
+- React (react, react-dom)
+- Router (react-router, react-router-dom, history)
+- Polyfill (core-js, @babel/runtime)
+- Semi (@ies/semi, @douyinfe/semi-ui)
 - Arco (@arco-design/web-react)
-- Babel Runtime (@babel/runtime、@babel/runtime-corejs2、@babel/runtime-corejs3)
-- Lodash (lodash、lodash-es)
-- CoreJS (core-js)
+- Lodash (lodash, lodash-es)
 
 这种拆包策略将常用的包进行分组，然后拆分为单独的 Chunk，一般 Chunk 的数量不会很多，适合绝大部分应用，同时也是我们推荐的拆包策略。
 


### PR DESCRIPTION
# PR Details

## Description

Adjust default split chunk group:

- remove the `babel` group, because the `@babel/runtime` is only 10KB after minified, the minSize of split chunk is `20kb`, so the `babel` group can not be splitted.

![image](https://user-images.githubusercontent.com/7237365/203993239-670a58fd-0ed6-48f5-9d16-0a64aefb056e.png)

<img width="632" alt="截屏2022-11-25 下午9 06 27" src="https://user-images.githubusercontent.com/7237365/203993107-4ce91ca9-c9ac-43b9-8ff2-a67fe65f0952.png">

- Merge `core-js` and `babel` into a new `polyfill` group.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
