### PR TITLE
feat(builder): support port placeholder in dev.startUrl config

### DIFF
--- a/.changeset/quick-wombats-remember.md
+++ b/.changeset/quick-wombats-remember.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder': patch
+'@modern-js/builder-doc': patch
+---
+
+feat(builder): support port placeholder in dev.startUrl config
+
+feat(builder): 支持在 dev.startUrl 配置项中使用端口号占位符

--- a/packages/builder/builder-doc/docs/en/config/dev/startUrl.md
+++ b/packages/builder/builder-doc/docs/en/config/dev/startUrl.md
@@ -10,12 +10,24 @@ You can set it to the following values:
 ```js
 export default {
   dev: {
-    // Open the project's default preview page
+    // Open the project's default preview page, equivalent to `http://localhost:<port>`
     startUrl: true,
     // Open the specified page
     startUrl: 'http://localhost:8080',
     // Open multiple pages
     startUrl: ['http://localhost:8080', 'http://localhost:8080/about'],
+  },
+};
+```
+
+## Port placeholder
+
+Since the port number may change, you can use the `<port>` placeholder to refer to the current port number, and Builder will automatically replace the placeholder with the actual listening port number.
+
+```js
+export default {
+  dev: {
+    startUrl: 'http://localhost:<port>/home',
   },
 };
 ```

--- a/packages/builder/builder-doc/docs/zh/config/dev/startUrl.md
+++ b/packages/builder/builder-doc/docs/zh/config/dev/startUrl.md
@@ -10,12 +10,24 @@
 ```js
 export default {
   dev: {
-    // 打开项目的默认页面
+    // 打开项目的默认页面，等价于 `http://localhost:<port>`
     startUrl: true,
     // 打开指定的页面
     startUrl: 'http://localhost:8080',
     // 打开多个页面
     startUrl: ['http://localhost:8080', 'http://localhost:8080/about'],
+  },
+};
+```
+
+## 端口号占位符
+
+由于端口号可能会发生变动，你可以使用 `<port>` 占位符来指代当前端口号，Builder 会自动将占位符替换为实际监听的端口号。
+
+```js
+export default {
+  dev: {
+    startUrl: 'http://localhost:<port>/home',
   },
 };
 ```

--- a/packages/builder/builder-doc/modern.config.ts
+++ b/packages/builder/builder-doc/modern.config.ts
@@ -167,7 +167,7 @@ export default defineConfig({
   doc: {
     root: path.join(__dirname, 'docs'),
     lang: 'zh',
-    base: isProd ? '/builder/' : '/',
+    base: '/builder/',
     title: 'Modern.js Builder',
     markdown: {
       checkDeadLinks: isProd,
@@ -216,6 +216,9 @@ export default defineConfig({
         globalVars: {
           MODERN_JS: 'Modern.js',
         },
+      },
+      dev: {
+        startUrl: 'http://localhost:<port>/builder/',
       },
     },
   },

--- a/packages/builder/builder/src/plugins/startUrl.ts
+++ b/packages/builder/builder/src/plugins/startUrl.ts
@@ -1,6 +1,9 @@
 import _ from '@modern-js/utils/lodash';
 import type { DefaultBuilderPlugin } from '@modern-js/builder-shared';
 
+export const replacePlaceholder = (url: string, port: number) =>
+  url.replace(/<port>/g, String(port));
+
 export function builderPluginStartUrl(): DefaultBuilderPlugin {
   return {
     name: 'builder-plugin-start-url',
@@ -34,7 +37,7 @@ export function builderPluginStartUrl(): DefaultBuilderPlugin {
         } else {
           urls.push(
             ..._.castArray(startUrl).map(item =>
-              item.replace(/<port>/g, String(port)),
+              replacePlaceholder(item, port),
             ),
           );
         }

--- a/packages/builder/builder/src/plugins/startUrl.ts
+++ b/packages/builder/builder/src/plugins/startUrl.ts
@@ -15,8 +15,10 @@ export function builderPluginStartUrl(): DefaultBuilderPlugin {
         if (!isFirstCompile || !port) {
           return;
         }
+
         const config = api.getNormalizedConfig();
-        const { startUrl } = config.dev;
+        const { https, startUrl } = config.dev;
+
         if (!startUrl) {
           return;
         }
@@ -25,12 +27,18 @@ export function builderPluginStartUrl(): DefaultBuilderPlugin {
           '@modern-js/builder-shared/open'
         );
         const urls: string[] = [];
+
         if (startUrl === true) {
-          const protocol = config.dev.https ? 'https' : 'http';
+          const protocol = https ? 'https' : 'http';
           urls.push(`${protocol}://localhost:${port}`);
         } else {
-          urls.push(..._.castArray(startUrl));
+          urls.push(
+            ..._.castArray(startUrl).map(item =>
+              item.replace(/<port>/g, String(port)),
+            ),
+          );
         }
+
         for (const url of urls) {
           await open(url);
         }

--- a/packages/builder/builder/tests/plugins/startUrl.test.ts
+++ b/packages/builder/builder/tests/plugins/startUrl.test.ts
@@ -1,0 +1,16 @@
+import { expect, describe, it } from 'vitest';
+import { replacePlaceholder } from '@/plugins/startUrl';
+
+describe('plugins/startUrl', () => {
+  it('#replacePlaceholder - should replace port number correctly', () => {
+    expect(replacePlaceholder('http://localhost:8080', 3000)).toEqual(
+      'http://localhost:8080',
+    );
+    expect(replacePlaceholder('http://localhost:<port>', 3000)).toEqual(
+      'http://localhost:3000',
+    );
+    expect(replacePlaceholder('http://localhost:<port>/path/', 3000)).toEqual(
+      'http://localhost:3000/path/',
+    );
+  });
+});

--- a/website/module-tools/modern.config.ts
+++ b/website/module-tools/modern.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
   doc: {
     root: path.join(__dirname, 'docs'),
     lang: 'zh',
-    base: isDevCommand ? '' : '/module-tools/',
+    base: '/module-tools/',
     title: 'Module Tools',
     // The plugins for doc tools.
     plugins: [
@@ -114,6 +114,11 @@ export default defineConfig({
           description: 'Module Engineering Solutions',
         },
       ],
+    },
+  },
+  builderConfig: {
+    dev: {
+      startUrl: 'http://localhost:<port>/module-tools/',
     },
   },
 });


### PR DESCRIPTION
## Description

## Related Issue

Support port placeholder in `dev.startUrl` config.

Since the port number may change, you can use the `<port>` placeholder to refer to the current port number, and Builder will automatically replace the placeholder with the actual listening port number.

```js
export default {
  dev: {
    startUrl: 'http://localhost:<port>/home',
  },
};
```


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
