### PR TITLE
Release v2.0.0-beta.4

### DIFF
--- a/packages/builder/builder-doc/package.json
+++ b/packages/builder/builder-doc/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/builder/builder-rspack-provider/package.json
+++ b/packages/builder/builder-rspack-provider/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
@@ -51,7 +51,7 @@
     "typescript": "^4"
   },
   "peerDependencies": {
-    "@modern-js/e2e": "workspace:^2.0.0-beta.3"
+    "@modern-js/e2e": "workspace:^2.0.0-beta.4"
   },
   "peerDependenciesMeta": {
     "@modern-js/e2e": {

--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
@@ -113,7 +113,7 @@
     "typescript": "^4"
   },
   "peerDependencies": {
-    "@modern-js/e2e": "workspace:^2.0.0-beta.3"
+    "@modern-js/e2e": "workspace:^2.0.0-beta.4"
   },
   "peerDependenciesMeta": {
     "@modern-js/e2e": {

--- a/packages/builder/builder/package.json
+++ b/packages/builder/builder/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-esbuild/package.json
+++ b/packages/builder/plugin-esbuild/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-image-compress/package.json
+++ b/packages/builder/plugin-image-compress/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-node-polyfill/package.json
+++ b/packages/builder/plugin-node-polyfill/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-swc/package.json
+++ b/packages/builder/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/builder-plugin-swc",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "SWC plugin for builder in Modern.js",
   "main": "./dist/index.js",
   "types": "./src/index.ts",

--- a/packages/cli/babel-preset-app/CHANGELOG.md
+++ b/packages/cli/babel-preset-app/CHANGELOG.md
@@ -1,5 +1,52 @@
 # @modern-js/babel-preset-app
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- a7c6883: fix: only register babel-plugin-ssr-loader-id when SSR is enabled
+
+  fix: 仅在开启 SSR 的场景下注册 babel-plugin-ssr-loader-id
+
+- decfcd989d: fix(babel-preset-app): remove useless plugin-transform-destructuring
+
+  fix(babel-preset-app): 移除多余的 plugin-transform-destructuring 插件
+
+- 7b7d12c: refactor: Substract getCorejsVersion to the util package, so that swc plugin can reuse it.
+  refactor: 将 getCorejsVersion 提取到 util 包，让 swc 插件可以复用其逻辑
+- fd1d9fd: fix: can not resolve core-js when compile third party packages
+
+  fix: 修复编译三方包时无法找到 core-js 的问题
+
+- Updated dependencies [27c0151e8c]
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [67472ca]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/babel-preset-base@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/babel-preset-app/package.json
+++ b/packages/cli/babel-preset-app/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/babel-preset-base/CHANGELOG.md
+++ b/packages/cli/babel-preset-base/CHANGELOG.md
@@ -1,5 +1,47 @@
 # @modern-js/babel-preset-base
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 27c0151e8c: refactor: remove @babel/plugin-proposal-function-bind
+
+  refactor: 移除 @babel/plugin-proposal-function-bind
+
+- 67472ca: fix: move babel-plugin-marcos to plugin-tailwindcss
+
+  fix: 将 babel-plugin-marcos 依赖移动到 plugin-tailwindcss 中
+
+- ea7cf06: chore: bump webpack/babel-loader/postcss-loader/tsconfig-paths
+
+  chore: 升级 webpack/babel-loader/postcss-loader/tsconfig-paths 版本
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/babel-preset-base/package.json
+++ b/packages/cli/babel-preset-base/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/cli/babel-preset-lib/CHANGELOG.md
+++ b/packages/cli/babel-preset-lib/CHANGELOG.md
@@ -1,5 +1,38 @@
 # @modern-js/babel-preset-lib
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [27c0151e8c]
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [67472ca]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/babel-preset-base@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/babel-preset-lib/package.json
+++ b/packages/cli/babel-preset-lib/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/babel-preset-module/CHANGELOG.md
+++ b/packages/cli/babel-preset-module/CHANGELOG.md
@@ -1,5 +1,36 @@
 # @modern-js/babel-preset-module
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/babel-preset-lib@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/babel-preset-module/package.json
+++ b/packages/cli/babel-preset-module/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/core/CHANGELOG.md
+++ b/packages/cli/core/CHANGELOG.md
@@ -1,5 +1,101 @@
 # @modern-js/core
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Minor Changes
+
+- c9e800d39a: feat: support React18 streaming SSR
+  feat: 支持 React18 流式 SSR
+- 92f0eade39: feat:
+
+  1. core: 增加 test 函数
+  2. module plugins: 增加 `babel`, `mainField`, `target` 插件
+  3. storybook: 修改部分逻辑并且增加 tspath webpack 插件
+  4. 增加 designSystem 配置
+
+  feat:
+
+  1. core: add test method
+  2. module plugins: add `babel`, `mainField`, `target` plugin
+  3. storybook: change some logic and add tspath webpack plugin
+  4. add `designSystem` config
+
+- edd1cfb1af: feat: modernjs Access builder compiler
+  feat: modernjs 接入 builder 构建
+- d5a31df781: refactor: remove unbundle configs and types
+
+  refactor: 移除 unbundle 相关的配置项和类型定义
+
+- b8494ef: feat: remove use plugin types restrict
+  feat: 移除使用 plugin 类型限制
+- e4558a0: feat:
+
+  1. add `runBin` function
+  2. config internal plugins constants in the app/module/doc tools
+  3. add app/module/doc tools internal plugins
+
+  feat:
+
+  1. 添加 `runBin` 函数
+  2. 在 app/module/doc tools 里配置内部插件
+  3. 增加 app/module/doc tools 使用的插件常量
+
+### Patch Changes
+
+- 85edee888c: feat(app-tools): support tools.htmlPlugin config
+
+  feat(app-tools): 支持 tools.htmlPlugin 配置项
+
+- b8bbe036c7: feat: change type logic
+  feat: 修改类型相关的逻辑
+- 8b8e1bb571: feat: support nested routes
+  feat: 支持嵌套路由
+- 3bbea92b2a: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- b7a96c35fc: fix(app-tools): loose CLI init options after restart
+
+  fix(app-tools): 修复重启 CLI 后丢失 init options 的问题
+
+- cce8ecee2d: fix: handle some `TODO` & `FIXME`, change some tests
+  fix: 处理一些 `TODO` 和 `FIXME`, 修改了一些 tests
+- ea7cf06: chore: bump webpack/babel-loader/postcss-loader/tsconfig-paths
+
+  chore: 升级 webpack/babel-loader/postcss-loader/tsconfig-paths 版本
+
+- 14b712da84: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [a2509bfbdb]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [f179749375]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/node-bundle-require@2.0.0-beta.4
+  - @modern-js/plugin@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/cli/doc-core/package.json
+++ b/packages/cli/doc-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/doc-core",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/packages/cli/plugin-bff/CHANGELOG.md
+++ b/packages/cli/plugin-bff/CHANGELOG.md
@@ -1,5 +1,51 @@
 # @modern-js/plugin-bff
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 8ff2cf4c71: fix: bff api loader should run before babel loader
+  fix: bff 一体化调用的 loader 应该在 babel loader 前执行
+- ea7cf06: chore: bump webpack/babel-loader/postcss-loader/tsconfig-paths
+
+  chore: 升级 webpack/babel-loader/postcss-loader/tsconfig-paths 版本
+
+- Updated dependencies [9b915e0c10]
+- Updated dependencies [7879e8f]
+- Updated dependencies [d4e8e6fb90]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [2344eb26ed]
+- Updated dependencies [a2509bfbdb]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [a8642da58f]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [c2bb0f1745]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/server-utils@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/bff-core@2.0.0-beta.4
+  - @modern-js/create-request@2.0.0-beta.4
+  - @modern-js/babel-compiler@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/plugin-bff/package.json
+++ b/packages/cli/plugin-bff/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-changeset/CHANGELOG.md
+++ b/packages/cli/plugin-changeset/CHANGELOG.md
@@ -1,5 +1,36 @@
 # @modern-js/plugin-changeset
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/plugin-i18n@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/plugin-changeset/package.json
+++ b/packages/cli/plugin-changeset/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-data-loader/package.json
+++ b/packages/cli/plugin-data-loader/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-i18n/CHANGELOG.md
+++ b/packages/cli/plugin-i18n/CHANGELOG.md
@@ -1,5 +1,35 @@
 # @modern-js/plugin-i18n
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/plugin-i18n/package.json
+++ b/packages/cli/plugin-i18n/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-lint/CHANGELOG.md
+++ b/packages/cli/plugin-lint/CHANGELOG.md
@@ -1,5 +1,52 @@
 # @modern-js/plugin-lint
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- a3af050486: fix(plugin-lint): failed to execute modern lint command
+
+  fix(plugin-lint): 修复执行 modern lint 命令失败的问题
+
+- d4a456659b: chore: rename plugin-jarvis to plugin-lint
+
+  chore: 重命名 plugin-jarvis 为 plugin-lint
+
+- f680410886: feat: upgrade ESLint to 8.x version
+
+  feat: 升级 ESLint 到 8.x 版本
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [d4a456659b]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [f680410886]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/eslint-config@2.0.0-beta.4
+  - @modern-js-app/eslint-config@2.0.0-beta.4
+  - @modern-js/tsconfig@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/plugin-lint/package.json
+++ b/packages/cli/plugin-lint/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-module-babel/package.json
+++ b/packages/cli/plugin-module-babel/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/cli/plugin-module-main-fields/package.json
+++ b/packages/cli/plugin-module-main-fields/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/cli/plugin-module-target/package.json
+++ b/packages/cli/plugin-module-target/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/cli/plugin-proxy/CHANGELOG.md
+++ b/packages/cli/plugin-proxy/CHANGELOG.md
@@ -1,5 +1,35 @@
 # @modern-js/plugin-proxy
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/plugin-proxy/package.json
+++ b/packages/cli/plugin-proxy/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-ssg/CHANGELOG.md
+++ b/packages/cli/plugin-ssg/CHANGELOG.md
@@ -1,5 +1,41 @@
 # @modern-js/plugin-ssg
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6604f1b: feat: support router basename
+  feat: router 插件支持设置 basename
+- cc971eabfc: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 8b8e1bb571: feat: support nested routes
+  feat: 支持嵌套路由
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/plugin-ssg/package.json
+++ b/packages/cli/plugin-ssg/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-storybook/CHANGELOG.md
+++ b/packages/cli/plugin-storybook/CHANGELOG.md
@@ -1,5 +1,161 @@
 # @modern-js/plugin-storybook
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Minor Changes
+
+- 0bb776858a: feat: change Hooks logic
+  feat: 修改 Hooks 逻辑
+- 92f0eade39: feat:
+
+  1. core: 增加 test 函数
+  2. module plugins: 增加 `babel`, `mainField`, `target` 插件
+  3. storybook: 修改部分逻辑并且增加 tspath webpack 插件
+  4. 增加 designSystem 配置
+
+  feat:
+
+  1. core: add test method
+  2. module plugins: add `babel`, `mainField`, `target` plugin
+  3. storybook: change some logic and add tspath webpack plugin
+  4. add `designSystem` config
+
+- f0ee9120db: feat: change dev menu log
+  feat: 修改 dev 菜单展示的内容
+
+### Patch Changes
+
+- a2509bfbdb: feat: bump esbuild from 0.14.38 to 0.15.7
+
+  feat: 将 esbuild 从 0.14.38 版本升级至 0.15.7 版本
+
+- a23106a: fix(plugin-storybook): adapt builder & remove @modern-js/webpack dependency
+
+  fix(plugin-storybook): 适配 modern/builder，并移除 @modern-js/webpack 依赖
+
+- ea7cf06: chore: bump webpack/babel-loader/postcss-loader/tsconfig-paths
+
+  chore: 升级 webpack/babel-loader/postcss-loader/tsconfig-paths 版本
+
+- Updated dependencies [2344eb26ed]
+- Updated dependencies [a11fcf8b50]
+- Updated dependencies [c9f912ca4d]
+- Updated dependencies [95be7cc49c]
+- Updated dependencies [a931594]
+- Updated dependencies [e439457a51]
+- Updated dependencies [e7ce063]
+- Updated dependencies [4d1545f8c0]
+- Updated dependencies [4a7693f]
+- Updated dependencies [b18fa8f3ed]
+- Updated dependencies [2bc090c089]
+- Updated dependencies [ba53257]
+- Updated dependencies [f0abb2e]
+- Updated dependencies [f96a725211]
+- Updated dependencies [7879e8f]
+- Updated dependencies [828f42f9ce]
+- Updated dependencies [060abd4553]
+- Updated dependencies [50d4675]
+- Updated dependencies [309cd71a1c]
+- Updated dependencies [c7456864a8]
+- Updated dependencies [c9e800d39a]
+- Updated dependencies [3cf9633195]
+- Updated dependencies [6604f1b]
+- Updated dependencies [57077b2c64]
+- Updated dependencies [6aca875]
+- Updated dependencies [2ff6167be0]
+- Updated dependencies [287f298990]
+- Updated dependencies [fda836f]
+- Updated dependencies [423188db70]
+- Updated dependencies [fd2d652c03]
+- Updated dependencies [d6bc321]
+- Updated dependencies [0c2d8dae31]
+- Updated dependencies [2edad29dd7]
+- Updated dependencies [3e57f2bd58]
+- Updated dependencies [fe17f51055]
+- Updated dependencies [85edee888c]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [c5798d2]
+- Updated dependencies [fbf5eed5aa]
+- Updated dependencies [a2509bfbdb]
+- Updated dependencies [309f08b]
+- Updated dependencies [3998875791]
+- Updated dependencies [752480d]
+- Updated dependencies [a7c6883]
+- Updated dependencies [b827e35]
+- Updated dependencies [ab3924a70e]
+- Updated dependencies [425e57092d]
+- Updated dependencies [3998875791]
+- Updated dependencies [ba86b8b711]
+- Updated dependencies [e4357f1856]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [4369648ae2]
+- Updated dependencies [5402fdb0ca]
+- Updated dependencies [2ae58176fe]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [92c0994468]
+- Updated dependencies [2cc2eb3]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [5d67c26cdb]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [83ac356]
+- Updated dependencies [18360a38d7]
+- Updated dependencies [6bda14ed71]
+- Updated dependencies [0b314e6946]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [5911154129]
+- Updated dependencies [40ed5874c6]
+- Updated dependencies [af4422d67f]
+- Updated dependencies [705adc1dae]
+- Updated dependencies [60d5378632]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [c258e34202]
+- Updated dependencies [812913ccdd]
+- Updated dependencies [7248342e4d]
+- Updated dependencies [568eab1e42]
+- Updated dependencies [8b8e1bb571]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [ae71096d45]
+- Updated dependencies [9144c21]
+- Updated dependencies [e06b9a2]
+- Updated dependencies [b710adb843]
+- Updated dependencies [a23010138d]
+- Updated dependencies [75d1b2657c]
+- Updated dependencies [18aaf42249]
+- Updated dependencies [34702d5]
+- Updated dependencies [fcace5b5b9]
+- Updated dependencies [3fae2d03b3]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [8a6d45f105]
+- Updated dependencies [143d8dd]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [6354cfa]
+- Updated dependencies [90e2879520]
+- Updated dependencies [e4558a0]
+- Updated dependencies [df41d71ade]
+- Updated dependencies [f727e5c6cc]
+- Updated dependencies [5e3cecd523]
+- Updated dependencies [92de772]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [da2d1fc3c2]
+- Updated dependencies [543be9558e]
+- Updated dependencies [fd1d9fd]
+- Updated dependencies [14b712da84]
+- Updated dependencies [a24f1c9]
+  - @modern-js/runtime@2.0.0-beta.4
+  - @modern-js/builder-webpack-provider@2.0.0-beta.4
+  - @modern-js/builder-shared@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/builder-plugin-node-polyfill@2.0.0-beta.4
+  - @modern-js/plugin-router-legacy@2.0.0-beta.4
+  - @modern-js/builder@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/plugin-storybook/package.json
+++ b/packages/cli/plugin-storybook/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -85,8 +85,8 @@
     "webpack-chain": "^6.5.1"
   },
   "peerDependencies": {
-    "@modern-js/runtime": "workspace:^2.0.0-beta.3",
-    "@modern-js/plugin-router-legacy": "workspace:^2.0.0-beta.3",
+    "@modern-js/runtime": "workspace:^2.0.0-beta.4",
+    "@modern-js/plugin-router-legacy": "workspace:^2.0.0-beta.4",
     "react": ">=18"
   },
   "sideEffects": false,

--- a/packages/cli/plugin-swc/CHANGELOG.md
+++ b/packages/cli/plugin-swc/CHANGELOG.md
@@ -1,5 +1,42 @@
 # @modern-js/core
 
+## 2.0.0-beta.4
+
+### Minor Changes
+
+- bbe4c4a: feat: add @modern-js/plugin-swc
+
+  feat: 新增 @modern-js/plugin-swc 插件
+
+### Patch Changes
+
+- Updated dependencies [c8a22763b4]
+- Updated dependencies [7879e8f]
+- Updated dependencies [a9b38ea196]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [0dd63a6909]
+- Updated dependencies [3fae2d03b3]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/builder-plugin-swc@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Minor Changes

--- a/packages/cli/plugin-swc/package.json
+++ b/packages/cli/plugin-swc/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/cli/plugin-tailwind/CHANGELOG.md
+++ b/packages/cli/plugin-tailwind/CHANGELOG.md
@@ -1,5 +1,102 @@
 # @modern-js/plugin-tailwindcss
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Minor Changes
+
+- 92f0eade39: feat:
+
+  1. add style config and add new hook
+  2. add dts alias logic
+  3. add copy logic
+  4. add log logic
+  5. add skipDeps config
+
+  feat:
+
+  1. 添加样式配置以及新的 hook
+  2. 添加 dts 别名处理
+  3. 添加 copy 逻辑
+  4. 添加日志逻辑
+  5. 添加 skipDeps 配置
+
+- 92f0eade39: feat:
+
+  1. core: 增加 test 函数
+  2. module plugins: 增加 `babel`, `mainField`, `target` 插件
+  3. storybook: 修改部分逻辑并且增加 tspath webpack 插件
+  4. 增加 designSystem 配置
+
+  feat:
+
+  1. core: add test method
+  2. module plugins: add `babel`, `mainField`, `target` plugin
+  3. storybook: change some logic and add tspath webpack plugin
+  4. add `designSystem` config
+
+### Patch Changes
+
+- d6546ad916: add buildConfig style in module-tools and remove tools
+  在 module-tools 里新增 buildConfig style 并删除 tools
+- 67472ca: fix: move babel-plugin-marcos to plugin-tailwindcss
+
+  fix: 将 babel-plugin-marcos 依赖移动到 plugin-tailwindcss 中
+
+- Updated dependencies [2344eb26ed]
+- Updated dependencies [a11fcf8b50]
+- Updated dependencies [a931594]
+- Updated dependencies [e7ce063]
+- Updated dependencies [b18fa8f3ed]
+- Updated dependencies [7879e8f]
+- Updated dependencies [50d4675]
+- Updated dependencies [c9e800d39a]
+- Updated dependencies [6604f1b]
+- Updated dependencies [6aca875]
+- Updated dependencies [fda836f]
+- Updated dependencies [d6bc321]
+- Updated dependencies [3e57f2bd58]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [c5798d2]
+- Updated dependencies [fbf5eed5aa]
+- Updated dependencies [a2509bfbdb]
+- Updated dependencies [a7c6883]
+- Updated dependencies [425e57092d]
+- Updated dependencies [e4357f1856]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [4369648ae2]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [92c0994468]
+- Updated dependencies [2cc2eb3]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [6bda14ed71]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [40ed5874c6]
+- Updated dependencies [60d5378632]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [8b8e1bb571]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [9144c21]
+- Updated dependencies [b710adb843]
+- Updated dependencies [18aaf42249]
+- Updated dependencies [34702d5]
+- Updated dependencies [fcace5b5b9]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/runtime@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/cli/plugin-tailwind/package.json
+++ b/packages/cli/plugin-tailwind/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "tailwindcss": "^2.0.4",
-    "@modern-js/runtime": "workspace:^2.0.0-beta.3"
+    "@modern-js/runtime": "workspace:^2.0.0-beta.4"
   },
   "peerDependenciesMeta": {
     "@modern-js/runtime": {

--- a/packages/generator/generator-cases/CHANGELOG.md
+++ b/packages/generator/generator-cases/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @modern-js/generator-cases
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [dda38c9c3e]
+  - @modern-js/generator-common@3.0.0-beta.4
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generator-cases/package.json
+++ b/packages/generator/generator-cases/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/generator-common/CHANGELOG.md
+++ b/packages/generator/generator-common/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @modern-js/generator-common
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [dda38c9c3e]
+  - @modern-js/plugin-i18n@2.0.0-beta.4
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generator-common/package.json
+++ b/packages/generator/generator-common/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/generator-plugin/CHANGELOG.md
+++ b/packages/generator/generator-plugin/CHANGELOG.md
@@ -1,5 +1,43 @@
 # @modern-js/generator-plugin
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- d4a456659b: chore: rename plugin-jarvis to plugin-lint
+
+  chore: 重命名 plugin-jarvis 为 plugin-lint
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/plugin-i18n@2.0.0-beta.4
+  - @modern-js/generator-common@3.0.0-beta.4
+  - @modern-js/generator-utils@3.0.0-beta.4
+  - @modern-js/new-action@2.0.0-beta.4
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generator-plugin/package.json
+++ b/packages/generator/generator-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/generator-plugin",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/generator-utils/CHANGELOG.md
+++ b/packages/generator/generator-utils/CHANGELOG.md
@@ -1,5 +1,37 @@
 # @modern-js/generator-utils
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/plugin-i18n@2.0.0-beta.4
+  - @modern-js/generator-common@3.0.0-beta.4
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generator-utils/package.json
+++ b/packages/generator/generator-utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/generators/base-generator/CHANGELOG.md
+++ b/packages/generator/generators/base-generator/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @modern-js/base-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- f680410886: feat: upgrade ESLint to 8.x version
+
+  feat: 升级 ESLint 到 8.x 版本
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/base-generator/package.json
+++ b/packages/generator/generators/base-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./src/index.ts",

--- a/packages/generator/generators/bff-generator/CHANGELOG.md
+++ b/packages/generator/generators/bff-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/bff-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/bff-generator/package.json
+++ b/packages/generator/generators/bff-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./src/index.ts",

--- a/packages/generator/generators/changeset-generator/CHANGELOG.md
+++ b/packages/generator/generators/changeset-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/changeset-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/changeset-generator/package.json
+++ b/packages/generator/generators/changeset-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/dependence-generator/CHANGELOG.md
+++ b/packages/generator/generators/dependence-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/dependence-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/dependence-generator/package.json
+++ b/packages/generator/generators/dependence-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/entry-generator/CHANGELOG.md
+++ b/packages/generator/generators/entry-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/entry-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/entry-generator/package.json
+++ b/packages/generator/generators/entry-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/eslint-generator/CHANGELOG.md
+++ b/packages/generator/generators/eslint-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/eslint-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/eslint-generator/package.json
+++ b/packages/generator/generators/eslint-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/generator-generator/CHANGELOG.md
+++ b/packages/generator/generators/generator-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/generator-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/generator-generator/package.json
+++ b/packages/generator/generators/generator-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/module-generator/CHANGELOG.md
+++ b/packages/generator/generators/module-generator/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @modern-js/module-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- d4a456659b: chore: rename plugin-jarvis to plugin-lint
+
+  chore: 重命名 plugin-jarvis 为 plugin-lint
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/module-generator/package.json
+++ b/packages/generator/generators/module-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/monorepo-generator/CHANGELOG.md
+++ b/packages/generator/generators/monorepo-generator/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @modern-js/monorepo-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- d4a456659b: chore: rename plugin-jarvis to plugin-lint
+
+  chore: 重命名 plugin-jarvis 为 plugin-lint
+
+- f680410886: feat: upgrade ESLint to 8.x version
+
+  feat: 升级 ESLint 到 8.x 版本
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/monorepo-generator/package.json
+++ b/packages/generator/generators/monorepo-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/mwa-generator/CHANGELOG.md
+++ b/packages/generator/generators/mwa-generator/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @modern-js/mwa-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- d4a456659b: chore: rename plugin-jarvis to plugin-lint
+
+  chore: 重命名 plugin-jarvis 为 plugin-lint
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/mwa-generator/package.json
+++ b/packages/generator/generators/mwa-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/packages-generator/package.json
+++ b/packages/generator/generators/packages-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/repo-generator/CHANGELOG.md
+++ b/packages/generator/generators/repo-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/repo-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/repo-generator/package.json
+++ b/packages/generator/generators/repo-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/router-legacy-generator/package.json
+++ b/packages/generator/generators/router-legacy-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/server-generator/CHANGELOG.md
+++ b/packages/generator/generators/server-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/server-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/server-generator/package.json
+++ b/packages/generator/generators/server-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./src/index.ts",

--- a/packages/generator/generators/ssg-generator/CHANGELOG.md
+++ b/packages/generator/generators/ssg-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/ssg-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/ssg-generator/package.json
+++ b/packages/generator/generators/ssg-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/storybook-generator/CHANGELOG.md
+++ b/packages/generator/generators/storybook-generator/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @modern-js/storybook-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 2344eb26ed: fix: storybook generator runtimeDependenceVersion keyword
+
+  fix: storybook 生成器 runtimeDependenceVersion 关键字
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/storybook-generator/package.json
+++ b/packages/generator/generators/storybook-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/tailwindcss-generator/CHANGELOG.md
+++ b/packages/generator/generators/tailwindcss-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/tailwindcss-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/tailwindcss-generator/package.json
+++ b/packages/generator/generators/tailwindcss-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/test-generator/CHANGELOG.md
+++ b/packages/generator/generators/test-generator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/test-generator
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/generators/test-generator/package.json
+++ b/packages/generator/generators/test-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/upgrade-generator/package.json
+++ b/packages/generator/generators/upgrade-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/new-action/CHANGELOG.md
+++ b/packages/generator/new-action/CHANGELOG.md
@@ -1,5 +1,37 @@
 # @modern-js/new-action
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/generator-common@3.0.0-beta.4
+  - @modern-js/generator-utils@3.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/new-action/package.json
+++ b/packages/generator/new-action/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/plugins/generator-plugin/CHANGELOG.md
+++ b/packages/generator/plugins/generator-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/generator-plugin-plugin
 
+## 3.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
 ## 3.0.0-beta.3
 
 ### Major Changes

--- a/packages/generator/plugins/generator-plugin/package.json
+++ b/packages/generator/plugins/generator-plugin/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/review/eslint-config-app/CHANGELOG.md
+++ b/packages/review/eslint-config-app/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @modern-js-app/eslint-config
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- d4a456659b: chore: rename plugin-jarvis to plugin-lint
+
+  chore: 重命名 plugin-jarvis 为 plugin-lint
+
+- f680410886: feat: upgrade ESLint to 8.x version
+
+  feat: 升级 ESLint 到 8.x 版本
+
+- Updated dependencies [a7c6883]
+- Updated dependencies [decfcd989d]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [fd1d9fd]
+  - @modern-js/babel-preset-app@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/review/eslint-config-app/package.json
+++ b/packages/review/eslint-config-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js-app/eslint-config",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "The meta-framework suite designed from scratch for frontend-focused modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/review/eslint-config/CHANGELOG.md
+++ b/packages/review/eslint-config/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @modern-js/eslint-config
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- d4a456659b: chore: rename plugin-jarvis to plugin-lint
+
+  chore: 重命名 plugin-jarvis 为 plugin-lint
+
+- f680410886: feat: upgrade ESLint to 8.x version
+
+  feat: 升级 ESLint 到 8.x 版本
+
+- Updated dependencies [d4a456659b]
+- Updated dependencies [f680410886]
+- Updated dependencies [dda38c9c3e]
+  - @modern-js-app/eslint-config@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/review/eslint-config/package.json
+++ b/packages/review/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/eslint-config",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "The meta-framework suite designed from scratch for frontend-focused modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/review/tsconfig/CHANGELOG.md
+++ b/packages/review/tsconfig/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/tsconfig
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/review/tsconfig/package.json
+++ b/packages/review/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/tsconfig",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "The meta-framework suite designed from scratch for frontend-focused modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/runtime/plugin-garfish/CHANGELOG.md
+++ b/packages/runtime/plugin-garfish/CHANGELOG.md
@@ -1,5 +1,72 @@
 # @modern-js/plugin-garfish
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 6604f1b: feat: support router basename
+  feat: router 插件支持设置 basename
+- 21d2ddb59c: feat: support async export provider for module federation
+  支持模块联邦场景异步导出 provider
+- cce8ecee2d: fix: handle some `TODO` & `FIXME`, change some tests
+  fix: 处理一些 `TODO` 和 `FIXME`, 修改了一些 tests
+- 2344eb26ed: fix: loadApp when dom is mount
+  修复 dom 未渲染时挂载子应用行为
+- Updated dependencies [2344eb26ed]
+- Updated dependencies [a11fcf8b50]
+- Updated dependencies [a931594]
+- Updated dependencies [e7ce063]
+- Updated dependencies [b18fa8f3ed]
+- Updated dependencies [7879e8f]
+- Updated dependencies [50d4675]
+- Updated dependencies [c9e800d39a]
+- Updated dependencies [6604f1b]
+- Updated dependencies [6aca875]
+- Updated dependencies [fda836f]
+- Updated dependencies [d6bc321]
+- Updated dependencies [3e57f2bd58]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [c5798d2]
+- Updated dependencies [fbf5eed5aa]
+- Updated dependencies [a2509bfbdb]
+- Updated dependencies [a7c6883]
+- Updated dependencies [425e57092d]
+- Updated dependencies [e4357f1856]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [4369648ae2]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [92c0994468]
+- Updated dependencies [2cc2eb3]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [6bda14ed71]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [40ed5874c6]
+- Updated dependencies [60d5378632]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [8b8e1bb571]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [9144c21]
+- Updated dependencies [b710adb843]
+- Updated dependencies [18aaf42249]
+- Updated dependencies [34702d5]
+- Updated dependencies [fcace5b5b9]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/runtime@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "typesVersions": {
@@ -66,7 +66,7 @@
     "react-loadable": "^5.5.0"
   },
   "peerDependencies": {
-    "@modern-js/runtime": "workspace:^2.0.0-beta.3"
+    "@modern-js/runtime": "workspace:^2.0.0-beta.4"
   },
   "peerDependenciesMeta": {
     "@modern-js/runtime": {

--- a/packages/runtime/plugin-router-legacy/package.json
+++ b/packages/runtime/plugin-router-legacy/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/runtime/plugin-runtime/CHANGELOG.md
+++ b/packages/runtime/plugin-runtime/CHANGELOG.md
@@ -1,5 +1,131 @@
 # @modern-js/runtime
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Minor Changes
+
+- c9e800d39a: feat: support React18 streaming SSR
+  feat: 支持 React18 流式 SSR
+- 543be9558e: feat: compile server loader and support handle loader request
+  feat: 编译 server loader 并支持处理 loader 的请求
+
+### Patch Changes
+
+- 2344eb26ed: fix: bootstrap function params type define
+
+  fix: 修复 bootstrap 函数参数类型定义
+
+- a11fcf8b50: feat: fallback logic of streaming ssr
+  feat: streaming ssr 降级逻辑
+- a931594: feat: support modify routes for csr app
+  feat: 支持 modifyRoutes API
+- e7ce063: fix: root layout css chunks should't be loaded
+  fix: 不应该加载 root layout 的 css chunks
+- b18fa8f3ed: feat: remove @loadable/component in streaming ssr
+  feat: 移除 streaming ssr 中的 @loadable/component 逻辑
+- 50d4675: fix: add document cli export
+
+  fix: 增加 document cli 插件的导出
+
+- 6604f1b: feat: support router basename
+  feat: router 插件支持设置 basename
+- fda836f: feat: support `models`,`initialState` config for state plugin
+  feat: state 插件支持`model`,`initialState` 配置
+- d6bc321: fix: the Document.tsx missed hmr
+
+  fix: Document.tsx 未能引发 hmr
+
+- 3e57f2bd58: feat: add document feature with plugin
+
+  feat: 增加 document 功能插件
+
+- 2e6031955e: fix: some optimizations for router and loader
+  fix: 一些 router 和 loader 的优化
+  q
+- c5798d2: fix(runtime): apply babel-plugin-ssr-loader-id when SSR is not used
+
+  fix(runtime): 在未启动 SSR 时需要注册 babel-plugin-ssr-loader-id
+
+- fbf5eed5aa: fix: fix ssg failure due to lack of Web Response API
+  fix: 修复因为缺少 Web Response API 而导致 ssg 失败
+- a2509bfbdb: feat: bump esbuild from 0.14.38 to 0.15.7
+
+  feat: 将 esbuild 从 0.14.38 版本升级至 0.15.7 版本
+
+- a7c6883: fix: only register babel-plugin-ssr-loader-id when SSR is enabled
+
+  fix: 仅在开启 SSR 的场景下注册 babel-plugin-ssr-loader-id
+
+- 425e57092d: feat: export react-router-dom/server staticRouter
+  feat: 导出 react-router-dom/server 的 staticRouter 组件
+- e4357f1856: fix: change default document file and name
+
+  fix: 重置默认的 document 文件和文件名
+
+- 4369648ae2: fix: fix html template of streaming ssr
+  fix: 修复流式渲染的 html 模版
+- 92c0994468: chore: remove `registerPrefetch`
+  chore: 移除 `registerPrefetch`
+- 2cc2eb3: fix: fix state plugin config
+  fix: 修复 state 插件 config 参数
+- 6bda14ed71: feat: refactor router with react-router@6.4
+
+  feat: 使用 react-router@6.4 重构路由模块
+
+- 92004d1906: feat: support load chunks parallelly
+  feat: 支持并行加载 chunks
+- 40ed5874c6: feat: inject css chunk into html for streaming ssr
+  feat: streaming ssr 返回的 html 注入 css chunk
+- 60d5378632: fix: function extname should not return array
+  fix: 函数 extname 不应该返回一个数组
+- 8b8e1bb571: feat: support nested routes
+  feat: 支持嵌套路由
+- 3bbea92b2a: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- 9144c21: fix: esbuild config use file
+
+  fix: 更改 esbuild 读取指定 ts 配置
+
+- 18aaf42249: fix: fix server loader redirects
+  fix: 修复 server loader 重定向错误
+- 34702d5: feat: support internal env vars: metaName_TARGET
+  feat: 支持内置环境变量 metaName_TARGET
+- fcace5b5b9: fix: remove overmuch `@modernjs/utils` dependency import in ssr runtime & SSR hydrate error
+  fix: 去除 ssr 运行时过多的 `@modernjs/utils` 依赖引入 & SSR hydrate 错误
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [6bda14ed71]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [40ed5874c6]
+- Updated dependencies [87c1ff86b9]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [102d32e4ba]
+- Updated dependencies [8b8e1bb571]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [f179749375]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/types@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/plugin@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "engines": {
     "node": ">=14.17.6"
   },

--- a/packages/runtime/plugin-testing/CHANGELOG.md
+++ b/packages/runtime/plugin-testing/CHANGELOG.md
@@ -1,5 +1,82 @@
 # @modern-js/plugin-testing
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- cc971eabfc: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 14b712da84: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [2344eb26ed]
+- Updated dependencies [a11fcf8b50]
+- Updated dependencies [a931594]
+- Updated dependencies [e7ce063]
+- Updated dependencies [b18fa8f3ed]
+- Updated dependencies [7879e8f]
+- Updated dependencies [50d4675]
+- Updated dependencies [c9e800d39a]
+- Updated dependencies [6604f1b]
+- Updated dependencies [d032d49e09]
+- Updated dependencies [6aca875]
+- Updated dependencies [fda836f]
+- Updated dependencies [15bf09d9c8]
+- Updated dependencies [d6bc321]
+- Updated dependencies [3e57f2bd58]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [c5798d2]
+- Updated dependencies [fbf5eed5aa]
+- Updated dependencies [a2509bfbdb]
+- Updated dependencies [a7c6883]
+- Updated dependencies [425e57092d]
+- Updated dependencies [decfcd989d]
+- Updated dependencies [e4357f1856]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [4369648ae2]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [92c0994468]
+- Updated dependencies [2cc2eb3]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [6bda14ed71]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [40ed5874c6]
+- Updated dependencies [60d5378632]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [102d32e4ba]
+- Updated dependencies [8b8e1bb571]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [73cd29dd9f]
+- Updated dependencies [9144c21]
+- Updated dependencies [b710adb843]
+- Updated dependencies [cce8ecee2d]
+- Updated dependencies [18aaf42249]
+- Updated dependencies [34702d5]
+- Updated dependencies [f179749375]
+- Updated dependencies [fcace5b5b9]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [fd1d9fd]
+- Updated dependencies [14b712da84]
+  - @modern-js/runtime@2.0.0-beta.4
+  - @modern-js/prod-server@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/babel-preset-app@2.0.0-beta.4
+  - @modern-js/plugin@2.0.0-beta.4
+  - @modern-js/babel-compiler@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -127,7 +127,7 @@
   "peerDependencies": {
     "react": ">=17",
     "react-dom": ">=17",
-    "@modern-js/runtime": "workspace:^2.0.0-beta.3"
+    "@modern-js/runtime": "workspace:^2.0.0-beta.4"
   },
   "peerDependenciesMeta": {
     "@modern-js/runtime": {

--- a/packages/server/bff-core/CHANGELOG.md
+++ b/packages/server/bff-core/CHANGELOG.md
@@ -1,5 +1,42 @@
 # @modern-js/bff-core
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 2344eb26ed: fix: esbuild should not handle js files
+  fix: esbuild 不应该处理非 js 文件
+- a2509bfbdb: feat: bump esbuild from 0.14.38 to 0.15.7
+
+  feat: 将 esbuild 从 0.14.38 版本升级至 0.15.7 版本
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/bff-runtime@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/bff-core/package.json
+++ b/packages/server/bff-core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/bff-runtime/CHANGELOG.md
+++ b/packages/server/bff-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/bff-runtime
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/bff-runtime/package.json
+++ b/packages/server/bff-runtime/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/core/CHANGELOG.md
+++ b/packages/server/core/CHANGELOG.md
@@ -1,5 +1,46 @@
 # @modern-js/server-plugin
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Minor Changes
+
+- 543be9558e: feat: compile server loader and support handle loader request
+  feat: 编译 server loader 并支持处理 loader 的请求
+
+### Patch Changes
+
+- 15bf09d9c8: feat: support completely custom server, export render() api for render single page
+  feat: 支持完全自定义 Server，导出 render() 方法用来渲染单个页面
+- cc971eabfc: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [f179749375]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/plugin@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/create-request/CHANGELOG.md
+++ b/packages/server/create-request/CHANGELOG.md
@@ -1,5 +1,35 @@
 # @modern-js/create-request
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/create-request/package.json
+++ b/packages/server/create-request/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-egg/CHANGELOG.md
+++ b/packages/server/plugin-egg/CHANGELOG.md
@@ -1,5 +1,41 @@
 # @modern-js/plugin-egg
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 3bbea92b2a: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [2344eb26ed]
+- Updated dependencies [a2509bfbdb]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/bff-core@2.0.0-beta.4
+  - @modern-js/bff-runtime@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/plugin-egg/package.json
+++ b/packages/server/plugin-egg/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-express/CHANGELOG.md
+++ b/packages/server/plugin-express/CHANGELOG.md
@@ -1,5 +1,49 @@
 # @modern-js/plugin-express
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 8d24bed25b: fix: compat Hook API in /server namespace
+  fix: 在 @modern-js/runtime/server 命名空间下兼容 Hook API
+- 3bbea92b2a: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [2344eb26ed]
+- Updated dependencies [a2509bfbdb]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [6bda14ed71]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [40ed5874c6]
+- Updated dependencies [87c1ff86b9]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [102d32e4ba]
+- Updated dependencies [8b8e1bb571]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/types@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/bff-core@2.0.0-beta.4
+  - @modern-js/bff-runtime@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/plugin-express/package.json
+++ b/packages/server/plugin-express/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-koa/CHANGELOG.md
+++ b/packages/server/plugin-koa/CHANGELOG.md
@@ -1,5 +1,49 @@
 # @modern-js/plugin-koa
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 8d24bed25b: fix: compat Hook API in /server namespace
+  fix: 在 @modern-js/runtime/server 命名空间下兼容 Hook API
+- 3bbea92b2a: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [2344eb26ed]
+- Updated dependencies [a2509bfbdb]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [6bda14ed71]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [40ed5874c6]
+- Updated dependencies [87c1ff86b9]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [102d32e4ba]
+- Updated dependencies [8b8e1bb571]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/types@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/bff-core@2.0.0-beta.4
+  - @modern-js/bff-runtime@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/plugin-koa/package.json
+++ b/packages/server/plugin-koa/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-nest/CHANGELOG.md
+++ b/packages/server/plugin-nest/CHANGELOG.md
@@ -1,5 +1,41 @@
 # @modern-js/plugin-nest
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 3bbea92b2a: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [2344eb26ed]
+- Updated dependencies [a2509bfbdb]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/bff-core@2.0.0-beta.4
+  - @modern-js/bff-runtime@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/plugin-nest/package.json
+++ b/packages/server/plugin-nest/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/server/plugin-polyfill/CHANGELOG.md
+++ b/packages/server/plugin-polyfill/CHANGELOG.md
@@ -1,5 +1,39 @@
 # @modern-js/plugin-polyfill
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- ebbeed1ece: fix(plugin-polyfill): failed to join flags when restart CLI
+
+  fix(plugin-polyfill): 修复重启 CLI 时报错 join flags 失败的问题
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/plugin-polyfill/package.json
+++ b/packages/server/plugin-polyfill/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-server/CHANGELOG.md
+++ b/packages/server/plugin-server/CHANGELOG.md
@@ -1,5 +1,43 @@
 # @modern-js/plugin-server
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 3bbea92b2a: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- Updated dependencies [9b915e0c10]
+- Updated dependencies [7879e8f]
+- Updated dependencies [d4e8e6fb90]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [a8642da58f]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [c2bb0f1745]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/server-utils@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/babel-compiler@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/plugin-server/package.json
+++ b/packages/server/plugin-server/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "types": "./src/server.ts",
   "jsnext:source": "./src/server.ts",
   "main": "./dist/js/node/server.js",

--- a/packages/server/prod-server/CHANGELOG.md
+++ b/packages/server/prod-server/CHANGELOG.md
@@ -1,5 +1,74 @@
 # @modern-js/prod-server
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Minor Changes
+
+- c9e800d39a: feat: support React18 streaming SSR
+  feat: 支持 React18 流式 SSR
+- 543be9558e: feat: compile server loader and support handle loader request
+  feat: 编译 server loader 并支持处理 loader 的请求
+
+### Patch Changes
+
+- 7879e8f: refactor: remove enableModernMode config
+
+  refactor: 不再支持 enableModernMode 配置项
+
+- d032d49e09: export createHandle
+  导出 createHandle 函数
+- 15bf09d9c8: feat: support completely custom server, export render() api for render single page
+  feat: 支持完全自定义 Server，导出 render() 方法用来渲染单个页面
+- cc971eabfc: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 40ed5874c6: feat: inject css chunk into html for streaming ssr
+  feat: streaming ssr 返回的 html 注入 css chunk
+- 102d32e4ba: feat(server): add `req` and `res` to SSR context
+
+  feat(server): 添加 `req` 和 `res` 到 SSR context 中
+
+- 3bbea92b2a: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- 73cd29dd9f: fix(server): add favicon fallback handler
+
+  fix(server): 添加 favicon 兜底处理逻辑
+
+- cce8ecee2d: fix: handle some `TODO` & `FIXME`, change some tests
+  fix: 处理一些 `TODO` 和 `FIXME`, 修改了一些 tests
+- 18aaf42249: fix: fix server loader redirects
+  fix: 修复 server loader 重定向错误
+- 14b712da84: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [15bf09d9c8]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/server-core@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/prod-server/package.json
+++ b/packages/server/prod-server/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/server/CHANGELOG.md
+++ b/packages/server/server/CHANGELOG.md
@@ -1,5 +1,84 @@
 # @modern-js/server
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Minor Changes
+
+- b710adb843: feat: extract the data loader
+  feat: 提取 data loader
+
+### Patch Changes
+
+- 7879e8f: refactor: remove enableModernMode config
+
+  refactor: 不再支持 enableModernMode 配置项
+
+- d4e8e6fb90: fix: modernjs dev server can't start normaly
+  fix: modernjs dev 服务端不能正常启动
+- 15bf09d9c8: feat: support completely custom server, export render() api for render single page
+  feat: 支持完全自定义 Server，导出 render() 方法用来渲染单个页面
+- 61f21d1e77: fix: ignore the entire distPath for pia ssr bundle
+  fix: dist 目录的产物不应该被 ts-node 编译
+- 4f277fe: fix(server): remove peer dependencies warning
+
+  fix(server): 修复 peer dependencies 出现 warning 提示的问题
+
+- cce8ecee2d: fix: handle some `TODO` & `FIXME`, change some tests
+  fix: 处理一些 `TODO` 和 `FIXME`, 修改了一些 tests
+- ea7cf06: chore: bump webpack/babel-loader/postcss-loader/tsconfig-paths
+
+  chore: 升级 webpack/babel-loader/postcss-loader/tsconfig-paths 版本
+
+- ebbeed1ece: chore: dev server default cross origin
+  chore: 开发环境 Server 默认跨域
+- 14b712da84: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [9b915e0c10]
+- Updated dependencies [7879e8f]
+- Updated dependencies [c9e800d39a]
+- Updated dependencies [d4e8e6fb90]
+- Updated dependencies [d032d49e09]
+- Updated dependencies [6aca875]
+- Updated dependencies [15bf09d9c8]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [6bda14ed71]
+- Updated dependencies [a8642da58f]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [40ed5874c6]
+- Updated dependencies [87c1ff86b9]
+- Updated dependencies [c2bb0f1745]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [102d32e4ba]
+- Updated dependencies [8b8e1bb571]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [73cd29dd9f]
+- Updated dependencies [b710adb843]
+- Updated dependencies [cce8ecee2d]
+- Updated dependencies [18aaf42249]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/server-utils@2.0.0-beta.4
+  - @modern-js/prod-server@2.0.0-beta.4
+  - @modern-js/types@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/utils/CHANGELOG.md
+++ b/packages/server/utils/CHANGELOG.md
@@ -1,5 +1,59 @@
 # @modern-js/server-utils
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 9b915e0c10: fix: tsconfig-paths plugin's new node use old node flag
+  fix: tsconfig-paths 插件转换的新节点使用旧节点的 flag
+- 7879e8f: refactor: remove enableModernMode config
+
+  refactor: 不再支持 enableModernMode 配置项
+
+- d4e8e6fb90: fix: modernjs dev server can't start normaly
+  fix: modernjs dev 服务端不能正常启动
+- a8642da58f: fix(server-utils): incorrect babel-compiler version
+
+  fix(server-utils): 修复引用错误的 babel-compiler 版本的问题
+
+- c2bb0f1745: chore(server-utils): using pre-bundled tsconfig-paths
+
+  chore(server-utils): 使用预打包的 tsconfig-paths 依赖
+
+- 14b712da84: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [f179749375]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/plugin@2.0.0-beta.4
+  - @modern-js/babel-preset-lib@2.0.0-beta.4
+  - @modern-js/babel-compiler@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/solutions/app-tools/CHANGELOG.md
+++ b/packages/solutions/app-tools/CHANGELOG.md
@@ -1,5 +1,310 @@
 # @modern-js/app-tools
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Minor Changes
+
+- edd1cfb1af: feat: modernjs Access builder compiler
+  feat: modernjs 接入 builder 构建
+- b710adb843: feat: extract the data loader
+  feat: 提取 data loader
+- bbe4c4a: feat: add @modern-js/plugin-swc
+
+  feat: 新增 @modern-js/plugin-swc 插件
+
+- e4558a0: feat:
+
+  1. add `runBin` function
+  2. config internal plugins constants in the app/module/doc tools
+  3. add app/module/doc tools internal plugins
+
+  feat:
+
+  1. 添加 `runBin` 函数
+  2. 在 app/module/doc tools 里配置内部插件
+  3. 增加 app/module/doc tools 使用的插件常量
+
+- 543be9558e: feat: compile server loader and support handle loader request
+  feat: 编译 server loader 并支持处理 loader 的请求
+
+### Patch Changes
+
+- c9f912ca4d: feat(app-tools): improve build logs of dev and build command
+
+  feat(app-tools): 优化 dev 和 build 过程中的日志展示
+
+- 0078da4c80: fix: remove webpack oneof rule in new config, save in legacy mode.
+  fix: 在新模式下删除 webpack oneof 规则，兼容模式下保留
+- 103973cde9: fix: builder tools.webpackChain config args not match the Modernjs tools.webpackChain
+  fix: builder tools.webpackChain 配置传参无法匹配 Modernjs tools.webpackChain
+- 7879e8f: refactor: remove enableModernMode config
+
+  refactor: 不再支持 enableModernMode 配置项
+
+- 0be536d: fix(app-tools): html.template config not work
+
+  fix(app-tools): 修复 html.template 配置项不生效的问题
+
+- d4e8e6fb90: fix: modernjs dev server can't start normaly
+  fix: modernjs dev 服务端不能正常启动
+- 0b2d1ef02b: fix: repeat register `babel-plugin-lodash`
+  fix: 重复注册 `babel-plugin-lodash`
+- 217c43a: fix: should generate path correctly for data loader
+  fix: 应该生成正确的路径给 data loader
+- 82cef85ed7: fix: specify builder compiler framework
+  fix: 指明 builder 构建时框架
+- 1eeb052: fix: support set entry with file-system based router
+  fix: 约定式路由支持设置 entry
+- e011faf: fix: the esbuild watcher should be stoped when cli restart
+  fix: 当 cli 重启时，esbuild watcher 应该停止监听文件
+- 3e57f2bd58: feat: add document feature with plugin
+
+  feat: 增加 document 功能插件
+
+- 3941653: fix: add esbuild to dependencies
+  fix: 将 esbuild 添加到依赖中
+- 33aeb51: feat: add manifest field for router config
+  feat: 为 router 配置添加 manifest 字段
+- 85edee888c: feat(app-tools): support tools.htmlPlugin config
+
+  feat(app-tools): 支持 tools.htmlPlugin 配置项
+
+- 2e6031955e: fix: some optimizations for router and loader
+  fix: 一些 router 和 loader 的优化
+  q
+- 752480d: fix(app-tools): failed to copy public assets
+
+  fix(app-tools): 修复拷贝 public 下的静态文件失败的问题
+
+- a55b9656c4: fix: rename "loader routes" file to avoid influence ssr
+  fix: 重命名 loader routes 避免影响 ssr
+- 5402fdb0ca: feat(Builder): add output.disableTsChecker config
+
+  feat(Builder): 新增 output.disableTsChecker 配置项
+
+- dc8eeb9cbb: fix: clear distDirectory in prepare hook & inject data loader plugin to server
+  fix: 在 prepare hook 中清理 dist 目录，并且向 server 中注入 data loader plugin
+- cc971eabfc: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 5b9049f2e9: feat: inject async js chunk when streaming ssr
+  feat: streaming ssr 时, 注入 async 类型的 js chunk
+- d4a456659b: chore: rename plugin-jarvis to plugin-lint
+
+  chore: 重命名 plugin-jarvis 为 plugin-lint
+
+- 6bda14ed71: feat: refactor router with react-router@6.4
+
+  feat: 使用 react-router@6.4 重构路由模块
+
+- d36c6ee126: fix(app-tools): failed to run inspect command
+
+  fix(app-tools): 修复运行 inspect 命令失败的问题
+
+- 92004d1906: feat: support load chunks parallelly
+  feat: 支持并行加载 chunks
+- b8bbe036c7: feat: change type logic
+  feat: 修改类型相关的逻辑
+- 40ed5874c6: feat: inject css chunk into html for streaming ssr
+  feat: streaming ssr 返回的 html 注入 css chunk
+- af4422d67f: feat(builder): complete utils of tools.webpack
+
+  feat(builder): 补全 tools.webpack 提供的 utils 方法
+
+- 4293748: fix: router config maybe not defined
+  fix: router 配置可能不存在
+- 87c1ff86b9: feat(app-tools): attach builder instance to appContext
+
+  feat(app-tools): 将 builder 实例挂载到 appContext 上
+
+- c258e34202: fix: add builder hooks `beforeBuild` params
+  fix: 新增 builder hooks `beforeBuild` 的参数
+- 3b3d709ee2: fix(app-tools): cli --analyze option not work
+
+  fix(app-tools): 修复 --analyze 命令行参数不生效的问题
+
+- 8b8e1bb571: feat: support nested routes
+  feat: 支持嵌套路由
+- f5178e1: fix(app-tools): dev.startUrl not work
+
+  fix(app-tools): 修复 dev.startUrl 不生效的问题
+
+- 88eb147: fix(app-tools): builder's onBeforeCreateDevServer hook not work
+
+  fix(app-tools): 修复 builder 的 onBeforeCreateDevServer hook 无法触发的问题
+
+- 8c32dc4: fix: builder should not be checked when apiOnly is true
+  fix: 当 apiOnly 为 true 时，builder 不应该被校验
+- a2c8cc3eb5: fix: change tools define userconfig type
+  fix: 修改工程定义的 UserConfig 类型
+- b7a96c35fc: fix(app-tools): loose CLI init options after restart
+
+  fix(app-tools): 修复重启 CLI 后丢失 init options 的问题
+
+- df62445: fix: fix generateCode logic for windows
+  fix: 兼容 generateCode 的逻辑在 windows 平台
+- 7de97ae24f: fix: `deploy` command has't load `builder` instance
+  fix: `deploy` 命令没有加载 builder 实例
+- cce8ecee2d: fix: handle some `TODO` & `FIXME`, change some tests
+  fix: 处理一些 `TODO` 和 `FIXME`, 修改了一些 tests
+- c3b7de4bfb: fix(app-tools): dev.assetPrefix not work
+
+  fix(app-tools): 修复 dev.assetPrefix 配置项不生效的问题
+
+- 16a3441: fix(app-tools): remove duplicated port log
+
+  fix(app-tools): 修复 port 重复的日志输出两遍的问题
+
+- 92004d1906: fix: use loadable lazy instead of loadable
+  fix: 使用 loadable lazy 组件替代 loadable
+- c677befc22: fix(app-tools): compat legacy resolve behavior
+
+  fix(app-tools): 兼容旧版本 node_modules 解析逻辑
+
+- f1b8e8a: fix(app-tools): failed to copy HTML from config/public dir
+
+  fix(app-tools): 修复从 config/public 拷贝 HTML 文件时可能出现编译错误的问题
+
+- 3f7cde5caa: fix: builder plugin setup can't get config
+  fix: builder 插件在 setup 阶段无法拿到 config
+- 99213e4bae: fix: process does't exit when exec command
+  fix: 修复执行命令时进程未退出的问题
+- b16fd964da: fix: `modern-js/app-tools` pass error config to builder.
+  fix: `modern-js/app-tools` 传递错误的 config 给 builder.
+- 16ef1a7: fix(app-tools): should not increase port when restart
+
+  fix(app-tools): 修复 restart 时端口号会增加的问题
+
+- 7eefedd7ca: fix: add html-webpack-plugin `__internal__` options, for bottom template
+  fix: 为了 bottom template, 增加 `html-webpack-plugin` `__internal__` 配置项，
+- 14b712da84: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [c9f912ca4d]
+- Updated dependencies [95be7cc49c]
+- Updated dependencies [e439457a51]
+- Updated dependencies [4d1545f8c0]
+- Updated dependencies [4a7693f]
+- Updated dependencies [2bc090c089]
+- Updated dependencies [ba53257]
+- Updated dependencies [f0abb2e]
+- Updated dependencies [f96a725211]
+- Updated dependencies [7879e8f]
+- Updated dependencies [828f42f9ce]
+- Updated dependencies [060abd4553]
+- Updated dependencies [309cd71a1c]
+- Updated dependencies [c7456864a8]
+- Updated dependencies [c9e800d39a]
+- Updated dependencies [d4e8e6fb90]
+- Updated dependencies [0ff846fb56]
+- Updated dependencies [3cf9633195]
+- Updated dependencies [6604f1b]
+- Updated dependencies [57077b2c64]
+- Updated dependencies [217c43a]
+- Updated dependencies [d032d49e09]
+- Updated dependencies [6aca875]
+- Updated dependencies [2ff6167be0]
+- Updated dependencies [287f298990]
+- Updated dependencies [15bf09d9c8]
+- Updated dependencies [423188db70]
+- Updated dependencies [fd2d652c03]
+- Updated dependencies [0c2d8dae31]
+- Updated dependencies [2edad29dd7]
+- Updated dependencies [85edee888c]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [a2509bfbdb]
+- Updated dependencies [309f08b]
+- Updated dependencies [3998875791]
+- Updated dependencies [752480d]
+- Updated dependencies [b827e35]
+- Updated dependencies [ab3924a70e]
+- Updated dependencies [3998875791]
+- Updated dependencies [ba86b8b711]
+- Updated dependencies [61f21d1e77]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [5402fdb0ca]
+- Updated dependencies [2ae58176fe]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [5d67c26cdb]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [83ac356]
+- Updated dependencies [a3af050486]
+- Updated dependencies [d4a456659b]
+- Updated dependencies [18360a38d7]
+- Updated dependencies [6bda14ed71]
+- Updated dependencies [0b314e6946]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [5911154129]
+- Updated dependencies [40ed5874c6]
+- Updated dependencies [af4422d67f]
+- Updated dependencies [705adc1dae]
+- Updated dependencies [f680410886]
+- Updated dependencies [87c1ff86b9]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [4f277fe]
+- Updated dependencies [102d32e4ba]
+- Updated dependencies [c258e34202]
+- Updated dependencies [812913ccdd]
+- Updated dependencies [7248342e4d]
+- Updated dependencies [568eab1e42]
+- Updated dependencies [8b8e1bb571]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [ae71096d45]
+- Updated dependencies [73cd29dd9f]
+- Updated dependencies [e06b9a2]
+- Updated dependencies [b710adb843]
+- Updated dependencies [b7a96c35fc]
+- Updated dependencies [a23010138d]
+- Updated dependencies [75d1b2657c]
+- Updated dependencies [cce8ecee2d]
+- Updated dependencies [18aaf42249]
+- Updated dependencies [f179749375]
+- Updated dependencies [b8494ef]
+- Updated dependencies [3fae2d03b3]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [8a6d45f105]
+- Updated dependencies [143d8dd]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [ebbeed1ece]
+- Updated dependencies [6354cfa]
+- Updated dependencies [90e2879520]
+- Updated dependencies [e4558a0]
+- Updated dependencies [df41d71ade]
+- Updated dependencies [f727e5c6cc]
+- Updated dependencies [5e3cecd523]
+- Updated dependencies [92de772]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [da2d1fc3c2]
+- Updated dependencies [543be9558e]
+- Updated dependencies [fd1d9fd]
+- Updated dependencies [14b712da84]
+- Updated dependencies [a24f1c9]
+  - @modern-js/builder-webpack-provider@2.0.0-beta.4
+  - @modern-js/builder-shared@2.0.0-beta.4
+  - @modern-js/prod-server@2.0.0-beta.4
+  - @modern-js/server@2.0.0-beta.4
+  - @modern-js/types@2.0.0-beta.4
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/core@2.0.0-beta.4
+  - @modern-js/builder-plugin-esbuild@2.0.0-beta.4
+  - @modern-js/plugin-data-loader@2.0.0-beta.4
+  - @modern-js/builder-plugin-node-polyfill@2.0.0-beta.4
+  - @modern-js/node-bundle-require@2.0.0-beta.4
+  - @modern-js/plugin-lint@2.0.0-beta.4
+  - @modern-js/plugin@2.0.0-beta.4
+  - @modern-js/builder@2.0.0-beta.4
+  - @modern-js/plugin-i18n@2.0.0-beta.4
+  - @modern-js/new-action@2.0.0-beta.4
+  - @modern-js/upgrade@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/solutions/doc-tools/package.json
+++ b/packages/solutions/doc-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modern-js/doc-tools",
   "description": "The doc generator for Modern.js",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/packages/solutions/module-tools/CHANGELOG.md
+++ b/packages/solutions/module-tools/CHANGELOG.md
@@ -1,5 +1,120 @@
 # @modern-js/module-tools
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Minor Changes
+
+- 92f0eade39: feat:
+
+  1. add style config and add new hook
+  2. add dts alias logic
+  3. add copy logic
+  4. add log logic
+  5. add skipDeps config
+
+  feat:
+
+  1. 添加样式配置以及新的 hook
+  2. 添加 dts 别名处理
+  3. 添加 copy 逻辑
+  4. 添加日志逻辑
+  5. 添加 skipDeps 配置
+
+- 4fd53b48fd: feat: add normalize config logic
+  feat: 添加处理配置的逻辑
+- f0ee9120db: feat: change dev menu log
+  feat: 修改 dev 菜单展示的内容
+- 148fbf8: feat: update afterBuild options
+  feat: 更新 afterBuild 函数的参数
+- 0bb776858a: feat: add ModuleContext
+  feat: 添加 ModuleContext
+- e6bfca6d31: feat: add type define and schema for config
+  feat: 为配置增加类型定义和 schema
+- 54abc88a2a: feat: add new and upgrade command
+  feat: 添加 new 和 upgrade 命令
+- e4558a0: feat:
+
+  1. add `runBin` function
+  2. config internal plugins constants in the app/module/doc tools
+  3. add app/module/doc tools internal plugins
+
+  feat:
+
+  1. 添加 `runBin` 函数
+  2. 在 app/module/doc tools 里配置内部插件
+  3. 增加 app/module/doc tools 使用的插件常量
+
+### Patch Changes
+
+- d6546ad916: add buildConfig style in module-tools and remove tools
+  在 module-tools 里新增 buildConfig style 并删除 tools
+- d61ca88a0b: update speedy version
+  更新依赖里 speedy 的版本
+- 9f9ef4e: fix: fix alias resolve
+  fix: 修复别名处理
+- b8bbe036c7: feat: export Hooks type
+  feat: 导出 Hooks 类型
+- cc971eabfc: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- ebbeed1ece: update speedy-core to fix sass resolve error
+  更新 speedy-core 版本以修复 sass resolve 错误
+- d4a456659b: chore: rename plugin-jarvis to plugin-lint
+
+  chore: 重命名 plugin-jarvis 为 plugin-lint
+
+- 540de1fd5d: fix: filename typo, color.ts --> colors.ts
+  fix: 文件名错误，color.ts 修改为 colors.ts
+- a2c8cc3eb5: fix: change tools define userconfig type
+  fix: 修改工程定义的 UserConfig 类型
+- 1be4ba1ccd: feat: add platform build log
+  feat: 添加 platform 构建的 log 内容
+- 14b712da84: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [c9e800d39a]
+- Updated dependencies [6aca875]
+- Updated dependencies [85edee888c]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [a3af050486]
+- Updated dependencies [d4a456659b]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [f680410886]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [8b8e1bb571]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [b7a96c35fc]
+- Updated dependencies [cce8ecee2d]
+- Updated dependencies [f179749375]
+- Updated dependencies [b8494ef]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/core@2.0.0-beta.4
+  - @modern-js/plugin-lint@2.0.0-beta.4
+  - @modern-js/plugin@2.0.0-beta.4
+  - @modern-js/plugin-changeset@2.0.0-beta.4
+  - @modern-js/plugin-i18n@2.0.0-beta.4
+  - @modern-js/new-action@2.0.0-beta.4
+  - @modern-js/upgrade@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -11,7 +11,7 @@
     "module-tools",
     "lib-tools"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "bin": {
     "modern": "./bin/modern.js",
     "modern-module": "./bin/modern.js"

--- a/packages/solutions/monorepo-tools/CHANGELOG.md
+++ b/packages/solutions/monorepo-tools/CHANGELOG.md
@@ -1,5 +1,56 @@
 # @modern-js/monorepo-tools
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- d4a456659b: chore: rename plugin-jarvis to plugin-lint
+
+  chore: 重命名 plugin-jarvis 为 plugin-lint
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [c9e800d39a]
+- Updated dependencies [6aca875]
+- Updated dependencies [85edee888c]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [a3af050486]
+- Updated dependencies [d4a456659b]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [f680410886]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [8b8e1bb571]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [b7a96c35fc]
+- Updated dependencies [cce8ecee2d]
+- Updated dependencies [f179749375]
+- Updated dependencies [b8494ef]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+  - @modern-js/core@2.0.0-beta.4
+  - @modern-js/plugin-lint@2.0.0-beta.4
+  - @modern-js/plugin@2.0.0-beta.4
+  - @modern-js/plugin-changeset@2.0.0-beta.4
+  - @modern-js/plugin-i18n@2.0.0-beta.4
+  - @modern-js/new-action@2.0.0-beta.4
+  - @modern-js/upgrade@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/solutions/monorepo-tools/package.json
+++ b/packages/solutions/monorepo-tools/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/toolkit/compiler/babel/CHANGELOG.md
+++ b/packages/toolkit/compiler/babel/CHANGELOG.md
@@ -1,5 +1,35 @@
 # @modern-js/babel-compiler
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/toolkit/compiler/babel/package.json
+++ b/packages/toolkit/compiler/babel/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/toolkit/create/CHANGELOG.md
+++ b/packages/toolkit/create/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @modern-js/create
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- cc971eabfc: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 6b6f180279: fix: generator bundle
+
+  fix: 生成器打包
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/toolkit/create/package.json
+++ b/packages/toolkit/create/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/toolkit/e2e/package.json
+++ b/packages/toolkit/e2e/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@modern-js/e2e",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "build": "tsc",

--- a/packages/toolkit/main-doc/package.json
+++ b/packages/toolkit/main-doc/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "npx ts-node ./scripts/sync.ts"
   },
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/toolkit/node-bundle-require/CHANGELOG.md
+++ b/packages/toolkit/node-bundle-require/CHANGELOG.md
@@ -1,5 +1,39 @@
 # @modern-js/node-bundle-require
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- a2509bfbdb: feat: bump esbuild from 0.14.38 to 0.15.7
+
+  feat: 将 esbuild 从 0.14.38 版本升级至 0.15.7 版本
+
+- Updated dependencies [7879e8f]
+- Updated dependencies [6aca875]
+- Updated dependencies [2e6031955e]
+- Updated dependencies [7b7d12c]
+- Updated dependencies [92f0eade39]
+- Updated dependencies [edd1cfb1af]
+- Updated dependencies [cc971eabfc]
+- Updated dependencies [5b9049f2e9]
+- Updated dependencies [92004d1906]
+- Updated dependencies [b8bbe036c7]
+- Updated dependencies [d5a31df781]
+- Updated dependencies [dda38c9c3e]
+- Updated dependencies [3bbea92b2a]
+- Updated dependencies [b710adb843]
+- Updated dependencies [ea7cf06]
+- Updated dependencies [bbe4c4a]
+- Updated dependencies [e4558a0]
+- Updated dependencies [abf3421a75]
+- Updated dependencies [543be9558e]
+- Updated dependencies [14b712da84]
+  - @modern-js/utils@2.0.0-beta.4
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/toolkit/node-bundle-require/package.json
+++ b/packages/toolkit/node-bundle-require/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/node-bundle-require",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "The meta-framework suite designed from scratch for frontend-focused modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/toolkit/plugin/CHANGELOG.md
+++ b/packages/toolkit/plugin/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @modern-js/plugin
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- b8bbe036c7: feat: change type logic
+  feat: 修改类型相关的逻辑
+- f179749375: fix: the sortPlugins api not work
+
+  fix: sortPlugins 没有真实生效
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/toolkit/plugin/package.json
+++ b/packages/toolkit/plugin/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/toolkit/types/CHANGELOG.md
+++ b/packages/toolkit/types/CHANGELOG.md
@@ -1,5 +1,41 @@
 # @modern-js/types
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Patch Changes
+
+- 7879e8f: refactor: remove enableModernMode config
+
+  refactor: 不再支持 enableModernMode 配置项
+
+- 2e6031955e: fix: some optimizations for router and loader
+  fix: 一些 router 和 loader 的优化
+  q
+- cc971eabfc: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 6bda14ed71: feat: refactor router with react-router@6.4
+
+  feat: 使用 react-router@6.4 重构路由模块
+
+- 40ed5874c6: feat: inject css chunk into html for streaming ssr
+  feat: streaming ssr 返回的 html 注入 css chunk
+- 87c1ff86b9: feat(app-tools): attach builder instance to appContext
+
+  feat(app-tools): 将 builder 实例挂载到 appContext 上
+
+- 102d32e4ba: feat(server): add `req` and `res` to SSR context
+
+  feat(server): 添加 `req` 和 `res` 到 SSR context 中
+
+- 8b8e1bb571: feat: support nested routes
+  feat: 支持嵌套路由
+- 3bbea92b2a: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/toolkit/types/package.json
+++ b/packages/toolkit/types/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "types": "./index.d.ts",
   "exports": {
     ".": "./index.d.ts",

--- a/packages/toolkit/upgrade/package.json
+++ b/packages/toolkit/upgrade/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/toolkit/utils/CHANGELOG.md
+++ b/packages/toolkit/utils/CHANGELOG.md
@@ -1,5 +1,89 @@
 # @modern-js/utils
 
+## 2.0.0-beta.4
+
+### Major Changes
+
+- dda38c9c3e: chore: v2
+
+### Minor Changes
+
+- 92f0eade39: feat:
+
+  1. core: 增加 test 函数
+  2. module plugins: 增加 `babel`, `mainField`, `target` 插件
+  3. storybook: 修改部分逻辑并且增加 tspath webpack 插件
+  4. 增加 designSystem 配置
+
+  feat:
+
+  1. core: add test method
+  2. module plugins: add `babel`, `mainField`, `target` plugin
+  3. storybook: change some logic and add tspath webpack plugin
+  4. add `designSystem` config
+
+- edd1cfb1af: feat: modernjs Access builder compiler
+  feat: modernjs 接入 builder 构建
+- d5a31df781: refactor: remove unbundle configs and types
+
+  refactor: 移除 unbundle 相关的配置项和类型定义
+
+- b710adb843: feat: extract the data loader
+  feat: 提取 data loader
+- bbe4c4a: feat: add @modern-js/plugin-swc
+
+  feat: 新增 @modern-js/plugin-swc 插件
+
+- e4558a0: feat:
+
+  1. add `runBin` function
+  2. config internal plugins constants in the app/module/doc tools
+  3. add app/module/doc tools internal plugins
+
+  feat:
+
+  1. 添加 `runBin` 函数
+  2. 在 app/module/doc tools 里配置内部插件
+  3. 增加 app/module/doc tools 使用的插件常量
+
+- 543be9558e: feat: compile server loader and support handle loader request
+  feat: 编译 server loader 并支持处理 loader 的请求
+
+### Patch Changes
+
+- 7879e8f: refactor: remove enableModernMode config
+
+  refactor: 不再支持 enableModernMode 配置项
+
+- 6aca875: fix: remove phantom webpack dependencies in node-polyfill and webpack-dev-middleware
+  fix: 移除 node-polyfill 插件和 webpack-dev-middleware 中对 webpack 的幻影依赖
+- 2e6031955e: fix: some optimizations for router and loader
+  fix: 一些 router 和 loader 的优化
+  q
+- 7b7d12c: refactor: Substract getCorejsVersion to the util package, so that swc plugin can reuse it.
+  refactor: 将 getCorejsVersion 提取到 util 包，让 swc 插件可以复用其逻辑
+- cc971eabfc: refactor: move server plugin load logic in `@modern-js/core`
+  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑
+- 5b9049f2e9: feat: inject async js chunk when streaming ssr
+  feat: streaming ssr 时, 注入 async 类型的 js chunk
+- 92004d1906: feat: support load chunks parallelly
+  feat: 支持并行加载 chunks
+- b8bbe036c7: feat: change type logic
+  feat: 修改类型相关的逻辑
+- 3bbea92b2a: feat: support Hook、Middleware new API
+  feat: 支持 Hook、Middleware 的新 API
+- ea7cf06: chore: bump webpack/babel-loader/postcss-loader/tsconfig-paths
+
+  chore: 升级 webpack/babel-loader/postcss-loader/tsconfig-paths 版本
+
+- abf3421a75: fix(dev-server): isDepsExists add non pkgPath judege
+
+  修复: isDepsExists 方法添加 package.json 不存在的兜底
+
+- 14b712da84: fix: use consistent alias type and default value across packages
+
+  fix: 在各个包中使用一致的 alias 类型定义和默认值
+
 ## 2.0.0-beta.3
 
 ### Major Changes

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16483,10 +16483,8 @@ packages:
     dependencies:
       ajv: 6.12.6
 
-  /ajv-formats/2.1.1_ajv@8.11.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -17259,7 +17257,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.75.0
+      webpack: 5.75.0_esbuild@0.15.7
     dev: false
 
   /babel-loader/8.2.5_tktscwi5cl3qcx6vcfwkvrwn6i:
@@ -34632,7 +34630,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1_ajv@8.11.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scmp/2.1.0:

--- a/scripts/build/package.json
+++ b/scripts/build/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/build",
   "private": true,
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "main": "./src/index.js",
   "bin": {
     "modern-lib": "./bin/modern.js",

--- a/scripts/check-changeset/package.json
+++ b/scripts/check-changeset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scripts/check-changeset",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "private": true,
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/codemod/package.json
+++ b/scripts/codemod/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/codemod",
   "private": true,
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "scripts": {
     "build": "modern-lib build"
   },

--- a/scripts/jest-config/package.json
+++ b/scripts/jest-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/jest-config",
   "private": true,
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "main": "jest.config.js",
   "devDependencies": {
     "@swc/core": "1.3.18",

--- a/scripts/lint-package-json/package.json
+++ b/scripts/lint-package-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scripts/lint-package-json",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "private": true,
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/prebundle/package.json
+++ b/scripts/prebundle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/prebundle",
   "private": true,
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "main": "./dist/index.js",
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/vitest-config/package.json
+++ b/scripts/vitest-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/vitest-config",
   "private": true,
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/website/builder/package.json
+++ b/website/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/builder-website",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "scripts": {
     "dev": "vuepress dev src --temp .temp",
     "build": "vuepress build src --temp .temp && cp ./src/.vuepress/index.html ./src/.vuepress/dist"

--- a/website/main/package.json
+++ b/website/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-website",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/website/module-tools/package.json
+++ b/website/module-tools/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@modern-js/module-tools-docs",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "docs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION

# Release v2.0.0-beta.4



## Features:

- [#2360](https://github.com/modern-js-dev/modern.js/pull/2360) 

  feat: support modify routes for csr app

  feat: 支持 modifyRoutes API

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  feat:

  1. add style config and add new hook

2. add dts alias logic

3. add copy logic

4. add log logic

5. add skipDeps config

feat:

1. 添加样式配置以及新的 hook

2. 添加 dts 别名处理

3. 添加 copy 逻辑

4. 添加日志逻辑

5. 添加 skipDeps 配置

- [#2305](https://github.com/modern-js-dev/modern.js/pull/2305) 

  feat(builder): increase target node version to 14

  feat(builder): 提升 node 构建产物的目标环境为 node 14

- [#2336](https://github.com/modern-js-dev/modern.js/pull/2336) 

  refactor: remove enableModernMode config

  refactor: 不再支持 enableModernMode 配置项

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  add buildConfig style in module-tools and remove tools

  在module-tools里新增buildConfig style并删除tools

- [#2315](https://github.com/modern-js-dev/modern.js/pull/2315) 

  feat: support router basename

  feat: router 插件支持设置 basename

- [#2297](https://github.com/modern-js-dev/modern.js/pull/2297) 

  feat: support `models`,`initialState` config for state plugin

  feat: state 插件支持`model`,`initialState` 配置

- [#2368](https://github.com/modern-js-dev/modern.js/pull/2368) 

  feat: add manifest field for router config

  feat: 为 router 配置添加 manifest 字段

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  fix: fix alias resolve

  fix: 修复别名处理

- [#2366](https://github.com/modern-js-dev/modern.js/pull/2366) 

  feat: deep merge sass and less options in builder

  feat: Builder 中深层合并 sass 和 less 配置

- [#2337](https://github.com/modern-js-dev/modern.js/pull/2337) 

  feat: add Script commponent

  feat: 增加 Script 组件支持

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  feat: add normalize config logic

  feat: 添加处理配置的逻辑

- [#2341](https://github.com/modern-js-dev/modern.js/pull/2341) 

  feat: modernjs Access builder compiler

  feat: modernjs 接入 builder 构建

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  refactor: move server plugin load logic in `@modern-js/core`

  refactor：移除在 `@modern-js/core` 中的 server 插件加载逻辑

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  chore: rename plugin-jarvis to plugin-lint

  chore: 重命名 plugin-jarvis 为 plugin-lint

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  fix: filename typo, color.ts --> colors.ts

  fix: 文件名错误，color.ts 修改为 colors.ts

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  feat: change dev menu log

  feat: 修改 dev 菜单展示的内容

- [#2372](https://github.com/modern-js-dev/modern.js/pull/2372) 

  feat: update afterBuild options

  feat: 更新 afterBuild 函数的参数

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) chore: v2

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  feat: add ModuleContext

  feat: 添加 ModuleContext

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  feat: add type define and schema for config

  feat: 为配置增加类型定义和 schema

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  fix: change tools define userconfig type

  fix: 修改工程定义的 UserConfig 类型

- [#2341](https://github.com/modern-js-dev/modern.js/pull/2341) 

  feat: extract the data loader

  feat: 提取 data loader

- [#2288](https://github.com/modern-js-dev/modern.js/pull/2288) 

  feat: support internal env vars: metaName_TARGET

  feat: 支持内置环境变量 metaName_TARGET

- [#2347](https://github.com/modern-js-dev/modern.js/pull/2347) 

  feat: remove use plugin types restrict

  feat: 移除使用 plugin 类型限制

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  feat: add new and upgrade command

  feat: 添加new 和 upgrade 命令

- [#2357](https://github.com/modern-js-dev/modern.js/pull/2357) 

  feat(Builder): attach more plugin API to builder instance

  feat(Builder): 在 builder 实例上暴露更多的插件 API 方法

- [#2335](https://github.com/modern-js-dev/modern.js/pull/2335) 

  feat: add platform build log

  feat: 添加 platform 构建的 log 内容

- [#2289](https://github.com/modern-js-dev/modern.js/pull/2289) 

  feat: add @modern-js/plugin-swc

  feat: 新增 @modern-js/plugin-swc 插件

- [#2325](https://github.com/modern-js-dev/modern.js/pull/2325) 

  types(builder): move more PluginAPI types to shared

  types(builder): 下沉更多的 PluginAPI 类型到 shared

- [#2296](https://github.com/modern-js-dev/modern.js/pull/2296) 

  feat:

  1. add `runBin` function

2. config internal plugins constants in the app/module/doc tools

3. add app/module/doc tools internal plugins

feat:

1. 添加 `runBin` 函数

2. 在 app/module/doc tools 里配置内部插件

3. 增加 app/module/doc tools 使用的插件常量

- [#2398](https://github.com/modern-js-dev/modern.js/pull/2398) 

  feat(builder): export type of hook callback functions

  feat(builder): 导出 hook 回调函数的类型

## Bug Fix:

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: bootstrap function params type define

  fix: 修复 bootstrap 函数参数类型定义

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: fallback logic of streaming ssr

  feat: streaming ssr 降级逻辑

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(app-tools): improve build logs of dev and build command

  feat(app-tools): 优化 dev 和 build 过程中的日志展示

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(builder): add output.disableCssModuleExtension config

  feat(builder): 新增 output.disableCssModuleExtension 配置项

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: tsconfig-paths plugin's new node use old node flag

  fix: tsconfig-paths 插件转换的新节点使用旧节点的 flag

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  refactor: remove @babel/plugin-proposal-function-bind

  refactor: 移除 @babel/plugin-proposal-function-bind

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(builder): display user friendly progress percentage

  feat(builder): 展示用户友好的进度条进度

- [#2300](https://github.com/modern-js-dev/modern.js/pull/2300) 

  fix: root layout css chunks should't be loaded

  fix: 不应该加载 root layout 的 css chunks

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): incorrect ModuleFilenameHelpers path

  fix(builder): 修复 ModuleFilenameHelpers 路径大小写错误

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: compat Hook API in /server namespace

  fix: 在 @modern-js/runtime/server 命名空间下兼容 Hook API

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: remove webpack oneof rule in new config, save in legacy mode.

  fix: 在新模式下删除 webpack oneof 规则，兼容模式下保留

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(plugin-swc): failed to remove babel-loader

  fix(plugin-swc): 修复未正确移除 babel-loader 的问题

- [#2367](https://github.com/modern-js-dev/modern.js/pull/2367) 

  fix(Builder): failed to resolve typescript in some cases

  fix(Builder): 修复个别场景下无法解析到 typescript 的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: remove @loadable/component in streaming ssr

  feat: 移除 streaming ssr 中的 @loadable/component 逻辑

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(builder): ignore externals when target is web worker

  feat(builder): 构建 web worker 产物时忽略 externals 配置

- [#2350](https://github.com/modern-js-dev/modern.js/pull/2350) 

  fix: using DeepReadonly instead of deepFreezed

  fix: 使用 DeepReadonly 来代替 deepFreezed

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: builder tools.webpackChain config args not match the Modernjs tools.webpackChain

  fix: builder tools.webpackChain 配置传参无法匹配 Modernjs tools.webpackChain

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: bff api loader should run before babel loader

  fix: bff 一体化调用的 loader 应该在 babel loader 前执行

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): disable mergeLonghand option of cssnano

  fix(builder): 禁用 cssnano 的 mergeLonghand 选项

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  perf(builder): remove CSS contents from web-worker outputs

  perf(builder): 移除 web-worker 产物中的 CSS 内容

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): should not trigger onDevCompileDone when build

  fix(builder): 修复 build 时会触发 onDevCompileDone 钩子的问题

- [#2340](https://github.com/modern-js-dev/modern.js/pull/2340) 

  fix(app-tools): html.template config not work

  fix(app-tools): 修复 html.template 配置项不生效的问题

- [#2328](https://github.com/modern-js-dev/modern.js/pull/2328) 

  fix: add document cli export

  fix: 增加 document cli 插件的导出

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): fix lazyCompilation.entries typo

  fix(builder): 修复 lazyCompilation.entries 拼写错误

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: fix js chunk injecting location

  fix: 修复 js chunk 注入位置

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder-plugin-swc): Fix minify plugin includes css.

  fix(builder-plugin-swc): 修复 minify 插件误将css文件加入minify

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: support React18 streaming SSR

  feat: 支持 React18 流式 SSR

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: modernjs dev server can't start normaly

  fix: modernjs dev 服务端不能正常启动

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): esbuild minimize target should be es2015

  fix(builder): 修复 esbuild 压缩时未默认生成 es2015 产物的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: repeat register `babel-plugin-lodash`

  fix: 重复注册 `babel-plugin-lodash`

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): remove copy plugin when context not exists

  fix(builder): 当 context 不存在时自动移除 copy 插件

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  update speedy version

  更新依赖里speedy的版本

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): should emit fallback asset to static/media dir

  fix(builder): 修复 fallback 后的文件未输出到 static/media 目录的问题

- [#2353](https://github.com/modern-js-dev/modern.js/pull/2353) 

  fix: should generate path correctly for data loader

  fix: 应该生成正确的路径给 data loader

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: specify builder compiler framework

  fix: 指明 builder 构建时框架

- [#2390](https://github.com/modern-js-dev/modern.js/pull/2390) 

  fix: support set entry with file-system based router

  fix: 约定式路由支持设置 entry

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  export createHandle

  导出 createHandle 函数

- [#2303](https://github.com/modern-js-dev/modern.js/pull/2303) 

  fix: remove phantom webpack dependencies in node-polyfill and webpack-dev-middleware

  fix: 移除 node-polyfill 插件和 webpack-dev-middleware 中对 webpack 的幻影依赖

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  perf(Builder): disable CSS source map in production

  perf(Builder): 在生产环境下禁用 CSS 的 source map

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): source map of CSS files not work

  fix(builder): 修复 CSS 文件的 source map 不生效的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: support completely custom server, export render() api for render single page

  feat: 支持完全自定义 Server，导出 render() 方法用来渲染单个页面

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): only apply one tsChecker plugin when multiple targets

  fix(builder): 当同时存在多个 target 时，仅启用一个 tsChecker 插件

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): inline chunk plugin should not change script inject position

  fix(builder): inline chunk 插件不应该修改 script 插入位置

- [#2380](https://github.com/modern-js-dev/modern.js/pull/2380) 

  fix: the esbuild watcher should be stoped when cli restart

  fix: 当 cli 重启时，esbuild watcher 应该停止监听文件

- [#2363](https://github.com/modern-js-dev/modern.js/pull/2363) 

  fix: the Document.tsx missed hmr

  fix: Document.tsx 未能引发 hmr

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): failed remove css for node/worker target

  fix(builder): 修复 node/worker 产物时未正确移除 CSS 代码的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  chore(builder): bump dependencies to latest version

  chore(builder): 升级编译相关依赖到最新版本

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: add document feature with plugin

  feat: 增加 document 功能插件

- [#2326](https://github.com/modern-js-dev/modern.js/pull/2326) 

  fix: add esbuild to dependencies

  fix: 将 esbuild 添加到依赖中

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: change plugin-router-legacy exports field for node environment

  fix: 修改 plugin-router-legacy 的 exports 字段

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(app-tools): support tools.htmlPlugin config

  feat(app-tools): 支持 tools.htmlPlugin 配置项

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: some optimizations for router and loader

  fix: 一些 router 和 loader 的优化

q

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: esbuild should not handle js files

  fix: esbuild 不应该处理非 js 文件

- [#2375](https://github.com/modern-js-dev/modern.js/pull/2375) 

  fix(runtime): apply babel-plugin-ssr-loader-id when SSR is not used

  fix(runtime): 在未启动 SSR 时需要注册 babel-plugin-ssr-loader-id

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: fix ssg failure due to lack of Web Response API

  fix: 修复因为缺少 Web Response API 而导致 ssg 失败

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: bump esbuild from 0.14.38 to 0.15.7

  feat: 将 esbuild 从 0.14.38 版本升级至 0.15.7 版本

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: upgrade command update husky error

  fix: 修复 upgrade 命令升级 husky 错误问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): typo in dev.progressBar options, quite should be quiet

  fix(builder): 修复 dev.progressBar 的选项拼写错误, quite 应为 quiet

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: refactor legacy router support change router config

  feat: 开启 legacy 路由支持修改 router 配置

- [#2397](https://github.com/modern-js-dev/modern.js/pull/2397) 

  fix(app-tools): failed to copy public assets

  fix(app-tools): 修复拷贝 public 下的静态文件失败的问题

- [#2348](https://github.com/modern-js-dev/modern.js/pull/2348) 

  fix: only register babel-plugin-ssr-loader-id when SSR is enabled

  fix: 仅在开启 SSR 的场景下注册 babel-plugin-ssr-loader-id

- [#2323](https://github.com/modern-js-dev/modern.js/pull/2323) 

  fix: asset retry invalid

  fix: 解决静态资源重试失效问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): invalidate cache when buildDependencies changed

  fix(builder): 修复当 buildDependencies 变化时构建缓存未失效的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: support async export provider for module federation

  支持模块联邦场景异步导出 provider

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: export react-router-dom/server staticRouter

  feat: 导出 react-router-dom/server 的 staticRouter 组件

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: export Hooks type

  feat: 导出 Hooks 类型

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): incorrect target label when inspect configs

  fix(builder): 修复 inspect configs 时展示的 target 不正确的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): incorrect rules after enabling asset fallback

  fix(builder): 修复开启 asset fallback 后 webpack rules 不正确的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(babel-preset-app): remove useless plugin-transform-destructuring

  fix(babel-preset-app): 移除多余的 plugin-transform-destructuring 插件

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: ignore the entire distPath for pia ssr bundle

  fix: dist 目录的产物不应该被 ts-node 编译

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: change default document file and name

  fix: 重置默认的 document 文件和文件名

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: rename "loader routes" file to avoid influence ssr

  fix: 重命名 loader routes 避免影响 ssr

- [#2358](https://github.com/modern-js-dev/modern.js/pull/2358) 

  refactor: Substract getCorejsVersion to the util package, so that swc plugin can reuse it.

  refactor: 将 getCorejsVersion 提取到 util 包，让 swc 插件可以复用其逻辑

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: fix html template of streaming ssr

  fix: 修复流式渲染的 html 模版

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(Builder): add output.disableTsChecker config

  feat(Builder): 新增 output.disableTsChecker 配置项

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: change Hooks logic

  feat: 修改 Hooks 逻辑

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(builder): build method support custom compiler

  feat(builder): build 方法支持传入自定义的 compiler 对象

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat:

  1. core: 增加 test 函数

2. module plugins: 增加 `babel`, `mainField`, `target` 插件

3. storybook: 修改部分逻辑并且增加 tspath webpack 插件

4. 增加 designSystem 配置

feat:

1. core: add test method

2. module plugins: add `babel`, `mainField`, `target` plugin

3. storybook: change some logic and add tspath webpack plugin

4. add `designSystem` config

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: fix builder-doc broken link

  fix: 修复 builder-doc 中无法跳转的链接

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  chore: remove `registerPrefetch`

  chore: 移除 `registerPrefetch`

- [#2378](https://github.com/modern-js-dev/modern.js/pull/2378) 

  fix: fix state plugin config

  fix: 修复 state 插件 config 参数

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(builder): add output.cssModuleLocalIdentName config

  feat(builder): 新增 output.cssModuleLocalIdentName 配置项

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: clear distDirectory in prepare hook & inject data loader plugin to server

  fix: 在 prepare hook 中清理 dist 目录，并且向 server 中注入 data loader plugin

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  update speedy-core to fix sass resolve error

  更新speedy-core版本以修复sass resolve错误

- [#2346](https://github.com/modern-js-dev/modern.js/pull/2346) 

  fix: move babel-plugin-marcos to plugin-tailwindcss

  fix: 将 babel-plugin-marcos 依赖移动到 plugin-tailwindcss 中

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: inject async js chunk when streaming ssr

  feat: streaming ssr 时, 注入 async 类型的 js chunk

- [#2349](https://github.com/modern-js-dev/modern.js/pull/2349) 

  fix: bump loader-utils to fix security issue

  fix: 升级 loader-utils 以修复安全问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(plugin-lint): failed to execute modern lint command

  fix(plugin-lint): 修复执行 modern lint 命令失败的问题

- [#2355](https://github.com/modern-js-dev/modern.js/pull/2355) 

  fix(plugin-storybook): adapt builder & remove @modern-js/webpack dependency

  fix(plugin-storybook): 适配 modern/builder，并移除 @modern-js/webpack 依赖

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(builder): make preset chunk names more readable

  feat(builder): 优化预设 chunk 命名的可读性

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: refactor router with react-router@6.4

  feat: 使用 react-router@6.4 重构路由模块

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  add api in module tools doc

  模块工程文档v2新增api部分

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(app-tools): failed to run inspect command

  fix(app-tools): 修复运行 inspect 命令失败的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(server-utils): incorrect babel-compiler version

  fix(server-utils): 修复引用错误的 babel-compiler 版本的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): failed to print correct file sizes

  fix(builder): 修复无法正确输出构建产物体积的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: support load chunks parallelly

  feat: 支持并行加载 chunks

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: change type logic

  feat: 修改类型相关的逻辑

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: develop documentation directly with main-doc

  feat: 直接使用 main-doc 包开发文档

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): adjust default split chunk group

  fix(builder): 调整默认的 split chunk 分组

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: inject css chunk into html for streaming ssr

  feat: streaming ssr 返回的 html 注入 css chunk

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(builder): complete utils of tools.webpack

  feat(builder): 补全 tools.webpack 提供的 utils 方法

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(Builder): allow to set some configs by target

  feat(Builder): 部分配置项支持根据 target 来设置

- [#2382](https://github.com/modern-js-dev/modern.js/pull/2382) 

  fix: router config maybe not defined

  fix: router 配置可能不存在

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(plugin-polyfill): failed to join flags when restart CLI

  fix(plugin-polyfill): 修复重启 CLI 时报错 join flags 失败的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: upgrade ESLint to 8.x version

  feat: 升级 ESLint 到 8.x 版本

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(app-tools): attach builder instance to appContext

  feat(app-tools): 将 builder 实例挂载到 appContext 上

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: function extname should not return array

  fix: 函数 extname 不应该返回一个数组

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  chore(server-utils): using pre-bundled tsconfig-paths

  chore(server-utils): 使用预打包的 tsconfig-paths 依赖

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  refactor: remove unbundle configs and types

  refactor: 移除 unbundle 相关的配置项和类型定义

- [#2377](https://github.com/modern-js-dev/modern.js/pull/2377) 

  fix(server): remove peer dependencies warning

  fix(server): 修复 peer dependencies 出现 warning 提示的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(server): add `req` and `res` to SSR context

  feat(server): 添加 `req` 和 `res` 到 SSR context 中

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: add builder hooks `beforeBuild` params

  fix: 新增 builder hooks `beforeBuild` 的参数

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(Builder): add output.disableCssExtract config

  feat(Builder): 新增 output.disableCssExtract 配置项

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  add api doc about style

  新增了style的api文档

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(app-tools): cli --analyze option not work

  fix(app-tools): 修复 --analyze 命令行参数不生效的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(builder): move part of config types to shared

  feat(builder): 将一部分公共的 config 类型定义下沉到 shared 中

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: storybook generator runtimeDependenceVersion keyword

  fix: storybook 生成器 runtimeDependenceVersion 关键字

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(builder): print progress in non-tty environment

  feat(builder): 在非 tty 环境下输出编译进度

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: support nested routes

  feat: 支持嵌套路由

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: support Hook、Middleware new API

  feat: 支持 Hook、Middleware 的新 API

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(builder): improve webpack config for node target

  feat(builder): 优化 target 为 node 时的 webpack 配置

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(server): add favicon fallback handler

  fix(server): 添加 favicon 兜底处理逻辑

- [#2373](https://github.com/modern-js-dev/modern.js/pull/2373) 

  fix(app-tools): dev.startUrl not work

  fix(app-tools): 修复 dev.startUrl 不生效的问题

- [#2374](https://github.com/modern-js-dev/modern.js/pull/2374) 

  fix: esbuild config use file

  fix: 更改 esbuild 读取指定 ts 配置

- [#2302](https://github.com/modern-js-dev/modern.js/pull/2302) 

  fix(app-tools): builder's onBeforeCreateDevServer hook not work

  fix(app-tools): 修复 builder 的 onBeforeCreateDevServer hook 无法触发的问题

- [#2309](https://github.com/modern-js-dev/modern.js/pull/2309) 

  fix: builder should not be checked when apiOnly is true

  fix: 当 apiOnly 为 true 时，builder 不应该被校验

- [#2324](https://github.com/modern-js-dev/modern.js/pull/2324) 

  fix(builder): failed to resolve schema-utils when import svg

  fix(builder): 修复引用 SVG 时找不到 schema-utils 模块的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(app-tools): loose CLI init options after restart

  fix(app-tools): 修复重启 CLI 后丢失 init options 的问题

- [#2332](https://github.com/modern-js-dev/modern.js/pull/2332) 

  fix: fix generateCode logic for windows

  fix: 兼容 generateCode 的逻辑在 windows 平台

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(builder): add api.getHTMLPaths method

  feat(builder): 新增 api.getHTMLPaths 方法

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): missing source map of inlined chunks

  fix(builder): 修复 inlined chunks 缺少 source map 文件的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: `deploy` command has't load `builder` instance

  fix: `deploy` 命令没有加载 builder 实例

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: handle some `TODO` & `FIXME`, change some tests

  fix: 处理一些 `TODO` 和 `FIXME`, 修改了一些 tests

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: fix server loader redirects

  fix: 修复 server loader 重定向错误

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  chore(plugin-swc): Update tests, add auto detect module type, add pluginLockCorejsVersion

  chore(plugin-swc): 更新单测，加入自动检测模块类型，加入了core-js和@swc/helpers 路径重写功能

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(app-tools): dev.assetPrefix not work

  fix(app-tools): 修复 dev.assetPrefix 配置项不生效的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: loadApp when dom is mount

  修复 dom 未渲染时挂载子应用行为

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: the sortPlugins api not work

  fix: sortPlugins 没有真实生效

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: remove overmuch `@modernjs/utils` dependency import in ssr runtime & SSR hydrate error

  fix: 去除 ssr 运行时过多的 `@modernjs/utils` 依赖引入 & SSR hydrate 错误

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(builder): add source.exclude config

  feat(builder): 新增 source.exclude 配置项

- [#2386](https://github.com/modern-js-dev/modern.js/pull/2386) 

  chore: bump webpack/babel-loader/postcss-loader/tsconfig-paths

  chore: 升级 webpack/babel-loader/postcss-loader/tsconfig-paths 版本

- [#2310](https://github.com/modern-js-dev/modern.js/pull/2310) 

  fix(app-tools): remove duplicated port log

  fix(app-tools): 修复 port 重复的日志输出两遍的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  chore(builder): move mini-css-extract-plugin type to dev dependencies

  chore(builder): 将 mini-css-extract-plugin 类型定义改为 dev dependencies

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: use loadable lazy instead of loadable

  fix: 使用 loadable lazy 组件替代 loadable

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(app-tools): compat legacy resolve behavior

  fix(app-tools): 兼容旧版本 node_modules 解析逻辑

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  chore: dev server default cross origin

  chore: 开发环境 Server 默认跨域

- [#2385](https://github.com/modern-js-dev/modern.js/pull/2385) 

  fix(app-tools): failed to copy HTML from config/public dir

  fix(app-tools): 修复从 config/public 拷贝 HTML 文件时可能出现编译错误的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: builder plugin setup can't get config

  fix: builder 插件在 setup 阶段无法拿到 config

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: process does't exit when exec command

  fix: 修复执行命令时进程未退出的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): should emit app icon to static/image dir

  fix(builder): 修复 app icon 未被输出到 static/image 目录的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: support update main-doc when package build or website build

  feat: 支持在包发布和官网发布时，更新 main-doc 包

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: `modern-js/app-tools` pass error config to builder.

  fix: `modern-js/app-tools` 传递错误的 config 给 builder.

- [#2338](https://github.com/modern-js-dev/modern.js/pull/2338) 

  fix(app-tools): should not increase port when restart

  fix(app-tools): 修复 restart 时端口号会增加的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: add html-webpack-plugin `__internal__` options, for bottom template

  fix: 为了 bottom template, 增加 `html-webpack-plugin` `__internal__` 配置项，

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: generator bundle

  fix: 生成器打包

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat(Builder): add experiments.lazyCompilation config

  feat(Builder): 新增 experiments.lazyCompilation 配置项

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  perf(builder): Using shorter classname in production to reduce bundle size

  perf(builder): 使用更简短的 CSS modules 类名来减少包体积

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): skip rem plugin when target is node or web worker

  fix(builder): 当构建 node 或 web worker 产物时跳过 rem 插件

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(dev-server): isDepsExists add non pkgPath judege

  修复: isDepsExists 方法添加 package.json 不存在的兜底

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix(builder): failed to resolve core-js in some cases

  fix(builder): 修复部分情况下无法找到 core-js 的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  feat: compile server loader and support handle loader request

  feat: 编译 server loader 并支持处理 loader 的请求

- [#2307](https://github.com/modern-js-dev/modern.js/pull/2307) 

  fix: can not resolve core-js when compile third party packages

  fix: 修复编译三方包时无法找到 core-js 的问题

- [#2281](https://github.com/modern-js-dev/modern.js/pull/2281) 

  fix: use consistent alias type and default value across packages

  fix: 在各个包中使用一致的 alias 类型定义和默认值

- [#2364](https://github.com/modern-js-dev/modern.js/pull/2364) 

  fix(builder): incorrect HMR behavior in some cases

  fix(builder): 修复部分场景下 HMR 失效或反复刷新的问题

