### PR TITLE
fix(app-tools): server.port not work in development

### DIFF
--- a/.changeset/few-lobsters-prove.md
+++ b/.changeset/few-lobsters-prove.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix(app-tools): server.port not work in development
+
+fix(app-tools): 修复开发环境下 server.port 不生效的问题

--- a/packages/solutions/app-tools/src/config/default.ts
+++ b/packages/solutions/app-tools/src/config/default.ts
@@ -4,7 +4,10 @@ import { IAppContext, AppUserConfig, AppLegacyUserConfig } from '../types';
 export function createDefaultConfig(appContext: IAppContext): AppUserConfig {
   const defaultBuilderConfig = createDefaultBuilderConfig();
 
-  const dev: AppUserConfig['dev'] = { ...defaultBuilderConfig.dev };
+  const dev: AppUserConfig['dev'] = {
+    ...defaultBuilderConfig.dev,
+    port: undefined,
+  };
   const tools: AppUserConfig['tools'] = { ...defaultBuilderConfig.tools };
   const output: AppUserConfig['output'] = {
     ...defaultBuilderConfig.output,

--- a/packages/solutions/app-tools/src/config/default.ts
+++ b/packages/solutions/app-tools/src/config/default.ts
@@ -6,6 +6,8 @@ export function createDefaultConfig(appContext: IAppContext): AppUserConfig {
 
   const dev: AppUserConfig['dev'] = {
     ...defaultBuilderConfig.dev,
+    // `dev.port` should not have a default value
+    // because we will use `server.port` by default
     port: undefined,
   };
   const tools: AppUserConfig['tools'] = { ...defaultBuilderConfig.tools };


### PR DESCRIPTION
# PR Details

## Description

Fix server.port not work in development, because `dev.port` has a default value and overrides the `server.port` config.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
