### PR TITLE
fix: .ejs is not a valid config file extension

### DIFF
--- a/.changeset/poor-queens-exercise.md
+++ b/.changeset/poor-queens-exercise.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/utils': patch
+---
+
+fix: .ejs is not a valid config file extension
+
+fix: 修复配置文件使用 .ejs 作为后缀的问题

--- a/packages/builder/builder-doc/modern.config.ts
+++ b/packages/builder/builder-doc/modern.config.ts
@@ -17,14 +17,17 @@ function getNavbar(lang: 'zh' | 'en'): NavItem[] {
     {
       text: getText('指南', 'Guide'),
       link: getLink('/guide/introduction'),
+      activeMatch: '/guide/',
     },
     {
       text: 'API',
       link: getLink('/api/'),
+      activeMatch: '/api/',
     },
     {
       text: getText('插件', 'Plugins'),
       link: getLink('/plugins/introduction'),
+      activeMatch: '/plugins/',
     },
   ];
 }

--- a/packages/toolkit/main-doc/en/configure/app/usage.mdx
+++ b/packages/toolkit/main-doc/en/configure/app/usage.mdx
@@ -19,10 +19,11 @@ Server runtime configuration can be configured in the `modern.server-runtime.con
 
 ## Configure in the configuration file
 
-Modern.js configuration files are defined in the root path of the project, and both `.js` and `.ts` formats are supported:
+Modern.js configuration files are defined in the root path of the project, and supports `.js`, `.ts` and `.mjs` formats:
 
 - `modern.config.js`
 - `modern.config.ts`
+- `modern.config.mjs`
 
 ### modern.config.js
 
@@ -50,7 +51,7 @@ export default {
 };
 ```
 
-### modern.config.ts
+### modern.config.ts (recommended)
 
 We recommend using configuration files in `.ts` format, which provides friendly TypeScript type hints to help you avoid configuration errors.
 

--- a/packages/toolkit/main-doc/en/guides/basic-features/builder.mdx
+++ b/packages/toolkit/main-doc/en/guides/basic-features/builder.mdx
@@ -4,7 +4,7 @@ sidebar_position: 2
 ---
 # Builder
 
-**Modern.js uses [Modern.js Builder](https://modernjs.dev/builder) to build your Web APP.**
+**Modern.js uses [Modern.js Builder](https://modernjs.dev/builder) to build your Web App.**
 
 Modern.js Builder is one of the core components of Modern.js. It is a build engine for Web development and can be used independently of Modern.js. Modern.js Builder supports multiple bundlers such as webpack and rspack, and it uses webpack by default.
 

--- a/packages/toolkit/main-doc/zh/configure/app/usage.mdx
+++ b/packages/toolkit/main-doc/zh/configure/app/usage.mdx
@@ -19,10 +19,11 @@ Modern.js 中有两种配置，一个是编译时配置，一个是服务端运�
 
 ## 在配置文件中配置
 
-Modern.js 的配置文件定义在项目的根目录下，同时支持 `.js` 和 `.ts` 两种格式：
+Modern.js 的配置文件定义在项目的根目录下，支持 `.js`, `.ts` 和 `.mjs` 格式：
 
 - `modern.config.js`
 - `modern.config.ts`
+- `modern.config.mjs`
 
 ### modern.config.js
 
@@ -50,7 +51,7 @@ export default {
 };
 ```
 
-### modern.config.ts
+### modern.config.ts（推荐）
 
 我们推荐使用 .ts 格式的配置文件，它提供了友好的 TypeScript 类型提示，从而帮助你避免配置中的错误。
 

--- a/packages/toolkit/utils/src/constants.ts
+++ b/packages/toolkit/utils/src/constants.ts
@@ -54,7 +54,7 @@ export const SHARED_DIR = 'shared';
  */
 export const CONFIG_CACHE_DIR = './node_modules/.cache/node-bundle-require';
 
-export const CONFIG_FILE_EXTENSIONS = ['.js', '.ts', '.ejs', '.mjs'];
+export const CONFIG_FILE_EXTENSIONS = ['.js', '.ts', '.mjs'];
 
 /**
  * Serialized config path


### PR DESCRIPTION
## Description

Modern configuration file supports `.js`, `.ts` and `.mjs` formats, and `.ejs` is not a valid config file extension, so `.ejs` should be removed from `CONFIG_FILE_EXTENSIONS`.

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
