### PR TITLE
feat: support auto inject metaName_ to webpack define plugin

### DIFF
--- a/packages/solutions/app-tools/src/config/initial/inits.ts
+++ b/packages/solutions/app-tools/src/config/initial/inits.ts
@@ -6,6 +6,7 @@ import {
   globby,
   isModernjsMonorepo,
 } from '@modern-js/utils';
+import { getAutoInjectEnv } from '../../utils/env';
 import { AppNormalizedConfig, IAppContext } from '../../types';
 
 export function initHtmlConfig(
@@ -58,6 +59,17 @@ export function initSourceConfig(
 ) {
   config.source.include = createBuilderInclude(config, appContext);
   config.source.moduleScopes = createBuilderModuleScope(config);
+  config.source.globalVars = createBuilderGlobalVars(config, appContext);
+
+  function createBuilderGlobalVars(
+    config: AppNormalizedConfig,
+    appContext: IAppContext,
+  ) {
+    const { globalVars = {} } = config.source;
+    const publicEnv = getAutoInjectEnv(appContext);
+    return { ...globalVars, ...publicEnv };
+  }
+
   function createBuilderInclude(
     config: AppNormalizedConfig,
     appContext: IAppContext,

--- a/packages/solutions/app-tools/src/utils/env.ts
+++ b/packages/solutions/app-tools/src/utils/env.ts
@@ -1,0 +1,14 @@
+import type { IAppContext } from '../types';
+
+export function getAutoInjectEnv(appContext: IAppContext) {
+  const { metaName } = appContext;
+  const prefix = `${metaName.split(/[-_]/)[0]}_`.toUpperCase();
+  const envReg = new RegExp(`^${prefix}`);
+  return Object.keys(process.env).reduce((prev, key) => {
+    const value = process.env[key];
+    if (envReg.test(key) && typeof value !== 'undefined') {
+      prev[`process.env.${key}`] = value;
+    }
+    return prev;
+  }, {} as Record<string, string>);
+}

--- a/packages/solutions/app-tools/tests/utils/env.test.ts
+++ b/packages/solutions/app-tools/tests/utils/env.test.ts
@@ -1,0 +1,14 @@
+import { getAutoInjectEnv } from '../../src/utils/env';
+
+describe('test env utils', () => {
+  it('should get auto inject env vars correctly', async () => {
+    process.env.MODERN_NAME = 'Modern.js';
+    process.env.MODERN_REGION = 'China';
+    process.env.MODERNA_NAME = 'Error';
+
+    const globalVars = getAutoInjectEnv({ metaName: 'modern' } as any);
+    expect(globalVars['process.env.MODERN_NAME']).toBe('Modern.js');
+    expect(globalVars['process.env.MODERN_REGION']).toBe('China');
+    expect(globalVars['process.env.MODERNA_NAME']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# PR Details

auto inject MODERN_ env vars to webpack define plugin

you can define in shell

```
MODERN_XXX=xxx pnpm run dev
```

or env var define in `.env.xxx` file

```
REACT_AGE=45
MODERN_XXX=xxx
```

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
