### PR TITLE
fix(doc-tools): improve tip style

### DIFF
--- a/packages/cli/doc-core/src/node/mdx/remarkPlugins/tip.ts
+++ b/packages/cli/doc-core/src/node/mdx/remarkPlugins/tip.ts
@@ -51,7 +51,7 @@ export const remarkPluginTip: Plugin<[], Root> = () => {
         {
           type: 'element',
           data: {
-            hProperties: { class: 'island-directive-content' },
+            hProperties: { class: 'modern-directive-content' },
           },
           children,
         },

--- a/packages/cli/doc-core/src/theme-default/components/SocialLinks/LinkContent.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/SocialLinks/LinkContent.tsx
@@ -53,7 +53,7 @@ export const LinkContent = (props: ILinkContentComp) => {
             border="rounded-xl"
             bg="white"
             style={{
-              boxShadow: 'var(--island-shadow-3)',
+              boxShadow: 'var(--modern-shadow-3)',
               border: '1px solid var(--modern-c-divider-light)',
               ...popperStyle,
             }}

--- a/packages/cli/doc-core/src/theme-default/styles/doc.css
+++ b/packages/cli/doc-core/src/theme-default/styles/doc.css
@@ -459,7 +459,7 @@
 .modern-doc .modern-directive {
   border: 1px solid transparent;
   border-radius: 8px;
-  padding: 16px 16px 8px;
+  padding: 16px 20px 8px;
   line-height: 24px;
   font-size: 14px;
   margin: 16px 0;


### PR DESCRIPTION
# PR Details

## Description

Fix `.modern-directive-content` not work, improve tip style.

Before:

<img width="808" alt="截屏2023-01-06 11 36 52" src="https://user-images.githubusercontent.com/7237365/210925267-304cd1c6-25f3-4eb6-b25a-db69a61a3099.png">

After:

<img width="817" alt="截屏2023-01-06 11 36 31" src="https://user-images.githubusercontent.com/7237365/210925272-25689d8a-a43e-4b03-a489-cc5a5fe2978b.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
