### PR TITLE
fix(doc-core): remove duplicate base URL

### DIFF
--- a/.changeset/fuzzy-tigers-beg.md
+++ b/.changeset/fuzzy-tigers-beg.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): remove duplicate base URL
+
+fix(doc-core): 修复 base URL 重复添加的问题

--- a/packages/builder/builder-doc/modern.config.ts
+++ b/packages/builder/builder-doc/modern.config.ts
@@ -167,7 +167,7 @@ export default defineConfig({
   doc: {
     root: path.join(__dirname, 'docs'),
     lang: 'zh',
-    base: isProd ? '/builder/' : '/',
+    base: '/builder/',
     title: 'Modern.js Builder',
     markdown: {
       checkDeadLinks: isProd,
@@ -217,6 +217,9 @@ export default defineConfig({
           MODERN_JS: 'Modern.js',
         },
       },
+      dev: {
+        startUrl: 'http://localhost:8080/builder/'
+      }
     },
   },
 });

--- a/packages/builder/builder-doc/modern.config.ts
+++ b/packages/builder/builder-doc/modern.config.ts
@@ -167,7 +167,7 @@ export default defineConfig({
   doc: {
     root: path.join(__dirname, 'docs'),
     lang: 'zh',
-    base: '/builder/',
+    base: isProd ? '/builder/' : '/',
     title: 'Modern.js Builder',
     markdown: {
       checkDeadLinks: isProd,
@@ -217,9 +217,6 @@ export default defineConfig({
           MODERN_JS: 'Modern.js',
         },
       },
-      dev: {
-        startUrl: 'http://localhost:8080/builder/'
-      }
     },
   },
 });

--- a/packages/cli/doc-core/src/theme-default/components/HomeHero/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/HomeHero/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '../Button';
 import styles from './index.module.scss';
-import { normalizeHref, withBase, usePageData } from '@/runtime';
+import { normalizeHref, usePageData } from '@/runtime';
 
 const DEFAULT_HERO = {
   name: 'modern',
@@ -59,7 +59,7 @@ export function HomeHero() {
                 <Button
                   type="a"
                   text={action.text}
-                  href={normalizeHref(withBase(action.link))}
+                  href={normalizeHref(action.link)}
                   theme={action.theme}
                 />
               </div>


### PR DESCRIPTION
# PR Details

## Description

Remove duplicate base URL in Action Button, the `<Link>` component will call `withBase`, so we do not need to call `withBase` in Action Button.

![tDbSfk8AIo](https://user-images.githubusercontent.com/7237365/212225791-740bdefb-a10b-4cab-b6d5-ba9577216b00.jpg)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
