### PR TITLE
fix: inaccurate error info

### DIFF
--- a/.changeset/nasty-timers-brush.md
+++ b/.changeset/nasty-timers-brush.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix the wrong error message
+修复错误的报错信息

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@modern-js/core": "workspace:*",
-    "@modern-js/libuild": "0.7.2",
+    "@modern-js/libuild": "~0.7.3",
     "@modern-js/new-action": "workspace:*",
     "@modern-js/plugin": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",

--- a/packages/solutions/module-tools/src/builder/build.ts
+++ b/packages/solutions/module-tools/src/builder/build.ts
@@ -261,7 +261,7 @@ export const buildLib = async (
     throw new InternalBuildError(e, {
       target,
       format,
-      buildType: 'bundle',
+      buildType,
     });
   }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2902,7 +2902,7 @@ importers:
   packages/solutions/module-tools:
     specifiers:
       '@modern-js/core': workspace:*
-      '@modern-js/libuild': 0.7.2
+      '@modern-js/libuild': ~0.7.3
       '@modern-js/libuild-plugin-svgr': 0.6.0
       '@modern-js/libuild-plugin-swc': 0.6.0
       '@modern-js/new-action': workspace:*
@@ -2927,7 +2927,7 @@ importers:
       typescript: ^4
     dependencies:
       '@modern-js/core': link:../../cli/core
-      '@modern-js/libuild': 0.7.2
+      '@modern-js/libuild': 0.7.3
       '@modern-js/libuild-plugin-svgr': 0.6.0
       '@modern-js/libuild-plugin-swc': 0.6.0
       '@modern-js/new-action': link:../../generator/new-action
@@ -12627,8 +12627,8 @@ packages:
       '@modern-js/swc-plugins': 0.0.9
     dev: false
 
-  /@modern-js/libuild/0.7.2:
-    resolution: {integrity: sha512-1gnzi9z5nfzm3B4fpivYYKygi1vDWySM8CmrwZVo5KRMRWrRI3Grf9Bm3i2PGbTK1Wk1CnBy/8i5+KvEOsxr0A==}
+  /@modern-js/libuild/0.7.3:
+    resolution: {integrity: sha512-0mrQjp/k6RgtzQCRvjdg8jKJS8ofgpAeBQqHCP8aE6NJ8Lvx5B1erI/K15oBfUtc6UTFk3E8vXaL7eWBPSLomg==}
     hasBin: true
     dependencies:
       '@ast-grep/napi': 0.1.13


### PR DESCRIPTION
# PR Details


<!--- Provide a general summary of your changes in the Title above -->

## Description
When i use module-tools, i use bundleless, but i get a log like this, i fix it.
libuild error is fixed already in this [commit](https://github.com/modern-js-dev/libuild/commit/3092decefece9faa9d36ce8c372231b02c84307a)
![image](https://user-images.githubusercontent.com/50694858/208877567-0c7cdc3b-6832-43e6-90e5-97d037f605b7.png)


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
