### PR TITLE
fix: doc-tools overview page error

### DIFF
--- a/.changeset/shaggy-stingrays-explain.md
+++ b/.changeset/shaggy-stingrays-explain.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix: overview error caused by pages not found
+
+fix: 大纲页面因 pages 数据找不到而报错

--- a/packages/cli/doc-core/src/node/mdx/remarkPlugins/toc.ts
+++ b/packages/cli/doc-core/src/node/mdx/remarkPlugins/toc.ts
@@ -4,14 +4,9 @@ import { parse } from 'acorn';
 import Slugger from 'github-slugger';
 import type { Root } from 'hast';
 import type { MdxjsEsm, Program } from 'mdast-util-mdxjs-esm';
+import { Header } from '@/shared/types';
 
 const slugger = new Slugger();
-
-interface TocItem {
-  id: string;
-  text: string;
-  depth: number;
-}
 
 interface ChildNode {
   type: 'link' | 'text' | 'inlineCode';
@@ -27,7 +22,7 @@ interface Heading {
 
 export const parseToc = (tree: Root) => {
   let title = '';
-  const toc: TocItem[] = [];
+  const toc: Header[] = [];
 
   visitChildren((node: Heading) => {
     if (node.type !== 'heading' || !node.depth || !node.children) {

--- a/packages/cli/doc-core/src/node/virtualModule/siteData.ts
+++ b/packages/cli/doc-core/src/node/virtualModule/siteData.ts
@@ -185,6 +185,10 @@ export async function createSiteDataVirtualModulePlugin(
     root: userRoot,
     lang: userConfig?.lang || 'zh',
     logo: userConfig?.logo || '',
+    pages: pages.map(({ routePath, toc }) => ({
+      routePath,
+      toc,
+    })),
   };
   await fs.ensureDir(path.join(userRoot, PUBLIC_DIR));
   await fs.writeFile(

--- a/packages/cli/doc-core/src/shared/types/index.ts
+++ b/packages/cli/doc-core/src/shared/types/index.ts
@@ -23,6 +23,7 @@ export interface Header {
   text: string;
   depth: number;
 }
+
 export interface SiteSiteData {
   title: string;
   description: string;
@@ -107,6 +108,10 @@ export interface SiteData<ThemeConfig = NormalizedDefaultThemeConfig> {
   icon: string;
   themeConfig: ThemeConfig;
   logo: string;
+  pages: {
+    routePath: string;
+    toc: Header[];
+  }[];
 }
 
 export interface PageBasicInfo {

--- a/packages/cli/doc-core/src/theme-default/components/Overview/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Overview/index.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { Header, NormalizedSidebarGroup, SidebarItem } from 'shared/types';
-import { routes } from 'virtual-routes';
 import { useSidebarData } from '../../logic';
 import { Link } from '../Link';
 import { isEqualPath } from '../../logic/utils';
@@ -19,11 +18,12 @@ interface Group {
 }
 
 export function Overview() {
-  const { routePath } = usePageData();
-  const overviewRoutes = routes.filter(
-    route =>
-      route.path.startsWith(routePath.replace(/overview$/, '')) &&
-      route.path !== routePath,
+  const { routePath, siteData } = usePageData();
+  const { pages } = siteData;
+  const overviewModules = pages.filter(
+    page =>
+      page.routePath.startsWith(routePath.replace(/overview$/, '')) &&
+      page.routePath !== routePath,
   );
   const { items: overviewSidebarGroups } = useSidebarData() as {
     items: (NormalizedSidebarGroup | SidebarItem)[];
@@ -35,8 +35,8 @@ export function Overview() {
         name: sidebarGroup.text || '',
         items: (sidebarGroup as NormalizedSidebarGroup).items.map(
           (item: NormalizedSidebarGroup | SidebarItem) => {
-            const pageModule = overviewRoutes.find(m =>
-              isEqualPath(m.path, withBase(item.link || '')),
+            const pageModule = overviewModules.find(m =>
+              isEqualPath(m.routePath, withBase(item.link || '')),
             );
             const getChildLink = (
               traverseItem: SidebarItem | NormalizedSidebarGroup,

--- a/packages/cli/doc-core/src/theme-default/components/Overview/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Overview/index.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { Header, NormalizedSidebarGroup, SidebarItem } from 'shared/types';
+import { routes } from 'virtual-routes';
 import { useSidebarData } from '../../logic';
 import { Link } from '../Link';
 import { isEqualPath } from '../../logic/utils';
@@ -18,12 +19,11 @@ interface Group {
 }
 
 export function Overview() {
-  const { siteData, routePath } = usePageData();
-  const { pages } = siteData;
-  const overviewPageModules = pages.filter(
-    page =>
-      page.routePath.startsWith(routePath.replace(/overview$/, '')) &&
-      page.routePath !== routePath,
+  const { routePath } = usePageData();
+  const overviewRoutes = routes.filter(
+    route =>
+      route.path.startsWith(routePath.replace(/overview$/, '')) &&
+      route.path !== routePath,
   );
   const { items: overviewSidebarGroups } = useSidebarData() as {
     items: (NormalizedSidebarGroup | SidebarItem)[];
@@ -35,8 +35,8 @@ export function Overview() {
         name: sidebarGroup.text || '',
         items: (sidebarGroup as NormalizedSidebarGroup).items.map(
           (item: NormalizedSidebarGroup | SidebarItem) => {
-            const pageModule = overviewPageModules.find(m =>
-              isEqualPath(m.routePath, withBase(item.link || '')),
+            const pageModule = overviewRoutes.find(m =>
+              isEqualPath(m.path, withBase(item.link || '')),
             );
             const getChildLink = (
               traverseItem: SidebarItem | NormalizedSidebarGroup,

--- a/packages/cli/doc-core/src/theme-default/components/Siderbar/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Siderbar/index.tsx
@@ -40,7 +40,7 @@ export function SidebarItemComp(props: SidebarItemProps) {
     return (
       <SidebarGroupComp
         id={id}
-        key={id}
+        key={`${item.text}-${id}`}
         item={item}
         depth={depth}
         activeMatcher={activeMatcher}
@@ -77,7 +77,6 @@ export function SidebarGroupComp(props: SidebarItemProps) {
   const innerRef = useRef<HTMLDivElement>(null);
   const initialRender = useRef(true);
   const initialState = useRef((item as NormalizedSidebarGroup).collapsed);
-
   const active = item.link && activeMatcher(item.link);
   const { collapsed, collapsible = true } = item as NormalizedSidebarGroup;
   const collapsibleIcon = (


### PR DESCRIPTION
## Description

修复问题:

1. 大纲页面因为 pages 找不到而报错；
2. SidebarGroup 组件因 key 值不唯一，导致切换路由时 collapse 状态错乱，产生没必要的 collopse 动画

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
