### PR TITLE
feat(builder): improve succeed and failed progress log

### DIFF
--- a/.changeset/grumpy-clocks-invent.md
+++ b/.changeset/grumpy-clocks-invent.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+feat(builder): improve succeed and failed progress log
+
+feat(builder): 优化编译成功或失败时的进度条效果

--- a/packages/builder/builder-webpack-provider/src/plugins/progress.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/progress.ts
@@ -11,6 +11,9 @@ export const builderPluginProgress = (): BuilderPlugin => ({
         return;
       }
 
+      const isFirstTarget =
+        !Array.isArray(api.context.target) || target === api.context.target[0];
+
       const { ProgressPlugin } = await import(
         '../webpackPlugins/ProgressPlugin/ProgressPlugin'
       );
@@ -18,6 +21,8 @@ export const builderPluginProgress = (): BuilderPlugin => ({
         {
           id: TARGET_ID_MAP[target],
           ...(options === true ? {} : options),
+          // If there is multiple target, show recompile log only once
+          showRecompileLog: isFirstTarget,
         },
       ]);
     });

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/bar.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/bar.ts
@@ -8,13 +8,13 @@ const defaultOption: Props = {
   current: 0,
   color: 'green',
   bgColor: 'gray',
-  char: '█',
+  char: '■',
   width: 25,
   buildIcon: '◯',
   finishIcon: '✔',
-  finishInfo: 'done',
+  finishInfo: 'Succeed',
   errorIcon: '✖',
-  errorInfo: 'fail',
+  errorInfo: 'Compile Failed',
   message: '',
   done: false,
   spaceWidth: 1,
@@ -65,7 +65,7 @@ export const renderBar = (option: Partial<Props>) => {
   };
   const space = ' '.repeat(spaceWidth);
   const percent = clamp(Math.floor((current / total) * 100), 0, 100);
-  const fc = Reflect.get(chalk, color);
+  const fc = hasErrors ? chalk.bold.red : Reflect.get(chalk, color);
   const bc = Reflect.get(chalk, bgColor);
   const idStr = id ? fc(padding(id, maxIdLen)) : '';
   const { columns = FULL_WIDTH } = process.stdout;
@@ -73,14 +73,16 @@ export const renderBar = (option: Partial<Props>) => {
   if (done) {
     const info = hasErrors ? errorInfo : finishInfo;
     const icon = hasErrors ? errorIcon : finishIcon;
-    const message = chalk.gray(
-      compileTime ? `${info} in ${compileTime}` : info,
+    const message = fc(
+      compileTime && !hasErrors ? `${info} in ${compileTime}` : info,
     );
+
     if (columns >= MIDDLE_WIDTH) {
       return [idStr, fc(`${icon}${space}${message}`)].join('');
     }
     return [idStr, fc(`${message}`)].join('');
   }
+
   const msgStr = Reflect.get(
     chalk,
     messageColor,

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/non-tty.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/non-tty.ts
@@ -26,7 +26,7 @@ export function createNonTTYLogger() {
       if (hasErrors) {
         logger.error(`[${id}] compile failed in ${compileTime}`);
       } else {
-        logger.success(`[${id}] compile done in ${compileTime}`);
+        logger.success(`[${id}] compile succeed in ${compileTime}`);
       }
     }
     // print progress when percentage increased by more than 10%

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -674,6 +674,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       "showDependencies": true,
       "showEntries": true,
       "showModules": true,
+      "showRecompileLog": true,
     },
     ForkTsCheckerWebpackPlugin {
       "options": {

--- a/tests/e2e/webpack-builder/progress/index.test.ts
+++ b/tests/e2e/webpack-builder/progress/index.test.ts
@@ -27,7 +27,7 @@ test('should emit progress log in non-TTY environment', async () => {
     infoMsgs.some(message => message.includes('[Client] compile progress')),
   ).toBeTruthy();
   expect(
-    successMsgs.some(message => message.includes('[Client] compile done')),
+    successMsgs.some(message => message.includes('[Client] compile succeed')),
   ).toBeTruthy();
 
   process.stdout.isTTY = true;


### PR DESCRIPTION
## Description

- improve succeed and failed progress log, make the status more intuitive.
- Add a recompile log.

### Before

The recompile is succeed, but user may not know it.

<img width="911" alt="截屏2023-01-20 下午2 45 15" src="https://user-images.githubusercontent.com/7237365/213641334-7cbf16f1-ad6a-46e2-844b-a330d24cea46.png">


### After

There will be a recompile log, and the succeed status is more intuitive.

![image](https://user-images.githubusercontent.com/7237365/213641318-131f4814-89ae-422c-9410-e40c43acfca9.png)

<img width="443" alt="截屏2023-01-20 下午3 26 59" src="https://user-images.githubusercontent.com/7237365/213641084-55279cdd-3581-4d06-9d08-6dfa6bac18ab.png">


## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
