### PR TITLE
chore: fix exclude-less integration test

### DIFF
--- a/tests/e2e/webpack-builder/cache/package.json
+++ b/tests/e2e/webpack-builder/cache/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@e2e/webpack-builder-progress",
+  "name": "@e2e/webpack-builder-cache",
   "version": "0.1.0",
   "scripts": {
     "test": "playwright test"

--- a/tests/integration/css/fixtures/exclude-less/modern.config.js
+++ b/tests/integration/css/fixtures/exclude-less/modern.config.js
@@ -1,10 +1,10 @@
-/* eslint-disable import/no-commonjs */
 module.exports = {
   tools: {
     less: (opts, { addExcludes }) => {
       addExcludes([/b\.less$/]);
     },
   },
+  output: {
+    enableAssetFallback: true,
+  },
 };
-
-/* eslint-enable import/no-commonjs */

--- a/tests/integration/css/fixtures/exclude-sass/modern.config.js
+++ b/tests/integration/css/fixtures/exclude-sass/modern.config.js
@@ -1,10 +1,10 @@
-/* eslint-disable import/no-commonjs */
 module.exports = {
   tools: {
     sass: (opts, { addExcludes }) => {
       addExcludes([/b\.scss$/]);
     },
   },
+  output: {
+    enableAssetFallback: true,
+  },
 };
-
-/* eslint-enable import/no-commonjs */


### PR DESCRIPTION
# PR Details

## Description

Fix exclude-less integration test, the `output.enableAssetFallback` is default `false` now.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
