### PR TITLE
fix: disable exit process after build

### DIFF
--- a/.changeset/red-windows-flow.md
+++ b/.changeset/red-windows-flow.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: can't exit process after build
+fix: 在 build 后不退出程序

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -86,9 +86,6 @@ export const buildCommand = async (
     .action(async (options: BuildOptions) => {
       const { build } = await import('./commands/build');
       await build(api, options);
-      // force exit after build.
-      // eslint-disable-next-line no-process-exit
-      process.exit(0);
     });
 
   for (const platformBuilder of platformBuilders) {


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
analyse webpack plugin will start a server after build,
and maybe has some webpack plugin required continue to run after build 

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
