### PR TITLE
feat: doc-tools support sidebar link-only config

### DIFF
--- a/packages/cli/doc-core/src/node/createBuilder.ts
+++ b/packages/cli/doc-core/src/node/createBuilder.ts
@@ -145,18 +145,18 @@ export async function createModernBuilder(
   // Add post plugin
   docPlugins.push(replacePlugin());
 
+  const internalBuilderConfig = await createInternalBuildConfig(
+    userRoot,
+    config,
+    isSSR,
+  );
+
   // Process doc config by plugins
   for (const plugin of docPlugins) {
     if (typeof plugin.config === 'function') {
       config.doc = await plugin.config(config.doc || {});
     }
   }
-
-  const internalBuilderConfig = await createInternalBuildConfig(
-    userRoot,
-    config,
-    isSSR,
-  );
 
   const builderProvider = builderWebpackProvider({
     builderConfig: mergeBuilderConfig(

--- a/packages/cli/doc-core/src/node/plugins/replace.ts
+++ b/packages/cli/doc-core/src/node/plugins/replace.ts
@@ -1,6 +1,11 @@
 import { SidebarItem } from '../../shared/types/default-theme';
 import { applyReplaceRules } from '../utils/applyReplaceRules';
-import { DocPlugin, SidebarGroup, NavItem, DocConfig } from '@/shared/types';
+import {
+  DocPlugin,
+  NormalizedSidebarGroup,
+  NavItem,
+  DocConfig,
+} from '@/shared/types';
 
 // The plugin is used to replace the text in the nav and sidebar config
 export function replacePlugin(): DocPlugin {
@@ -30,7 +35,7 @@ export function replacePlugin(): DocPlugin {
       }
       // Replace sidebar config
       const traverseSidebar = (
-        sidebarItem: SidebarGroup | SidebarItem,
+        sidebarItem: NormalizedSidebarGroup | SidebarItem,
       ): void => {
         if ('items' in sidebarItem) {
           sidebarItem.items.forEach(item => {
@@ -41,11 +46,14 @@ export function replacePlugin(): DocPlugin {
           sidebarItem.text = applyReplaceRules(sidebarItem.text, replaceRules);
         }
       };
-      (Object.values(sidebar).flat() as (SidebarGroup | SidebarItem)[]).forEach(
-        sidebarItem => {
-          traverseSidebar(sidebarItem);
-        },
-      );
+      (
+        Object.values(sidebar).flat() as (
+          | NormalizedSidebarGroup
+          | SidebarItem
+        )[]
+      ).forEach(sidebarItem => {
+        traverseSidebar(sidebarItem);
+      });
       return docConfig;
     },
   };

--- a/packages/cli/doc-core/src/shared/types/default-theme.ts
+++ b/packages/cli/doc-core/src/shared/types/default-theme.ts
@@ -127,7 +127,7 @@ export interface Sidebar {
 export interface SidebarGroup {
   text: string;
   link?: string;
-  items: (SidebarItem | SidebarGroup)[];
+  items: (SidebarItem | SidebarGroup | string)[];
   collapsible?: boolean;
   collapsed?: boolean;
 }
@@ -211,4 +211,22 @@ export interface LocaleLinks {
 export interface LocaleLink {
   text: string;
   link: string;
+}
+
+// normalized config ---------------------------------------------------------
+export interface NormalizedSidebarGroup extends Omit<SidebarGroup, 'items'> {
+  items: (SidebarItem | NormalizedSidebarGroup)[];
+  collapsible: boolean;
+  collapsed: boolean;
+}
+export interface NormalizedSidebar {
+  [path: string]: (NormalizedSidebarGroup | SidebarItem)[];
+}
+export interface NormalizedLocales extends Omit<LocaleConfig, 'sidebar'> {
+  sidebar: NormalizedSidebar;
+}
+
+export interface NormalizedConfig extends Omit<Config, 'locales' | 'sidebar'> {
+  locales: NormalizedLocales[];
+  sidebar: NormalizedSidebar;
 }

--- a/packages/cli/doc-core/src/shared/types/index.ts
+++ b/packages/cli/doc-core/src/shared/types/index.ts
@@ -2,10 +2,13 @@ import type { ComponentType } from 'react';
 import type { BuilderConfig } from '@modern-js/builder-webpack-provider';
 import type { PluginConfig } from '@modern-js/core';
 import type { PluggableList } from 'unified';
-import { Config as DefaultThemeConfig } from './default-theme';
+import {
+  Config as DefaultThemeConfig,
+  NormalizedConfig as NormalizedDefaultThemeConfig,
+} from './default-theme';
 import { DocPlugin } from './Plugin';
 
-export { DefaultThemeConfig };
+export { DefaultThemeConfig, NormalizedDefaultThemeConfig };
 export * from './default-theme';
 
 export { DocPlugin };
@@ -91,7 +94,7 @@ export interface DocConfig<ThemeConfig = DefaultThemeConfig> {
   outDir?: string;
 }
 
-export interface SiteData<ThemeConfig = unknown> {
+export interface SiteData<ThemeConfig = NormalizedDefaultThemeConfig> {
   root: string;
   base: string;
   lang: string;

--- a/packages/cli/doc-core/src/theme-default/components/Overview/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Overview/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Header, SidebarGroup, SidebarItem } from 'shared/types';
+import { Header, NormalizedSidebarGroup, SidebarItem } from 'shared/types';
 import { useSidebarData } from '../../logic';
 import { Link } from '../Link';
 import { isEqualPath } from '../../logic/utils';
@@ -26,20 +26,20 @@ export function Overview() {
       page.routePath !== routePath,
   );
   const { items: overviewSidebarGroups } = useSidebarData() as {
-    items: (SidebarGroup | SidebarItem)[];
+    items: (NormalizedSidebarGroup | SidebarItem)[];
   };
   const groups = useMemo(() => {
     return overviewSidebarGroups
       .filter(item => 'items' in item)
       .map(sidebarGroup => ({
         name: sidebarGroup.text || '',
-        items: (sidebarGroup as SidebarGroup).items.map(
-          (item: SidebarGroup | SidebarItem) => {
+        items: (sidebarGroup as NormalizedSidebarGroup).items.map(
+          (item: NormalizedSidebarGroup | SidebarItem) => {
             const pageModule = overviewPageModules.find(m =>
               isEqualPath(m.routePath, withBase(item.link || '')),
             );
             const getChildLink = (
-              traverseItem: SidebarItem | SidebarGroup,
+              traverseItem: SidebarItem | NormalizedSidebarGroup,
             ): string => {
               if (traverseItem.link) {
                 return traverseItem.link;

--- a/packages/cli/doc-core/src/theme-default/components/Search/logic/search.ts
+++ b/packages/cli/doc-core/src/theme-default/components/Search/logic/search.ts
@@ -16,10 +16,11 @@ export interface Header {
 
 interface PageDataForSearch {
   title: string;
-  headers: string[];
   content: string;
   path: string;
   rawHeaders: Header[];
+  headers: string[];
+  headerStr: string;
 }
 
 interface CommonMatchResult {
@@ -89,13 +90,15 @@ export class PageSearcher {
         );
       })
       .map(page => {
+        const headers = (page.toc || []).map((header: Header) => header.text);
         return {
           title:
             page.title ??
             page.frontmatter?.title ??
             page.routePath.split('/').pop() ??
             '',
-          headers: (page.toc || []).map((header: Header) => header.text),
+          headers,
+          headerStr: headers.join(' '),
           content: normalizeContent(page.content || ''),
           path: page.routePath,
           rawHeaders: page.toc || [],
@@ -116,7 +119,7 @@ export class PageSearcher {
       async: true,
       doc: {
         id: 'path',
-        field: ['title', 'headers', 'content'],
+        field: ['title', 'headerStr', 'content'],
       },
       ...options,
     };

--- a/packages/cli/doc-core/src/theme-default/components/Siderbar/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Siderbar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { SidebarGroup, SidebarItem } from 'shared/types';
+import { NormalizedSidebarGroup, SidebarItem } from 'shared/types';
 import { matchRoutes, useNavigate } from 'react-router-dom';
 import { routes } from 'virtual-routes';
 import { Link } from '../Link';
@@ -12,7 +12,7 @@ interface Props {
   isSidebarOpen?: boolean;
   pathname: string;
   langRoutePrefix: string;
-  sidebarData: (SidebarGroup | SidebarItem)[];
+  sidebarData: (NormalizedSidebarGroup | SidebarItem)[];
 }
 
 const SINGLE_MENU_ITEM_HEIGHT = 28;
@@ -21,18 +21,18 @@ const singleItemHeight = SINGLE_MENU_ITEM_HEIGHT + MENU_ITEM_MARGIN;
 
 interface SidebarItemProps {
   id: string;
-  item: SidebarItem | SidebarGroup;
+  item: SidebarItem | NormalizedSidebarGroup;
   depth: number;
   activeMatcher: (link: string) => boolean;
   collapsed?: boolean;
   setSidebarData: React.Dispatch<
-    React.SetStateAction<(SidebarGroup | SidebarItem)[]>
+    React.SetStateAction<(NormalizedSidebarGroup | SidebarItem)[]>
   >;
   preloadLink: (link: string) => void;
 }
 
 // Notice: we must compute the height of children here, otherwise the animation of collapse will not work
-const getHeight = (item: SidebarGroup | SidebarItem): number => {
+const getHeight = (item: NormalizedSidebarGroup | SidebarItem): number => {
   if ('items' in item) {
     return item.collapsed
       ? singleItemHeight
@@ -86,7 +86,7 @@ export function SidebarGroupComp(props: SidebarItemProps) {
   const navigate = useNavigate();
   const containerRef = useRef<HTMLDivElement>(null);
   const active = item.link && activeMatcher(item.link);
-  const { collapsed, collapsible = true } = item as SidebarGroup;
+  const { collapsed, collapsible = true } = item as NormalizedSidebarGroup;
   const collapsibleIcon = (
     <div
       cursor-pointer="~"
@@ -109,7 +109,7 @@ export function SidebarGroupComp(props: SidebarItemProps) {
       const root = newSidebarData[initialIndex];
       let current = root;
       for (const index of indexes) {
-        current = (current as SidebarGroup).items[index];
+        current = (current as NormalizedSidebarGroup).items[index];
       }
       if ('items' in current) {
         current.collapsed = !current.collapsed;
@@ -161,7 +161,7 @@ export function SidebarGroupComp(props: SidebarItemProps) {
               : '0px',
         }}
       >
-        {(item as SidebarGroup)?.items?.map((item, index) => (
+        {(item as NormalizedSidebarGroup)?.items?.map((item, index) => (
           <div key={item.link} m="last:b-0.5 l-4">
             <SidebarItemComp
               {...props}
@@ -185,14 +185,17 @@ export function SideBar(props: Props) {
     sidebarData: rawSidebarData,
   } = props;
   const [sidebarData, setSidebarData] = useState<
-    (SidebarItem | SidebarGroup)[]
+    (SidebarItem | NormalizedSidebarGroup)[]
   >(rawSidebarData.filter(Boolean).flat());
   useEffect(() => {
     // 1. Update sidebarData when pathname changes
     // 2. For current active item, expand its parent group
     // Cache, Avoid redundant calculation
-    const matchCache = new WeakMap<SidebarGroup | SidebarItem, boolean>();
-    const match = (item: SidebarGroup | SidebarItem) => {
+    const matchCache = new WeakMap<
+      NormalizedSidebarGroup | SidebarItem,
+      boolean
+    >();
+    const match = (item: NormalizedSidebarGroup | SidebarItem) => {
       if (matchCache.has(item)) {
         return matchCache.get(item);
       }
@@ -210,7 +213,7 @@ export function SideBar(props: Props) {
       matchCache.set(item, false);
       return false;
     };
-    const traverse = (item: SidebarGroup | SidebarItem) => {
+    const traverse = (item: NormalizedSidebarGroup | SidebarItem) => {
       if ('items' in item) {
         item.items.forEach(traverse);
         if (match(item)) {
@@ -246,18 +249,20 @@ export function SideBar(props: Props) {
       }}
     >
       <nav m="t-1">
-        {sidebarData.map((item: SidebarGroup | SidebarItem, index: number) => (
-          <SidebarItemComp
-            id={String(index)}
-            item={item}
-            depth={0}
-            activeMatcher={activeMatcher}
-            key={item.text}
-            collapsed={(item as SidebarGroup).collapsed ?? true}
-            setSidebarData={setSidebarData}
-            preloadLink={preloadLink}
-          />
-        ))}
+        {sidebarData.map(
+          (item: NormalizedSidebarGroup | SidebarItem, index: number) => (
+            <SidebarItemComp
+              id={String(index)}
+              item={item}
+              depth={0}
+              activeMatcher={activeMatcher}
+              key={item.text}
+              collapsed={(item as NormalizedSidebarGroup).collapsed ?? true}
+              setSidebarData={setSidebarData}
+              preloadLink={preloadLink}
+            />
+          ),
+        )}
       </nav>
     </aside>
   );

--- a/packages/cli/doc-core/src/theme-default/logic/useLocaleSiteData.ts
+++ b/packages/cli/doc-core/src/theme-default/logic/useLocaleSiteData.ts
@@ -1,9 +1,9 @@
-import { LocaleConfig } from 'shared/types';
+import { NormalizedLocales } from 'shared/types';
 import { useLocation } from 'react-router-dom';
 import { usePageData, withBase } from '@/runtime';
 import { normalizeSlash } from '@/shared/utils/index';
 
-export function useLocaleSiteData(): LocaleConfig {
+export function useLocaleSiteData(): NormalizedLocales {
   const pageData = usePageData();
 
   const { pathname } =
@@ -18,7 +18,7 @@ export function useLocaleSiteData(): LocaleConfig {
       sidebar: themeConfig.sidebar,
       prevPageText: themeConfig.prevPageText,
       nextPageText: themeConfig.nextPageText,
-    } as LocaleConfig;
+    } as NormalizedLocales;
   }
   const localeKeys = locales.map(locale => locale.lang);
   const localeKey =

--- a/packages/cli/doc-core/src/theme-default/logic/useLocaleSiteData.ts
+++ b/packages/cli/doc-core/src/theme-default/logic/useLocaleSiteData.ts
@@ -31,5 +31,5 @@ export function useLocaleSiteData(): NormalizedLocales {
     ...localeInfo,
     langRoutePrefix:
       localeKey === defaultLang ? withBase('/') : withBase(localeKey),
-  };
+  } as NormalizedLocales;
 }

--- a/packages/cli/doc-core/src/theme-default/logic/usePrevNextPage.ts
+++ b/packages/cli/doc-core/src/theme-default/logic/usePrevNextPage.ts
@@ -1,4 +1,8 @@
-import { Sidebar, SidebarGroup, SidebarItem } from 'shared/types';
+import {
+  NormalizedSidebar,
+  NormalizedSidebarGroup,
+  SidebarItem,
+} from 'shared/types';
 import { useLocation } from 'react-router-dom';
 import { useLocaleSiteData } from './useLocaleSiteData';
 import { isEqualPath } from './utils';
@@ -9,8 +13,8 @@ export function usePrevNextPage() {
   const sidebar = localesData.sidebar || {};
   const flattenTitles: SidebarItem[] = [];
 
-  const walkThroughSidebar = (sidebar: Sidebar) => {
-    const walk = (sidebarItem: SidebarGroup | SidebarItem) => {
+  const walkThroughSidebar = (sidebar: NormalizedSidebar) => {
+    const walk = (sidebarItem: NormalizedSidebarGroup | SidebarItem) => {
       if ('items' in sidebarItem) {
         if (sidebarItem.link) {
           flattenTitles.push({

--- a/packages/cli/doc-core/src/theme-default/logic/useSidebarData.ts
+++ b/packages/cli/doc-core/src/theme-default/logic/useSidebarData.ts
@@ -1,4 +1,7 @@
-import { SidebarGroup, SidebarItem } from 'shared/types/default-theme';
+import {
+  NormalizedSidebarGroup,
+  SidebarItem,
+} from 'shared/types/default-theme';
 import { useEffect, useState } from 'react';
 import { useLocaleSiteData } from './useLocaleSiteData';
 import { isEqualPath } from './utils';
@@ -7,7 +10,7 @@ import { useLocation, withBase } from '@/runtime';
 interface SidebarData {
   // The group name for the sidebar
   group: string;
-  items: (SidebarGroup | SidebarItem)[];
+  items: (NormalizedSidebarGroup | SidebarItem)[];
 }
 
 export function useSidebarData(): SidebarData {
@@ -26,7 +29,7 @@ export function useSidebarData(): SidebarData {
       }
       // Such as `/guide/getting-started`, it will return the guide groups and the group name `Introduction`
       const result = sidebar[name].find(group => {
-        const match = (item: SidebarGroup | SidebarItem): boolean => {
+        const match = (item: NormalizedSidebarGroup | SidebarItem): boolean => {
           const equalFunc = () =>
             isEqualPath(withBase(item.link), currentPathname);
           if ('items' in item) {

--- a/packages/cli/doc-plugin-auto-sidebar/src/index.ts
+++ b/packages/cli/doc-plugin-auto-sidebar/src/index.ts
@@ -98,6 +98,8 @@ export interface Options {
   collapsed?: boolean;
 }
 
+const DEFAULT_POSITION = Infinity;
+
 export async function initFiles(paths: string[], userRoot: string) {
   return Promise.all(
     paths
@@ -168,8 +170,10 @@ export async function initAllCategories(
     }
 
     category.children.sort((a, b) => {
-      const positionA = a.meta?.position || a.meta?.sidebar_position || 0;
-      const positionB = b.meta?.position || b.meta?.sidebar_position || 0;
+      const positionA =
+        a.meta?.position || a.meta?.sidebar_position || DEFAULT_POSITION;
+      const positionB =
+        b.meta?.position || b.meta?.sidebar_position || DEFAULT_POSITION;
       return positionA - positionB;
     });
   });
@@ -203,8 +207,10 @@ export function getRootCategories(
     });
 
     category.children.sort((a, b) => {
-      const positionA = a.meta?.position || a.meta?.sidebar_position || 0;
-      const positionB = b.meta?.position || b.meta?.sidebar_position || 0;
+      const positionA =
+        a.meta?.position || a.meta?.sidebar_position || DEFAULT_POSITION;
+      const positionB =
+        b.meta?.position || b.meta?.sidebar_position || DEFAULT_POSITION;
       return positionA - positionB;
     });
 


### PR DESCRIPTION
# PR Details

1. 文档框架支持 sidebar 配置中仅填入文档路径，而不用填入 `{ text: string; link: string; }` 对象数据
2. 搜索索引优化，解决部分标题无法搜索到的问题 @李茂
3. 优化 auto sidebar 插件 sidebar_position 默认值 @嘉聪

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
