### PR TITLE
fix(app-tools): incorrect dev.assetPrefix when using server.port

### DIFF
--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -1,5 +1,4 @@
 import { PluginAPI, ResolvedConfigContext } from '@modern-js/core';
-import type { webpack } from '@modern-js/builder-webpack-provider';
 import { createFileWatcher } from '../utils/createFileWatcher';
 import { printInstructions } from '../utils/printInstructions';
 import {
@@ -58,16 +57,10 @@ export const dev = async (api: PluginAPI<AppTools>, options: DevOptions) => {
 
   await hookRunners.beforeDev();
 
-  let compiler: webpack.Compiler | webpack.MultiCompiler | undefined;
-
   if (!appContext.builder && !apiOnly) {
     throw new Error(
       'Expect the Builder to have been initialized, But the appContext.builder received `undefined`',
     );
-  }
-
-  if (!apiOnly) {
-    compiler = await appContext.builder!.createCompiler();
   }
 
   await generateRoutes(appContext);
@@ -78,7 +71,6 @@ export const dev = async (api: PluginAPI<AppTools>, options: DevOptions) => {
       https: normalizedConfig.dev.https,
       ...normalizedConfig.tools?.devServer,
     },
-    compiler: compiler || null,
     pwd: appDirectory,
     config: normalizedConfig,
     serverConfigFile,
@@ -86,7 +78,10 @@ export const dev = async (api: PluginAPI<AppTools>, options: DevOptions) => {
   };
 
   if (apiOnly) {
-    const app = await createServer(serverOptions);
+    const app = await createServer({
+      ...serverOptions,
+      compiler: null,
+    });
     app.listen(port, async (err: Error) => {
       if (err) {
         throw err;
@@ -95,7 +90,6 @@ export const dev = async (api: PluginAPI<AppTools>, options: DevOptions) => {
     });
   } else {
     const { server } = await appContext.builder!.startDevServer({
-      compiler,
       printURLs: false,
       serverOptions,
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4062,6 +4062,27 @@ importers:
       '@types/react-dom': 18.0.6
       typescript: 4.7.4
 
+  tests/integration/asset-prefix:
+    specifiers:
+      '@types/jest': ^27
+      '@types/node': ^14
+    dependencies:
+      '@types/jest': 27.5.2
+      '@types/node': 14.18.21
+
+  tests/integration/asset-prefix/fixtures/dev-asset-prefix:
+    specifiers:
+      '@babel/runtime': ^7.18.0
+      '@modern-js/app-tools': workspace:*
+      react: ^18
+      react-dom: ^18
+    dependencies:
+      '@babel/runtime': 7.18.6
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    devDependencies:
+      '@modern-js/app-tools': link:../../../../../packages/solutions/app-tools
+
   tests/integration/async-entry:
     specifiers:
       '@modern-js/app-tools': workspace:*

--- a/tests/integration/asset-prefix/fixtures/dev-asset-prefix/modern.config.ts
+++ b/tests/integration/asset-prefix/fixtures/dev-asset-prefix/modern.config.ts
@@ -1,0 +1,11 @@
+export default {
+  dev: {
+    assetPrefix: true,
+  },
+  output: {
+    polyfill: 'off',
+  },
+  server: {
+    port: 3333,
+  },
+};

--- a/tests/integration/asset-prefix/fixtures/dev-asset-prefix/package.json
+++ b/tests/integration/asset-prefix/fixtures/dev-asset-prefix/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "name": "integration-dev-asset-prefix",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "modern build"
+  },
+  "dependencies": {
+    "react": "^18",
+    "react-dom": "^18",
+    "@babel/runtime": "^7.18.0"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*"
+  }
+}

--- a/tests/integration/asset-prefix/fixtures/dev-asset-prefix/src/index.ts
+++ b/tests/integration/asset-prefix/fixtures/dev-asset-prefix/src/index.ts
@@ -1,0 +1,1 @@
+console.log('hello world!');

--- a/tests/integration/asset-prefix/package.json
+++ b/tests/integration/asset-prefix/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "integration-asset-prefix",
+  "version": "1.0.0",
+  "dependencies": {
+    "@types/jest": "^27",
+    "@types/node": "^14"
+  }
+}

--- a/tests/integration/asset-prefix/test/.eslintrc.js
+++ b/tests/integration/asset-prefix/test/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: ['@modern-js'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.json'],
+  },
+};

--- a/tests/integration/asset-prefix/test/index.test.ts
+++ b/tests/integration/asset-prefix/test/index.test.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+import { readFileSync } from 'fs';
+import { modernStart, killApp } from '../../../utils/modernTestUtils';
+
+const fixtures = path.resolve(__dirname, '../fixtures');
+
+describe('asset prefix', () => {
+  it(`should generate assetPrefix correctly when dev.assetPrefix is true`, async () => {
+    const appDir = path.resolve(fixtures, 'dev-asset-prefix');
+
+    const app = await modernStart(appDir);
+
+    const HTML = readFileSync(
+      path.join(appDir, 'dist/html/main/index.html'),
+      'utf-8',
+    );
+    expect(HTML.includes('//localhost:3333/static/js/')).toBeTruthy();
+
+    killApp(app);
+  });
+});

--- a/tests/integration/asset-prefix/test/tsconfig.json
+++ b/tests/integration/asset-prefix/test/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": true,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "emitDeclarationOnly": true,
+    "isolatedModules": true,
+    "paths": {},
+    "types": ["node", "jest"]
+  }
+}

--- a/tests/integration/mwa-app/modern.config.ts
+++ b/tests/integration/mwa-app/modern.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
-  runtime: {
-    state: true,
+  dev: {
+    assetPrefix: true,
   },
-  output: {
-    disableTsChecker: true,
+  server: {
+    port: 3333,
   },
 });


### PR DESCRIPTION
# PR Details

## Description

Fix incorrect dev.assetPrefix when using server.port:

```ts
export default defineConfig({
  dev: {
    assetPrefix: true,
  },
  server: {
    port: 3333,
  },
});
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
