### PR TITLE
fix: using DeepReadonly instead of deepFreezed

### DIFF
--- a/.changeset/cuddly-radios-destroy.md
+++ b/.changeset/cuddly-radios-destroy.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix: using DeepReadonly instead of deepFreezed
+
+fix: 使用 DeepReadonly 来代替 deepFreezed

--- a/packages/builder/builder-rspack-provider/src/core/createContext.ts
+++ b/packages/builder/builder-rspack-provider/src/core/createContext.ts
@@ -1,6 +1,5 @@
 import { join } from 'path';
 import {
-  deepFreezed,
   isFileExists,
   createContextByConfig,
   type CreateBuilderOptions,
@@ -38,7 +37,7 @@ export async function createContext(
     hooks: initHooks(),
     configValidatingTask,
     config: { ...builderConfig },
-    originalConfig: deepFreezed(userBuilderConfig),
+    originalConfig: userBuilderConfig,
     tsconfigPath: (await isFileExists(tsconfigPath)) ? tsconfigPath : undefined,
   };
 }

--- a/packages/builder/builder-rspack-provider/src/core/initConfigs.ts
+++ b/packages/builder/builder-rspack-provider/src/core/initConfigs.ts
@@ -1,7 +1,6 @@
 import {
   debug,
   isDebug,
-  deepFreezed,
   type PluginStore,
   type InspectConfigOptions,
   type CreateBuilderOptions,
@@ -17,7 +16,8 @@ async function modifyBuilderConfig(context: Context) {
   const [modified] = await context.hooks.modifyBuilderConfigHook.call(
     context.config,
   );
-  context.config = deepFreezed(modified);
+  context.config = modified;
+
   debug('modify builder config done');
 }
 
@@ -41,7 +41,7 @@ export async function initConfigs({
   });
 
   await modifyBuilderConfig(context);
-  context.normalizedConfig = deepFreezed(normalizeConfig(context.config));
+  context.normalizedConfig = normalizeConfig(context.config);
 
   const targets = ensureArray(builderOptions.target);
   const rspackConfigs = await Promise.all(

--- a/packages/builder/builder-rspack-provider/src/types/context.ts
+++ b/packages/builder/builder-rspack-provider/src/types/context.ts
@@ -1,4 +1,4 @@
-import type { BuilderContext } from '@modern-js/builder-shared';
+import type { BuilderContext, DeepReadonly } from '@modern-js/builder-shared';
 import type { Hooks } from '../core/initHooks';
 import type { BuilderConfig, NormalizedConfig } from './config';
 import type { BuilderPluginAPI } from './plugin';
@@ -8,13 +8,13 @@ export type Context = BuilderContext & {
   /** All hooks. */
   hooks: Readonly<Hooks>;
   /** Current builder config. */
-  config: Readonly<BuilderConfig>;
+  config: DeepReadonly<BuilderConfig>;
   /** The async task to validate schema of config. */
   configValidatingTask: Promise<void>;
   /** The original builder config passed from the createBuilder method. */
-  originalConfig: Readonly<BuilderConfig>;
+  originalConfig: DeepReadonly<BuilderConfig>;
   /** The normalized builder config. */
-  normalizedConfig?: Readonly<NormalizedConfig>;
+  normalizedConfig?: DeepReadonly<NormalizedConfig>;
   /** The plugin API. */
   pluginAPI?: BuilderPluginAPI;
 };

--- a/packages/builder/builder-shared/src/createContext.ts
+++ b/packages/builder/builder-shared/src/createContext.ts
@@ -2,11 +2,11 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { pick } from './pick';
 import {
+  DeepReadonly,
   BuilderContext,
   CreateBuilderOptions,
   NormalizedSharedOutputConfig,
 } from './types';
-import { deepFreezed } from './utils';
 import { getAbsoluteDistPath } from './fs';
 
 /**
@@ -42,7 +42,7 @@ export function createContextByConfig(
 
 export function createPublicContext(
   context: BuilderContext,
-): Readonly<BuilderContext> {
+): DeepReadonly<BuilderContext> {
   const ctx = pick(context, [
     'entry',
     'target',
@@ -55,5 +55,5 @@ export function createPublicContext(
     'configPath',
     'tsconfigPath',
   ]);
-  return deepFreezed(ctx);
+  return ctx;
 }

--- a/packages/builder/builder-shared/src/types/utils.ts
+++ b/packages/builder/builder-shared/src/types/utils.ts
@@ -18,3 +18,7 @@ export type ChainedConfig<Config, Utils = unknown> = ArrayOrNot<
       ? (config: Config) => Config | void
       : (config: Config, utils: Utils) => Config | void)
 >;
+
+export type DeepReadonly<T> = keyof T extends never
+  ? T
+  : { readonly [k in keyof T]: DeepReadonly<T[k]> };

--- a/packages/builder/builder-shared/src/utils.ts
+++ b/packages/builder/builder-shared/src/utils.ts
@@ -1,22 +1,9 @@
-import _ from '@modern-js/utils/lodash';
 import {
   CSS_MODULES_REGEX,
   GLOBAL_CSS_REGEX,
   NODE_MODULES_REGEX,
 } from './constants';
 import type { SharedBuilderConfig } from './types';
-
-export function deepFreezed<T>(obj: T): T {
-  if (!_.isObject(obj) || _.isNull(obj)) {
-    return obj;
-  }
-  if (Array.isArray(obj)) {
-    obj.forEach(deepFreezed);
-  } else {
-    Object.values(obj).forEach(deepFreezed);
-  }
-  return Object.freeze(obj);
-}
 
 export const extendsType =
   <T>() =>

--- a/packages/builder/builder-webpack-provider/src/core/createContext.ts
+++ b/packages/builder/builder-webpack-provider/src/core/createContext.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import {
   debug,
-  deepFreezed,
   isFileExists,
   type CreateBuilderOptions,
   createContextByConfig,
@@ -33,7 +32,7 @@ export function createPrimaryContext(
     hooks: initHooks(),
     configValidatingTask,
     config: { ...builderConfig },
-    originalConfig: deepFreezed(userBuilderConfig),
+    originalConfig: userBuilderConfig,
   };
 }
 

--- a/packages/builder/builder-webpack-provider/src/core/initConfigs.ts
+++ b/packages/builder/builder-webpack-provider/src/core/initConfigs.ts
@@ -1,7 +1,6 @@
 import {
   debug,
   isDebug,
-  deepFreezed,
   type PluginStore,
   type InspectConfigOptions,
   type CreateBuilderOptions,
@@ -17,7 +16,7 @@ async function modifyBuilderConfig(context: Context) {
   const [modified] = await context.hooks.modifyBuilderConfigHook.call(
     context.config,
   );
-  context.config = deepFreezed(modified);
+  context.config = modified;
   debug('modify builder config done');
 }
 
@@ -41,7 +40,11 @@ export async function initConfigs({
   });
 
   await modifyBuilderConfig(context);
-  context.normalizedConfig = deepFreezed(normalizeConfig(context.config));
+  context.normalizedConfig = normalizeConfig(context.config);
+
+  if (context.config.dev) {
+    context.config.dev.assetPrefix = '1';
+  }
 
   const targets = ensureArray(builderOptions.target);
   const webpackConfigs = await Promise.all(

--- a/packages/builder/builder-webpack-provider/src/plugins/css.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/css.ts
@@ -8,7 +8,7 @@ import {
   type BuilderTarget,
   type BuilderContext,
 } from '@modern-js/builder-shared';
-import _, { merge as deepMerge } from '@modern-js/utils/lodash';
+import { merge as deepMerge } from '@modern-js/utils/lodash';
 import type {
   WebpackChain,
   BuilderPlugin,
@@ -122,8 +122,7 @@ export async function applyBaseCSSRule(
         },
         sourceMap: enableSourceMap,
       },
-      // postcss-loader will modify config
-      _.cloneDeep(config.tools.postcss || {}),
+      config.tools.postcss || {},
       utils,
     );
     if (extraPlugins.length) {

--- a/packages/builder/builder-webpack-provider/src/types/context.ts
+++ b/packages/builder/builder-webpack-provider/src/types/context.ts
@@ -1,4 +1,4 @@
-import type { BuilderContext } from '@modern-js/builder-shared';
+import type { BuilderContext, DeepReadonly } from '@modern-js/builder-shared';
 import type { Hooks } from '../core/initHooks';
 import type { BuilderConfig, NormalizedConfig } from './config';
 import type { BuilderPluginAPI } from './plugin';
@@ -8,13 +8,13 @@ export type Context = BuilderContext & {
   /** All hooks. */
   hooks: Readonly<Hooks>;
   /** Current builder config. */
-  config: Readonly<BuilderConfig>;
+  config: DeepReadonly<BuilderConfig>;
   /** The async task to validate schema of config. */
   configValidatingTask: Promise<void>;
   /** The original builder config passed from the createBuilder method. */
-  originalConfig: Readonly<BuilderConfig>;
+  originalConfig: DeepReadonly<BuilderConfig>;
   /** The normalized builder config. */
-  normalizedConfig?: Readonly<NormalizedConfig>;
+  normalizedConfig?: DeepReadonly<NormalizedConfig>;
   /** The plugin API. */
   pluginAPI?: BuilderPluginAPI;
 };


### PR DESCRIPTION
# PR Details

## Description

Using DeepReadonly instead of deepFreezed, because deepFreezed may break the postcss or maybe another tools. We use a `DeepReadonly` type instead. It can also improve the runtime performance.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
