### PR TITLE
fix(builder): increase size limit when target is node

### DIFF
--- a/.changeset/forty-sloths-invite.md
+++ b/.changeset/forty-sloths-invite.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): increase size limit when target is node
+
+fix(builder): 修复 target 为 node 时体积限制过小的问题

--- a/.github/workflows/build-module-website.yml
+++ b/.github/workflows/build-module-website.yml
@@ -46,6 +46,6 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.2.5
         with:
           branch: gh-pages
-          folder: toolkit/module-doc/doc_build
+          folder: packages/toolkit/module-doc/doc_build
           target-folder: module-tools
           clean: true

--- a/packages/builder/builder-webpack-provider/src/plugins/basic.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/basic.ts
@@ -7,7 +7,7 @@ export const builderPluginBasic = (): BuilderPlugin => ({
   name: 'builder-plugin-basic',
 
   setup(api) {
-    api.modifyWebpackChain(async (chain, { isProd }) => {
+    api.modifyWebpackChain(async (chain, { isProd, isServer, isWebWorker }) => {
       // The base directory for resolving entry points and loaders from the configuration.
       chain.context(api.context.rootPath);
 
@@ -20,9 +20,15 @@ export const builderPluginBasic = (): BuilderPlugin => ({
         },
       });
 
-      // if the chunk size exceeds 1MiB, we will throw a warning
-      chain.performance.maxAssetSize(1024 * 1024);
-      chain.performance.maxEntrypointSize(1024 * 1024);
+      /**
+       * If the chunk size exceeds 3MB, we will throw a warning.
+       * If the target is server or web-worker, we will increase
+       * the limit to 30MB because they are only single file.
+       */
+      const maxAssetSize =
+        isServer || isWebWorker ? 30 * 1000 * 1000 : 3 * 1000 * 1000;
+      chain.performance.maxAssetSize(maxAssetSize);
+      chain.performance.maxEntrypointSize(maxAssetSize);
 
       // This will be futureDefaults in webpack 6
       chain.module.parser.merge({

--- a/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -31,8 +31,8 @@ exports[`webpackConfig > should allow to use tools.webpackChain to modify config
     },
   },
   "performance": {
-    "maxAssetSize": 1048576,
-    "maxEntrypointSize": 1048576,
+    "maxAssetSize": 3000000,
+    "maxEntrypointSize": 3000000,
   },
 }
 `;
@@ -53,8 +53,8 @@ exports[`webpackConfig > should allow tools.webpack to be an array 1`] = `
     },
   },
   "performance": {
-    "maxAssetSize": 1048576,
-    "maxEntrypointSize": 1048576,
+    "maxAssetSize": 3000000,
+    "maxEntrypointSize": 3000000,
   },
 }
 `;
@@ -75,8 +75,8 @@ exports[`webpackConfig > should allow tools.webpack to be an object 1`] = `
     },
   },
   "performance": {
-    "maxAssetSize": 1048576,
-    "maxEntrypointSize": 1048576,
+    "maxAssetSize": 3000000,
+    "maxEntrypointSize": 3000000,
   },
 }
 `;
@@ -97,8 +97,8 @@ exports[`webpackConfig > should allow tools.webpack to modify config object 1`] 
     },
   },
   "performance": {
-    "maxAssetSize": 1048576,
-    "maxEntrypointSize": 1048576,
+    "maxAssetSize": 3000000,
+    "maxEntrypointSize": 3000000,
   },
 }
 `;
@@ -119,8 +119,8 @@ exports[`webpackConfig > should allow tools.webpack to return config 1`] = `
     },
   },
   "performance": {
-    "maxAssetSize": 1048576,
-    "maxEntrypointSize": 1048576,
+    "maxAssetSize": 3000000,
+    "maxEntrypointSize": 3000000,
   },
 }
 `;
@@ -141,8 +141,8 @@ exports[`webpackConfig > should allow tools.webpackChain to be an array 1`] = `
     },
   },
   "performance": {
-    "maxAssetSize": 1048576,
-    "maxEntrypointSize": 1048576,
+    "maxAssetSize": 3000000,
+    "maxEntrypointSize": 3000000,
   },
 }
 `;

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -634,8 +634,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "publicPath": "/",
   },
   "performance": {
-    "maxAssetSize": 1048576,
-    "maxEntrypointSize": 1048576,
+    "maxAssetSize": 3000000,
+    "maxEntrypointSize": 3000000,
   },
   "plugins": [
     MiniCssExtractPlugin {
@@ -1433,8 +1433,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     "publicPath": "/",
   },
   "performance": {
-    "maxAssetSize": 1048576,
-    "maxEntrypointSize": 1048576,
+    "maxAssetSize": 3000000,
+    "maxEntrypointSize": 3000000,
   },
   "plugins": [
     MiniCssExtractPlugin {
@@ -2083,8 +2083,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "publicPath": "/",
   },
   "performance": {
-    "maxAssetSize": 1048576,
-    "maxEntrypointSize": 1048576,
+    "maxAssetSize": 30000000,
+    "maxEntrypointSize": 30000000,
   },
   "plugins": [
     DefinePlugin {
@@ -2707,8 +2707,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "publicPath": "/",
   },
   "performance": {
-    "maxAssetSize": 1048576,
-    "maxEntrypointSize": 1048576,
+    "maxAssetSize": 30000000,
+    "maxEntrypointSize": 30000000,
   },
   "plugins": [
     DefinePlugin {


### PR DESCRIPTION
## Description

- Increase size limit when target is node to avoid the webpack warning. (Also increased the default size limit to 3MB).

<img width="1183" alt="Screen Shot 2023-02-02 at 5 46 17 PM" src="https://user-images.githubusercontent.com/7237365/216321153-de420872-dae5-4357-8659-d107ef06f243.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
