### PR TITLE
feat(app-tools): allow to use dev.port config

### DIFF
--- a/.changeset/curly-months-occur.md
+++ b/.changeset/curly-months-occur.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+feat(app-tools): allow to use dev.port config
+
+feat(app-tools): 支持使用 dev.port 配置

--- a/packages/solutions/app-tools/src/builder/index.ts
+++ b/packages/solutions/app-tools/src/builder/index.ts
@@ -93,7 +93,7 @@ export function createBuilderProviderConfig(
     output,
     dev: {
       ...normalizedConfig.dev,
-      port: normalizedConfig.server?.port,
+      port: appContext.port,
     },
     html: htmlConfig,
   };

--- a/packages/solutions/app-tools/src/types/config/dev.ts
+++ b/packages/solutions/app-tools/src/types/config/dev.ts
@@ -4,8 +4,7 @@ type BuilderDevConfig = Required<BuilderConfig>['dev'];
 
 export type DevProxyOptions = string | Record<string, string>;
 
-// dev.port is omitted, using server.port instead
-export interface DevUserConfig extends Omit<BuilderDevConfig, 'port'> {
+export interface DevUserConfig extends BuilderDevConfig {
   /**
    * The configuration of `dev.proxy` is provided by `proxy` plugin.
    * Please use `yarn new` or `pnpm new` to enable the corresponding capability.

--- a/packages/toolkit/main-doc/en/docusaurus-plugin-content-docs/current/configure/app/server/port.md
+++ b/packages/toolkit/main-doc/en/docusaurus-plugin-content-docs/current/configure/app/server/port.md
@@ -7,12 +7,32 @@ sidebar_label: port
 - Type: `number`
 - Default: `8080`
 
-Modern.js's default port is `8080`, when using the `dev`, `start` or `serve` command. You can change the port number using this configuration:
+When Modern.js executes `dev`, `start` and `serve` commands, it will start with `8080` as the default port, and will automatically increment the port number when the port is occupied. You can change the port number of Server through this config:
 
 ```js title="modern.config.ts"
 export default defineConfig({
   server: {
     port: 3000,
+  },
+});
+```
+
+### Difference with dev.port
+
+In most cases, we recommend using `server.port` instead of `dev.port` to set the port number, the differences between them are as follows:
+
+- `dev.port` only takes effect in the development, and `server.port` takes effect in both development and production.
+- In the development, `dev.port` takes precedence over `server.port`.
+
+When you set `dev.port` and `server.port` at the same time, `dev.port` will take effect in the development, and `server.port` will take effect in the production. For example, in the following example, the port in the development is `3001`, and the port in the production is `3002`.
+
+```ts title="modern.config.ts"
+export default defineConfig({
+  dev: {
+    port: 3001,
+  },
+  server: {
+    port: 3002,
   },
 });
 ```

--- a/packages/toolkit/main-doc/zh/configure/app/server/port.md
+++ b/packages/toolkit/main-doc/zh/configure/app/server/port.md
@@ -7,12 +7,32 @@ sidebar_label: port
 - 类型： `number`
 - 默认值： `8080`
 
-Modern.js 在执行 `dev`, `start` 和 `serve` 命令时，会以 `8080` 为默认端口启动，通过该配置可以修改 Server 启动的端口号：
+Modern.js 在执行 `dev`, `start` 和 `serve` 命令时，会以 `8080` 为默认端口启动，并会在端口被占用时自动递增端口号。你可以通过该配置来修改 Server 启动的端口号：
 
 ```ts title="modern.config.ts"
 export default defineConfig({
   server: {
     port: 3000,
+  },
+});
+```
+
+### 与 dev.port 的区别
+
+大多数情况下，我们推荐使用 `server.port` 而不是 `dev.port` 来设置端口号，他们之间的区别如下：
+
+- `dev.port` 仅在开发环境下生效，`server.port` 在开发环境和生产环境下均能生效。
+- 在开发环境下，`dev.port` 的优先级高于 `server.port`。
+
+当你同时设置 `dev.port` 和 `server.port` 时，`dev.port` 会在开发环境下生效，`server.port` 会在生产环境下生效。比如以下示例，在开发环境下的端口号为 `3001`，在生产环境下的端口号为 `3002`。
+
+```ts title="modern.config.ts"
+export default defineConfig({
+  dev: {
+    port: 3001,
+  },
+  server: {
+    port: 3002,
   },
 });
 ```

--- a/packages/toolkit/main-doc/zh/configure/app/server/port.md
+++ b/packages/toolkit/main-doc/zh/configure/app/server/port.md
@@ -24,7 +24,7 @@ export default defineConfig({
 - `dev.port` 仅在开发环境下生效，`server.port` 在开发环境和生产环境下均能生效。
 - 在开发环境下，`dev.port` 的优先级高于 `server.port`。
 
-当你同时设置 `dev.port` 和 `server.port` 时，`dev.port` 会在开发环境下生效，`server.port` 会在生产环境下生效。比如以下示例，在开发环境下的端口号为 `3001`，在生产环境下的端口号为 `3002`。
+当你同时设置 `dev.port` 和 `server.port` 时，`dev.port` 会在开发环境下生效，`server.port` 会在生产环境下生效。比如以下例子，在开发环境下监听的端口号为 `3001`，在生产环境下监听的端口号为 `3002`。
 
 ```ts title="modern.config.ts"
 export default defineConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16536,8 +16536,10 @@ packages:
     dependencies:
       ajv: 6.12.6
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -17304,7 +17306,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.75.0_esbuild@0.15.7
+      webpack: 5.75.0
     dev: false
 
   /babel-loader/9.1.0_ztqwsvkb6z73luspkai6ilstpu:
@@ -34638,7 +34640,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scmp/2.1.0:


### PR DESCRIPTION
# PR Details

## Description

目前 Builder 提供的 `dev.port` 配置和 Modern.js 的 `server.port` 配置在功能上有一定重合，因此我们在 Modern.js 中没有支持 `dev.port` 配置项。

但是用户可以在 Modern.js 及 Builder 文档中找到 `dev.port` 相关的介绍，却无法配置后无法生效，因而产生了困惑。我们虽然可以删除 Modern.js 中关于 `dev.port` 的文档，却无法删除 Builder 文档中 `dev.port` 的文档。

为了避免这种情况，我们后续允许在 Modern.js 中使用 `dev.port`，并在文档中说明这两者的区别。

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
