### PR TITLE
fix(doc-core): list item missing line-height

### DIFF
--- a/.changeset/stale-rivers-reflect.md
+++ b/.changeset/stale-rivers-reflect.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): list item missing line-height
+
+fix(doc-core): 修复列表中的选项缺少 line-height 的问题

--- a/packages/cli/doc-core/src/theme-default/styles/doc.css
+++ b/packages/cli/doc-core/src/theme-default/styles/doc.css
@@ -123,6 +123,7 @@
 .modern-doc ol {
   padding-left: 1.25rem;
   margin: 16px 0;
+  line-height: 28px;
 }
 
 .modern-doc ul {


### PR DESCRIPTION
## Description

Fix list item missing line-height.

### Before

<img width="746" alt="Screen Shot 2023-02-01 at 8 46 31 PM" src="https://user-images.githubusercontent.com/7237365/216047425-bf9a5473-0a12-4dc2-9c2f-80cf410fbf40.png">

### After

<img width="745" alt="Screen Shot 2023-02-01 at 8 46 39 PM" src="https://user-images.githubusercontent.com/7237365/216047450-775981b7-2187-4bdb-811e-225ef3fabe71.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
