### PR TITLE
fix(app-tools): dev.startUrl not work

### DIFF
--- a/.changeset/slimy-icons-doubt.md
+++ b/.changeset/slimy-icons-doubt.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix(app-tools): dev.startUrl not work
+
+fix(app-tools): 修复 dev.startUrl 不生效的问题

--- a/packages/solutions/app-tools/src/builder/index.ts
+++ b/packages/solutions/app-tools/src/builder/index.ts
@@ -87,9 +87,8 @@ export function createBuilderProviderConfig(
     },
     output,
     dev: {
+      ...normalizedConfig.dev,
       port: normalizedConfig.server?.port,
-      https: normalizedConfig.dev.https,
-      assetPrefix: normalizedConfig.dev.assetPrefix,
     },
     html: htmlConfig,
     performance: {

--- a/packages/solutions/app-tools/src/types/config/dev.ts
+++ b/packages/solutions/app-tools/src/types/config/dev.ts
@@ -1,10 +1,11 @@
 import type { BuilderConfig } from '@modern-js/builder-webpack-provider';
 
-type BuilderEnvConfig = Required<BuilderConfig>['dev'];
+type BuilderDevConfig = Required<BuilderConfig>['dev'];
 
 export type DevProxyOptions = string | Record<string, string>;
-export interface DevUserConfig
-  extends Pick<BuilderEnvConfig, 'assetPrefix' | 'https'> {
+
+// dev.port is omitted, using server.port instead
+export interface DevUserConfig extends Omit<BuilderDevConfig, 'port'> {
   /**
    * The configuration of `dev.proxy` is provided by `proxy` plugin.
    * Please use `yarn new` or `pnpm new` to enable the corresponding capability.


### PR DESCRIPTION
# PR Details

## Description

Fix dev.startUrl not work, inherit all dev configs from builder (except dev.port).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
