### PR TITLE
fix: es5Plugin should apply after umd, umd will change the es5 code

### DIFF
--- a/.changeset/rotten-scissors-approve.md
+++ b/.changeset/rotten-scissors-approve.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix umd code can not support es5 target
+修复umd的代码不能被转换成es5的问题

--- a/packages/solutions/module-tools/src/builder/build.ts
+++ b/packages/solutions/module-tools/src/builder/build.ts
@@ -152,9 +152,9 @@ export const buildLib = async (
   const { es5Plugin, umdPlugin, transformPlugin } = await import(
     '@modern-js/libuild-plugin-swc'
   );
-  const plugins = target === 'es5' ? [es5Plugin()] : [];
-  if (format === 'umd') {
-    plugins.push(umdPlugin(umdModuleName));
+  const plugins = format === 'umd' ? [umdPlugin(umdModuleName)] : [];
+  if (target === 'es5') {
+    plugins.push(es5Plugin());
   }
   const { getProjectTsconfig } = await import('./dts/tsc');
   const tsconfigPath = dts


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
