### PR TITLE
docs: fix disableNodePolyfill default value

### DIFF
--- a/packages/toolkit/main-doc/en/docusaurus-plugin-content-docs/current/configure/app/output/disable-node-polyfill.md
+++ b/packages/toolkit/main-doc/en/docusaurus-plugin-content-docs/current/configure/app/output/disable-node-polyfill.md
@@ -5,16 +5,18 @@ sidebar_label: disableNodePolyfill
 # output.disableNodePolyfill
 
 - Type: `boolean`
-- Default: `false`
+- Default: `true`
 
-By default Modern.js has built-in [node polyfill removed by webpack 5](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed).
+This config is used to control whether to inject the Polyfill of the Node module into the code.
 
-If you confirm that you do not need any Node Polyfill in the project, you can configure the following in `modern.config.ts` to turn off the built-in imported Node Polyfill:
+By default, we will not inject Node Polyfill into the code to avoid bundle size increase. If you need to inject Node Polyfill, you can set `output.disableNodePolyfill` to `false`:
 
 ```ts title="modern.config.ts"
 export default defineConfig({
   output: {
-    disableNodePolyfill: true,
+    disableNodePolyfill: false,
   },
 });
 ```
+
+This config is implemented based on the Node Polyfill plugin of Modern.js Builder, you can read [Modern.js Builder - Node Polyfill Plugin](https://modernjs.dev/builder/en/plugins/plugin-node-polyfill.html) documentation for details.

--- a/packages/toolkit/main-doc/zh/configure/app/output/disable-node-polyfill.md
+++ b/packages/toolkit/main-doc/zh/configure/app/output/disable-node-polyfill.md
@@ -5,16 +5,18 @@ sidebar_label: disableNodePolyfill
 # output.disableNodePolyfill
 
 - 类型： `boolean`
-- 默认值： `false`
+- 默认值： `true`
 
-默认情况下我们内置了 [webpack 5 移除掉的 node polyfill](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed)。
+该配置项用于控制是否在代码中注入 Node 模块的 Polyfill。
 
-如果确认项目下不需要任何 Node Polyfill，可以在 `modern.config.ts` 中配置如下关闭内置引入的 Node Polyfill：
+默认情况下，我们不会将 Node Polyfill 注入到代码中，以避免造成代码体积增大。如果你需要注入 Node Polyfill，可以将 `output.disableNodePolyfill` 设置为 `false`：
 
 ```ts title="modern.config.ts"
 export default defineConfig({
   output: {
-    disableNodePolyfill: true,
+    disableNodePolyfill: false,
   },
 });
 ```
+
+该配置项基于 Modern.js Builder 的 Node Polyfill 插件实现，你可以阅读 [Modern.js Builder - Node Polyfill 插件](https://modernjs.dev/builder/zh/plugins/plugin-node-polyfill.html) 文档来了解详细信息。


### PR DESCRIPTION
# PR Details

## Description

The default value of `disableNodePolyfill` is `true` in Modern.js v2, so we should update the document.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
