### PR TITLE
fix(builder): should not emit async chunk when target is web-worker

### DIFF
--- a/.changeset/tricky-jobs-double.md
+++ b/.changeset/tricky-jobs-double.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): should not emit async chunk when target is web-worker
+
+fix(builder): 修复 target 为 web-worker 时产物中出现 async chunk 的问题

--- a/packages/builder/builder-rspack-provider/src/plugins/basic.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/basic.ts
@@ -24,8 +24,10 @@ export const builderPluginBasic = (): BuilderPlugin => ({
       // chain.performance.maxEntrypointSize(1024 * 1024);
 
       // // This will be futureDefaults in webpack 6
-      // chain.module.parser.set('javascript', {
-      //   exportsPresence: 'error',
+      // chain.module.parser.merge({
+      //   javascript: {
+      //     exportsPresence: 'error',
+      //   },
       // });
     });
   },

--- a/packages/builder/builder-webpack-provider/src/plugins/basic.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/basic.ts
@@ -25,8 +25,10 @@ export const builderPluginBasic = (): BuilderPlugin => ({
       chain.performance.maxEntrypointSize(1024 * 1024);
 
       // This will be futureDefaults in webpack 6
-      chain.module.parser.set('javascript', {
-        exportsPresence: 'error',
+      chain.module.parser.merge({
+        javascript: {
+          exportsPresence: 'error',
+        },
       });
     });
   },


### PR DESCRIPTION
## Description

Fix `dynamicImportMode: 'eager'` is overridden by Basic plugin.

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
