### PR TITLE
fix(builder): remove source map warning in production

### DIFF
--- a/.changeset/sour-balloons-matter.md
+++ b/.changeset/sour-balloons-matter.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): remove source map warning in production
+
+fix(builder): 修复生产环境存在 source map warning 的问题

--- a/packages/builder/builder-rspack-provider/src/plugins/devtool.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/devtool.ts
@@ -11,7 +11,10 @@ export const PluginDevtool = (): BuilderPlugin => ({
       if (!isUseJsSourceMap(config)) {
         rspackConfig.devtool = false;
       } else {
-        const devtool = isProd ? 'source-map' : 'cheap-module-source-map';
+        const devtool = isProd
+          ? // hide the source map URL in production to avoid Chrome warning
+            'hidden-source-map'
+          : 'cheap-module-source-map';
         rspackConfig.devtool = devtool;
       }
     });

--- a/packages/builder/builder-webpack-provider/src/plugins/devtool.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/devtool.ts
@@ -11,7 +11,10 @@ export const PluginDevtool = (): BuilderPlugin => ({
       if (!isUseJsSourceMap(config)) {
         chain.devtool(false);
       } else {
-        const devtool = isProd ? 'source-map' : 'cheap-module-source-map';
+        const devtool = isProd
+          ? // hide the source map URL in production to avoid Chrome warning
+            'hidden-source-map'
+          : 'cheap-module-source-map';
         chain.devtool(devtool);
       }
     });

--- a/website/builder/src/en/guide/advanced/build-performance.md
+++ b/website/builder/src/en/guide/advanced/build-performance.md
@@ -5,7 +5,7 @@ Modern.js Builder optimizes build performance by default, but as the project bec
 This document provides some optional speed-up strategies, developers can choose some of them to improve the build performance.
 
 :::tip 📢 Notice
-The strategies in [Bundle Size Optimization](/zh/guide/advanced/optimize-bundle) can also be used to improve build performance, so we won't repeat them here.
+The strategies in [Bundle Size Optimization](/en/guide/advanced/optimize-bundle) can also be used to improve build performance, so we won't repeat them here.
 :::
 
 ## General optimization strategy

--- a/website/builder/src/en/guide/advanced/inline-assets.md
+++ b/website/builder/src/en/guide/advanced/inline-assets.md
@@ -96,7 +96,7 @@ Excluding assets from inlining will increase the number of assets that the Web A
 
 In addition to inlining static resource files into JS files, Builder also supports inlining JS files into HTML files.
 
-Just enable the [output.enableInlineScripts](/zh/api/config-output.html#output-enableinlinescripts) config, and the generated JS files will not be written into the output directory, but will be directly inlined to the corresponding in the HTML file.
+Just enable the [output.enableInlineScripts](/en/api/config-output.html#output-enableinlinescripts) config, and the generated JS files will not be written into the output directory, but will be directly inlined to the corresponding in the HTML file.
 
 ```ts
 export default {
@@ -114,7 +114,7 @@ Inline JS files may cause the single HTML file to be too large, and it will brea
 
 You can also inline CSS files into HTML files.
 
-Just enable the [output.enableInlineStyles](/zh/api/config-output.html#output-enableinlinestyles) config, the generated CSS file will not be written into the output directory, but will be directly inlined to the corresponding in the HTML file.
+Just enable the [output.enableInlineStyles](/en/api/config-output.html#output-enableinlinestyles) config, the generated CSS file will not be written into the output directory, but will be directly inlined to the corresponding in the HTML file.
 
 ```ts
 export default {

--- a/website/builder/src/en/guide/basic/alias.md
+++ b/website/builder/src/en/guide/basic/alias.md
@@ -11,7 +11,7 @@ In Builder, you can set aliases in two ways:
 
 ## Using `source.alias` config
 
-[source.alias](/zh/api/config-source.html#source-alias) corresponds to webpack's native [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) config, you can configure it as an object or a function.
+[source.alias](/en/api/config-source.html#source-alias) corresponds to webpack's native [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) config, you can configure it as an object or a function.
 
 First, you can configure it as an object, for example:
 

--- a/website/builder/src/en/guide/basic/typescript.md
+++ b/website/builder/src/en/guide/basic/typescript.md
@@ -28,7 +28,7 @@ export default {
 };
 ```
 
-More configuration can be found at [tools.tsLoader](/zh/api/config-tools.html#tools-tsloader).
+More configuration can be found at [tools.tsLoader](/en/api/config-tools.html#tools-tsloader).
 
 If ts-loader is enabled with default configuration, it does not have type checking, we do type checking by [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin).
 
@@ -36,7 +36,7 @@ If ts-loader is enabled with default configuration, it does not have type checki
 
 If you want a super fast compiler, and you don't need some custom Babel plugins, then you can use SWC for compilation and minification.
 
-SWC plugin in Builder supports TypeScript, TSX and legacy decorator, you can check [SWC plugin](/zh/plugins/plugin-swc.html).
+SWC plugin in Builder supports TypeScript, TSX and legacy decorator, you can check [SWC plugin](/en/plugins/plugin-swc.html).
 
 ### Why Babel is the default option
 
@@ -56,7 +56,7 @@ export default {
 };
 ```
 
-More configurations can be seen at [tsChecker configuration](/zh/api/config-tools.html#tools-tschecker)。
+More configurations can be seen at [tsChecker configuration](/en/api/config-tools.html#tools-tschecker)。
 
 Note that if ts-loader is enabled and `compileOnly: false` is set, please disable tsChecker to avoid duplicate type-checking.
 

--- a/website/builder/src/en/plugins/list.md
+++ b/website/builder/src/en/plugins/list.md
@@ -7,4 +7,4 @@
 - [@modern-js/builder-plugin-node-polyfill](/plugins/plugin-node-polyfill.html): Inject Polyfills of Node core modules in the browser side.
 - [@modern-js/builder-plugin-image-compress](/plugins/plugin-image-compress.html)：Compress the image resources used in the project.
 
-You can find the source code of these plugins in [modern.js/packages/builder](https://github.com/modern-js-dev/modern.js/tree/next/packages/builder) directory.
+You can find the source code of these plugins in [modern.js/packages/builder](https://github.com/modern-js-dev/modern.js/tree/main/packages/builder) directory.

--- a/website/builder/src/zh/plugins/list.md
+++ b/website/builder/src/zh/plugins/list.md
@@ -7,4 +7,4 @@
 - [@modern-js/builder-plugin-node-polyfill](/plugins/plugin-node-polyfill.html)：注入 Node 核心模块在浏览器端的 Polyfills。
 - [@modern-js/builder-plugin-image-compress](/plugins/plugin-image-compress.html)：将项目中用到的图片资源进行压缩处理。
 
-你可以在 [modern.js/packages/builder](https://github.com/modern-js-dev/modern.js/tree/next/packages/builder) 目录下找到这些插件的源代码。
+你可以在 [modern.js/packages/builder](https://github.com/modern-js-dev/modern.js/tree/main/packages/builder) 目录下找到这些插件的源代码。


### PR DESCRIPTION
# PR Details

## Description

Remove source map warning in production, because we will not upload the source map files to CDN.

<img width="760" alt="截屏2022-12-15 19 56 04" src="https://user-images.githubusercontent.com/7237365/207853615-44e8eabc-b4dc-4cc8-abc7-59188bd7c5d7.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
