### PR TITLE
fix(builder): missing html.mountId default value

### DIFF
--- a/.changeset/heavy-dryers-burn.md
+++ b/.changeset/heavy-dryers-burn.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): missing html.mountId default value
+
+fix(builder): 修复 html.mountId 默认值错误的问题

--- a/packages/builder/builder-rspack-provider/src/plugins/html.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/html.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import {
   isFileExists,
-  DEFAULT_MOUNT_ID,
   getDistPath,
   setConfig,
   getMinify,
@@ -38,7 +37,7 @@ async function getTemplateParameters(
   const baseParameters = {
     meta,
     title,
-    mountId: mountId || DEFAULT_MOUNT_ID,
+    mountId,
     entryName,
     assetPrefix,
   };

--- a/packages/builder/builder-rspack-provider/src/types/config/html.ts
+++ b/packages/builder/builder-rspack-provider/src/types/config/html.ts
@@ -1,5 +1,8 @@
-import type { SharedHtmlConfig } from '@modern-js/builder-shared';
+import type {
+  SharedHtmlConfig,
+  NormalizedSharedHtmlConfig,
+} from '@modern-js/builder-shared';
 
 export type HtmlConfig = SharedHtmlConfig;
 
-export type NormalizedHtmlConfig = HtmlConfig;
+export type NormalizedHtmlConfig = NormalizedSharedHtmlConfig;

--- a/packages/builder/builder-shared/src/config.ts
+++ b/packages/builder/builder-shared/src/config.ts
@@ -9,16 +9,18 @@ import {
   IMAGE_DIST_DIR,
   MEDIA_DIST_DIR,
   SERVER_DIST_DIR,
+  DEFAULT_MOUNT_ID,
   DEFAULT_DATA_URL_SIZE,
 } from './constants';
 import type {
-  NormalizedSharedDevConfig,
-  NormalizedSharedOutputConfig,
+  BuilderTarget,
   SharedHtmlConfig,
-  NormalizedSharedSourceConfig,
   InspectConfigOptions,
   CreateBuilderOptions,
-  BuilderTarget,
+  NormalizedSharedDevConfig,
+  NormalizedSharedOutputConfig,
+  NormalizedSharedSourceConfig,
+  NormalizedSharedHtmlConfig,
 } from './types';
 import { logger } from './logger';
 import { join } from 'path';
@@ -42,8 +44,9 @@ export const defaultSourceConfig: NormalizedSharedSourceConfig = {
   compileJsDataURI: true,
 };
 
-export const defaultHtmlConfig: SharedHtmlConfig = {
+export const defaultHtmlConfig: NormalizedSharedHtmlConfig = {
   inject: 'head',
+  mountId: DEFAULT_MOUNT_ID,
   crossorigin: false,
   disableHtmlFolder: false,
 };

--- a/packages/builder/builder-shared/src/types/config/html.ts
+++ b/packages/builder/builder-shared/src/types/config/html.ts
@@ -91,4 +91,9 @@ export interface SharedHtmlConfig {
   >;
 }
 
-export type NormalizedHtmlConfig = SharedHtmlConfig;
+export type NormalizedSharedHtmlConfig = SharedHtmlConfig & {
+  mountId: string;
+  inject: ScriptInject;
+  crossorigin: boolean | CrossOrigin;
+  disableHtmlFolder: boolean;
+};

--- a/packages/builder/builder-shared/src/types/config/index.ts
+++ b/packages/builder/builder-shared/src/types/config/index.ts
@@ -1,5 +1,5 @@
 import type { SharedDevConfig, NormalizedSharedDevConfig } from './dev';
-import type { SharedHtmlConfig, NormalizedHtmlConfig } from './html';
+import type { SharedHtmlConfig, NormalizedSharedHtmlConfig } from './html';
 import type {
   SharedOutputConfig,
   NormalizedSharedOutputConfig,
@@ -29,7 +29,7 @@ export interface SharedBuilderConfig {
 
 export type SharedNormalizedConfig = DeepReadonly<{
   dev: NormalizedSharedDevConfig;
-  html: NormalizedHtmlConfig;
+  html: NormalizedSharedHtmlConfig;
   // alias type incompatible between webpack and rspack
   source: Omit<NormalizedSharedSourceConfig, 'alias'>;
   output: NormalizedSharedOutputConfig;

--- a/packages/builder/builder-webpack-provider/src/plugins/html.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/html.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import {
   isFileExists,
-  DEFAULT_MOUNT_ID,
   getDistPath,
   getMinify,
   getTitle,
@@ -41,7 +40,7 @@ async function getTemplateParameters(
   const baseParameters = {
     meta,
     title,
-    mountId: mountId || DEFAULT_MOUNT_ID,
+    mountId,
     entryName,
     assetPrefix,
   };

--- a/packages/builder/builder-webpack-provider/src/types/config/html.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/html.ts
@@ -1,5 +1,8 @@
-import type { SharedHtmlConfig } from '@modern-js/builder-shared';
+import type {
+  SharedHtmlConfig,
+  NormalizedSharedHtmlConfig,
+} from '@modern-js/builder-shared';
 
 export type HtmlConfig = SharedHtmlConfig;
 
-export type NormalizedHtmlConfig = HtmlConfig;
+export type NormalizedHtmlConfig = NormalizedSharedHtmlConfig;


### PR DESCRIPTION
# PR Details

## Description

Fix missing html.mountId default value, the `getDefaultConfig()` method should contain the default value of mountId.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
