### PR TITLE
feat: dev.startUrl reuse exsiting tab under osx system

### DIFF
--- a/packages/builder/builder-shared/src/index.ts
+++ b/packages/builder/builder-shared/src/index.ts
@@ -18,3 +18,4 @@ export * from './devServer';
 export * from './chain';
 export * from './schema';
 export * from './plugins';
+export * from './openBrowser';

--- a/packages/builder/builder-shared/src/openBrowser.ts
+++ b/packages/builder/builder-shared/src/openBrowser.ts
@@ -1,0 +1,59 @@
+/**
+ * The following code is modified based on source found in
+ * https://github.com/facebook/create-react-app
+ *
+ * MIT Licensed
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * https://github.com/facebook/create-react-app/blob/master/LICENSE
+ */
+import { execSync } from 'child_process';
+import open from '../compiled/open';
+
+const supportedChromiumBrowsers = [
+  'Google Chrome Canary',
+  'Google Chrome Dev',
+  'Google Chrome Beta',
+  'Google Chrome',
+  'Microsoft Edge',
+  'Brave Browser',
+  'Vivaldi',
+  'Chromium',
+];
+
+export async function openBrowser(url: string): Promise<boolean> {
+  // If we're on OS X, the user hasn't specifically
+  // requested a different browser, we can try opening
+  // a Chromium browser with AppleScript. This lets us reuse an
+  // existing tab when possible instead of creating a new one.
+  const shouldTryOpenChromeWithAppleScript = process.platform === 'darwin';
+
+  if (shouldTryOpenChromeWithAppleScript) {
+    try {
+      const ps = execSync('ps cax').toString();
+      const openedBrowser = supportedChromiumBrowsers.find(b => ps.includes(b));
+      if (openedBrowser) {
+        // Try to reuse existing tab with AppleScript
+        execSync(
+          `osascript openChrome.applescript "${encodeURI(
+            url,
+          )}" "${openedBrowser}"`,
+          {
+            stdio: 'ignore',
+          },
+        );
+        return true;
+      }
+    } catch (err) {
+      return false;
+    }
+  }
+
+  // Fallback to open
+  // (It will always open new tab)
+  try {
+    await open(url);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}

--- a/packages/builder/builder/src/plugins/startUrl.ts
+++ b/packages/builder/builder/src/plugins/startUrl.ts
@@ -26,9 +26,6 @@ export function builderPluginStartUrl(): DefaultBuilderPlugin {
           return;
         }
 
-        const { default: open } = await import(
-          '@modern-js/builder-shared/open'
-        );
         const urls: string[] = [];
 
         if (startUrl === true) {
@@ -42,8 +39,10 @@ export function builderPluginStartUrl(): DefaultBuilderPlugin {
           );
         }
 
+        const { openBrowser } = await import('@modern-js/builder-shared');
+
         for (const url of urls) {
-          await open(url);
+          await openBrowser(url);
         }
       });
     },


### PR DESCRIPTION
## Description

This PR will help OS X user when set `dev.startUrl: true` reuse an existing tab instead of creating a new one.

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
