### PR TITLE
fix(prod-server): failed to match html inside config/public directory

### DIFF
--- a/.changeset/lazy-planes-trade.md
+++ b/.changeset/lazy-planes-trade.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix(prod-server): failed to match html inside config/public directory
+
+fix(prod-server): 修复无法正确匹配 config/public 目录下的 HTML 文件 URL 的问题

--- a/packages/server/prod-server/src/libs/route/matcher.ts
+++ b/packages/server/prod-server/src/libs/route/matcher.ts
@@ -10,6 +10,13 @@ import { ModernRoute, ModernRouteInterface } from './route';
 // avoid import @modern-js/utils
 const removeTailSlash = (s: string): string => s.replace(/\/+$/, '');
 
+const removeHtmlSuffix = (url: string) => {
+  if (url.endsWith('.html')) {
+    return url.slice(0, -5);
+  }
+  return url;
+};
+
 const toPath = (reg: string, params: Record<string, any>) => {
   const fn = compile(reg, { encode: encodeURIComponent });
   return fn(params);
@@ -71,19 +78,19 @@ export class RouteMatcher {
         ? requestUrl.slice(0, -1)
         : requestUrl;
 
-    if (urlWithoutSlash.endsWith('.html')) {
-      urlWithoutSlash = urlWithoutSlash.slice(0, -5);
-    }
+    urlWithoutSlash = removeHtmlSuffix(urlWithoutSlash);
 
     if (this.urlMatcher) {
       return Boolean(this.urlMatcher(urlWithoutSlash));
     } else {
-      if (urlWithoutSlash.startsWith(this.urlPath)) {
+      const urlPath = removeHtmlSuffix(this.urlPath);
+
+      if (urlWithoutSlash.startsWith(urlPath)) {
         // avoid /abcd match /a
         if (
-          this.urlPath !== '/' &&
-          urlWithoutSlash.length > this.urlPath.length &&
-          !urlWithoutSlash.startsWith(`${this.urlPath}/`)
+          urlPath !== '/' &&
+          urlWithoutSlash.length > urlPath.length &&
+          !urlWithoutSlash.startsWith(`${urlPath}/`)
         ) {
           return false;
         }

--- a/packages/server/prod-server/tests/route.test.ts
+++ b/packages/server/prod-server/tests/route.test.ts
@@ -33,6 +33,22 @@ describe('test route', () => {
       expect(matcher.matchUrlPath('/home')).toBeFalsy();
       expect(matcher.matchUrlPath('/home.html')).toBeFalsy();
     });
+
+    test('should matcher work correctly with static routes', () => {
+      const routeSpec = {
+        urlPath: '/static.html',
+        isSPA: true,
+        isSSR: false,
+        entryPath: 'public/static.html',
+      };
+      const matcher = new RouteMatcher(routeSpec);
+      matcher.generate('');
+      expect(matcher.matchUrlPath('/static')).toBeTruthy();
+      expect(matcher.matchUrlPath('/static.html')).toBeTruthy();
+      expect(matcher.matchUrlPath('/static_html')).toBeFalsy();
+      expect(matcher.matchUrlPath('/static_2')).toBeFalsy();
+      expect(matcher.matchUrlPath('/static_2.html')).toBeFalsy();
+    });
   });
 
   describe('test route manager', () => {


### PR DESCRIPTION
## Description

Fix failed to match html inside config/public directory. The urlPath of static routes will be `/xxx.html`, we need to remove `.html` to make the `matchUrlPath` working as expected.

## Related Issue

https://github.com/modern-js-dev/modern.js/issues/2381

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
