### PR TITLE
feat(doc-core): append main title as a suffix

### DIFF
--- a/.changeset/stupid-ravens-wink.md
+++ b/.changeset/stupid-ravens-wink.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-doc': patch
+'@modern-js/doc-core': patch
+---
+
+feat(doc-core): append main title as a suffix
+
+feat(doc-core): 将站点名称作为页面标题的后缀

--- a/packages/builder/builder-doc/docs/en/api/index.mdx
+++ b/packages/builder/builder-doc/docs/en/api/index.mdx
@@ -1,3 +1,5 @@
 ---
 overview: true
 ---
+
+# API

--- a/packages/builder/builder-doc/docs/zh/api/index.mdx
+++ b/packages/builder/builder-doc/docs/zh/api/index.mdx
@@ -1,3 +1,5 @@
 ---
 overview: true
 ---
+
+# API

--- a/packages/cli/doc-core/src/theme-default/layout/Layout/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/layout/Layout/index.tsx
@@ -45,9 +45,17 @@ export const Layout: React.FC<LayoutProps> = props => {
   } = usePageData();
   const localesData = useLocaleSiteData();
 
-  // Priority: front matter title > h1 title > site title
-  const title =
-    (frontmatter?.title ?? articleTitle) || siteData.title || localesData.title;
+  // Priority: front matter title > h1 title
+  let title = frontmatter?.title ?? articleTitle;
+  const mainTitle = siteData.title || localesData.title;
+
+  if (title) {
+    // append main title as a suffix
+    title = `${title} - ${mainTitle}`;
+  } else {
+    title = mainTitle;
+  }
+
   const description =
     frontmatter?.description || siteData.description || localesData.description;
   // Use doc layout by default


### PR DESCRIPTION
# PR Details

## Description

Append main title as a suffix.

Fox example, the main title is `Modern.js`，so the API page title will become `API - Modern.js`.

![image](https://user-images.githubusercontent.com/7237365/211767521-efd6967f-4303-404e-a596-6f32951f44bf.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
