### PR TITLE
fix(builder): invalidate cache when buildDependencies changed

### DIFF
--- a/.changeset/hungry-humans-cough.md
+++ b/.changeset/hungry-humans-cough.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): invalidate cache when buildDependencies changed
+
+fix(builder): 修复当 buildDependencies 变化时构建缓存未失效的问题

--- a/packages/builder/builder-webpack-provider/src/plugins/cache.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/cache.ts
@@ -1,23 +1,66 @@
-import { join } from 'path';
-import { isFileExists } from '@modern-js/builder-shared';
+import { isAbsolute, join } from 'path';
+import {
+  BuildCacheOptions,
+  BuilderContext,
+  isFileExists,
+} from '@modern-js/builder-shared';
 import type { BuilderPlugin } from '../types';
+
+async function validateCache(
+  cacheDirectory: string,
+  buildDependencies: Record<string, string[]>,
+) {
+  const { fs } = await import('@modern-js/utils');
+  const configFile = join(cacheDirectory, 'buildDependencies.json');
+
+  if (await isFileExists(configFile)) {
+    const prevBuildDependencies = await fs.readJSON(configFile);
+
+    if (
+      JSON.stringify(prevBuildDependencies) ===
+      JSON.stringify(buildDependencies)
+    ) {
+      return;
+    }
+
+    /**
+     * If the filenames in the buildDependencies are changed, webpack will not invalidate the previous cache.
+     * So we need to remove the cache directory to make sure the cache is invalidated.
+     */
+    await fs.remove(cacheDirectory);
+  }
+
+  await fs.outputJSON(configFile, buildDependencies);
+}
+
+function getCacheDirectory(
+  { cacheDirectory }: BuildCacheOptions,
+  context: BuilderContext,
+) {
+  if (cacheDirectory) {
+    return isAbsolute(cacheDirectory)
+      ? cacheDirectory
+      : join(context.rootPath, cacheDirectory);
+  }
+  return join(context.cachePath, 'webpack');
+}
 
 export const PluginCache = (): BuilderPlugin => ({
   name: 'builder-plugin-cache',
 
   setup(api) {
     api.modifyWebpackChain(async (chain, { target, env }) => {
-      const buildCacheOption = api.getNormalizedConfig().performance.buildCache;
-      if (buildCacheOption === false) {
+      const { buildCache } = api.getNormalizedConfig().performance;
+
+      if (buildCache === false) {
         chain.cache(false);
         return;
       }
-      const buildCacheConfig =
-        typeof buildCacheOption === 'boolean' ? {} : buildCacheOption;
-      const { context } = api;
 
-      const cacheDirectory =
-        buildCacheConfig.cacheDirectory || join(context.cachePath, 'webpack');
+      const { context } = api;
+      const cacheConfig = typeof buildCache === 'boolean' ? {} : buildCache;
+
+      const cacheDirectory = getCacheDirectory(cacheConfig, context);
       const rootPackageJson = join(context.rootPath, 'package.json');
       const browserslistConfig = join(context.rootPath, '.browserslistrc');
 
@@ -37,6 +80,8 @@ export const PluginCache = (): BuilderPlugin => ({
       if (await isFileExists(browserslistConfig)) {
         buildDependencies.browserslistrc = [browserslistConfig];
       }
+
+      await validateCache(cacheDirectory, buildDependencies);
 
       chain.cache({
         // The default cache name of webpack is '${name}-${env}', and the `name` is `default` by default.

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/cache.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/cache.test.ts.snap
@@ -15,6 +15,8 @@ exports[`plugins/cache > should add cache config correctly 1`] = `
 }
 `;
 
+exports[`plugins/cache > should custom cache directory by user 1`] = `"<ROOT>/node_modules/.cache/tmp"`;
+
 exports[`plugins/cache > should watch framework config change 1`] = `
 {
   "cache": {

--- a/packages/builder/builder-webpack-provider/tests/plugins/cache.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/cache.test.ts
@@ -52,9 +52,9 @@ describe('plugins/cache', () => {
     });
 
     const config = await builder.unwrapWebpackConfig();
-    expect((config.cache as { cacheDirectory?: string }).cacheDirectory).toBe(
-      customCacheDirectory,
-    );
+    expect(
+      (config.cache as { cacheDirectory?: string }).cacheDirectory,
+    ).toMatchSnapshot();
   });
 
   it('should disable cache', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3753,6 +3753,31 @@ importers:
       '@types/react-dom': 18.0.6
       typescript: 4.7.4
 
+  tests/e2e/webpack-builder/cache:
+    specifiers:
+      '@modern-js/builder-shared': workspace:*
+      '@modern-js/builder-webpack-provider': workspace:*
+      '@modern-js/e2e': workspace:*
+      '@modern-js/utils': workspace:*
+      '@types/node': ^14
+      '@types/react': ^18
+      '@types/react-dom': ^18
+      react: ^18
+      react-dom: ^18
+      typescript: ^4
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    devDependencies:
+      '@modern-js/builder-shared': link:../../../../packages/builder/builder-shared
+      '@modern-js/builder-webpack-provider': link:../../../../packages/builder/builder-webpack-provider
+      '@modern-js/e2e': link:../../../../packages/toolkit/e2e
+      '@modern-js/utils': link:../../../../packages/toolkit/utils
+      '@types/node': 14.18.21
+      '@types/react': 18.0.21
+      '@types/react-dom': 18.0.6
+      typescript: 4.7.4
+
   tests/e2e/webpack-builder/css-modules:
     specifiers:
       '@modern-js/builder': workspace:*

--- a/tests/e2e/webpack-builder/cache/index.test.ts
+++ b/tests/e2e/webpack-builder/cache/index.test.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import { fs } from '@modern-js/utils';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { createStubBuilder } from '@modern-js/builder-webpack-provider/stub';
+
+test('should save the buildDependencies to cache directory', async () => {
+  const builder = await createStubBuilder({
+    webpack: true,
+    entry: { index: path.resolve('./src/index.js') },
+    configPath: __dirname,
+  });
+  await builder.build();
+
+  const configFile = path.resolve(
+    './node_modules/.cache/webpack/buildDependencies.json',
+  );
+  const buildDependencies = await fs.readJSON(configFile);
+  expect(Object.keys(buildDependencies)).toEqual(['packageJson', 'config']);
+});

--- a/tests/e2e/webpack-builder/cache/package.json
+++ b/tests/e2e/webpack-builder/cache/package.json
@@ -1,0 +1,22 @@
+{
+  "private": true,
+  "name": "@e2e/webpack-builder-progress",
+  "version": "0.1.0",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@modern-js/e2e": "workspace:*",
+    "@modern-js/builder-shared": "workspace:*",
+    "@modern-js/builder-webpack-provider": "workspace:*",
+    "@modern-js/utils": "workspace:*",
+    "@types/node": "^14",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "typescript": "^4"
+  }
+}

--- a/tests/e2e/webpack-builder/cache/src/index.js
+++ b/tests/e2e/webpack-builder/cache/src/index.js
@@ -1,0 +1,1 @@
+console.log('foo');

--- a/tests/e2e/webpack-builder/cache/tsconfig.json
+++ b/tests/e2e/webpack-builder/cache/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": ["src", "*.test.ts"]
+}


### PR DESCRIPTION
# PR Details

## Description

Invalidate webpack cache when buildDependencies changed.

If the filenames in the buildDependencies are changed, webpack will not invalidate the previous cache. So we need to remove the cache directory to make sure the cache is invalidated.


```bash
# generate cache
modern build

# should not hit the previous cache
modern build --config ./other-modern.config.ts
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
