### PR TITLE
fix(doc-core): fix nav dropdown item text wrap

### DIFF
--- a/.changeset/sixty-cats-cover.md
+++ b/.changeset/sixty-cats-cover.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): fix nav dropdown item text wrap
+
+fix(doc-core): 修复导航栏下拉菜单的文字换行问题

--- a/packages/cli/doc-core/src/theme-default/components/Nav/NavMenuGroup.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Nav/NavMenuGroup.tsx
@@ -51,7 +51,7 @@ export function NavMenuGroup(item: NavMenuGroupItem) {
           p="3"
           w="full"
           h="full"
-          className="min-w-128px max-h-100vh rounded-xl"
+          className="min-w-128px max-h-100vh rounded-xl whitespace-nowrap"
           bg="white"
           style={{
             boxShadow: 'var(--modern-shadow-3)',
@@ -73,10 +73,22 @@ export function NavMenuGroup(item: NavMenuGroupItem) {
               return (
                 <div key={child.link} font="medium">
                   <Link href={child.link}>
-                    <div className="rounded-md" hover="bg-mute" p="y-1.6 l-3">
+                    <div
+                      className="rounded-md"
+                      hover="bg-mute"
+                      p="y-1.6 l-3 r-6"
+                    >
                       <div flex="~">
-                        <span m="r-1">{child.text}</span>
-                        <Right w="11px" h="11px" text="text-3" m="t-1 r-1" />
+                        <span m="r-1">
+                          {child.text}
+                          <Right
+                            w="11px"
+                            h="11px"
+                            text="text-3"
+                            m="t-1 r-1 l-1"
+                            className="inline-block align-text-top"
+                          />
+                        </span>
                       </div>
                     </div>
                   </Link>


### PR DESCRIPTION
# PR Details

Fix nav dropdown item text wrap.

Before:

<img width="198" alt="截屏2023-01-11 10 37 30" src="https://user-images.githubusercontent.com/7237365/211706307-5b02b034-2ca7-4135-88c3-55d227997e2a.png">

After:

<img width="262" alt="截屏2023-01-11 10 45 13" src="https://user-images.githubusercontent.com/7237365/211706319-82dfb986-ebb3-4e17-9599-818328d69ec5.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
