### PR TITLE
feat(builder): increase target node version to 14

### DIFF
--- a/.changeset/cyan-beers-behave.md
+++ b/.changeset/cyan-beers-behave.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+feat(builder): increase target node version to 14
+
+feat(builder): 提升 node 构建产物的目标环境为 node 14

--- a/packages/builder/builder-shared/src/constants.ts
+++ b/packages/builder/builder-shared/src/constants.ts
@@ -7,7 +7,7 @@ export const DEFAULT_MOUNT_ID = 'root';
 
 export const DEFAULT_BROWSERSLIST = {
   web: ['> 0.01%', 'not dead', 'not op_mini all'],
-  node: ['node >= 12'],
+  node: ['node >= 14'],
   'web-worker': ['> 0.01%', 'not dead', 'not op_mini all'],
   'modern-web': [
     'chrome > 61',

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -377,7 +377,7 @@ exports[`plugins/babel > should adjust browserslist when target is node 1`] = `
                     "modules": false,
                     "shippedProposals": false,
                     "targets": [
-                      "node >= 12",
+                      "node >= 14",
                     ],
                     "useBuiltIns": false,
                   },
@@ -498,7 +498,7 @@ exports[`plugins/babel > should adjust browserslist when target is node 1`] = `
                     "modules": false,
                     "shippedProposals": false,
                     "targets": [
-                      "node >= 12",
+                      "node >= 14",
                     ],
                     "useBuiltIns": false,
                   },


### PR DESCRIPTION
# PR Details

## Description

The default node version of Modern.js 2.0 is 16.x, and the minimal required node version is 14.x. So we can increase the default node version of builder node target to 14.x.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
