### PR TITLE
fix(runtime): apply babel-plugin-ssr-loader-id when SSR is not used

### DIFF
--- a/.changeset/happy-laws-ring.md
+++ b/.changeset/happy-laws-ring.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(runtime): apply babel-plugin-ssr-loader-id when SSR is not used
+
+fix(runtime): 在未启动 SSR 时需要注册 babel-plugin-ssr-loader-id

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -100,17 +100,15 @@ export default (): CliPlugin<AppTools> => ({
             },
 
             babel: (config: any) => {
-              const userConfig = api.useResolvedConfigContext();
-              if (isUseSSRBundle(userConfig)) {
-                config.plugins.push(
-                  path.join(__dirname, './babel-plugin-ssr-loader-id'),
-                );
+              // Add id for useLoader method
+              // can be used both in client and server
+              config.plugins.push(
+                path.join(__dirname, './babel-plugin-ssr-loader-id'),
+              );
 
-                if (hasStringSSREntry(userConfig)) {
-                  config.plugins.push(
-                    require.resolve('@loadable/babel-plugin'),
-                  );
-                }
+              const userConfig = api.useResolvedConfigContext();
+              if (isUseSSRBundle(userConfig) && hasStringSSREntry(userConfig)) {
+                config.plugins.push(require.resolve('@loadable/babel-plugin'));
               }
             },
           },

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -100,8 +100,8 @@ export default (): CliPlugin<AppTools> => ({
             },
 
             babel: (config: any) => {
-              // Add id for useLoader method
-              // can be used both in client and server
+              // Add id for useLoader method,
+              // The useLoader can be used even if the SSR is not enabled
               config.plugins.push(
                 path.join(__dirname, './babel-plugin-ssr-loader-id'),
               );


### PR DESCRIPTION
# PR Details

## Description

The useLoader can be used even if the SSR is not enabled, so we should always register the `babel-plugin-ssr-loader-id`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
