### PR TITLE
feat(builder): export type of hook callback functions

### DIFF
--- a/.changeset/witty-mugs-repeat.md
+++ b/.changeset/witty-mugs-repeat.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+feat(builder): export type of hook callback functions
+
+feat(builder): 导出 hook 回调函数的类型

--- a/packages/builder/builder-rspack-provider/src/index.ts
+++ b/packages/builder/builder-rspack-provider/src/index.ts
@@ -1,4 +1,11 @@
 export { builderRspackProvider } from './provider';
 export type { BuilderRspackProvider } from './provider';
 
-export type { BuilderConfig, NormalizedConfig } from './types';
+export type {
+  // Config Types
+  BuilderConfig,
+  NormalizedConfig,
+
+  // Hook Callback Types
+  ModifyRspackConfigFn,
+} from './types';

--- a/packages/builder/builder-webpack-provider/src/index.ts
+++ b/packages/builder/builder-webpack-provider/src/index.ts
@@ -18,6 +18,10 @@ export type {
   PerformanceConfig,
   ExperimentsConfig,
 
+  // Hook Callback Types
+  ModifyWebpackChainFn,
+  ModifyWebpackConfigFn,
+
   // Third Party Types
   webpack,
   WebpackChain,

--- a/packages/builder/builder/src/index.ts
+++ b/packages/builder/builder/src/index.ts
@@ -10,4 +10,15 @@ export type {
   BuilderInstance,
   CreateBuilderOptions,
   InspectConfigOptions,
+
+  // Hook Callback Types
+  OnExitFn,
+  OnAfterBuildFn,
+  OnAfterCreateCompilerFn,
+  OnAfterStartDevServerFn,
+  OnBeforeBuildFn,
+  OnBeforeStartDevServerFn,
+  OnBeforeCreateCompilerFn,
+  OnDevCompileDoneFn,
+  ModifyBuilderConfigFn,
 } from '@modern-js/builder-shared';


### PR DESCRIPTION
# PR Details

Export type of hook callback functions.

```ts
import type { ModifyWebpackChainFn } from '@modern-js/builder-webpack-provider';

const fn: ModifyWebpackChainFn = (chain) => {
  chain.devtool(false);
}

api.modifyWebpackChain(fn);
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
