### PR TITLE
chore: catch react-dom/server require for react 17

### DIFF
--- a/.changeset/pretty-onions-fetch.md
+++ b/.changeset/pretty-onions-fetch.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+chore: catch react-dom/server require for react 17
+chore: 捕获引入 react-dom/server 的逻辑，避免在 react 17 下报错

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToStream/renderToPipe.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToStream/renderToPipe.ts
@@ -17,7 +17,7 @@ function renderToPipe(
       let renderToPipeableStream;
       try {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
-        renderToPipeableStream = require('react-dom/server');
+        ({ renderToPipeableStream } = require('react-dom/server'));
       } catch (e) {}
 
       const { pipe } = renderToPipeableStream(rootElement, {

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToStream/renderToPipe.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToStream/renderToPipe.ts
@@ -16,6 +16,7 @@ function renderToPipe(
     return new Promise(resolve => {
       let renderToPipeableStream;
       try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
         renderToPipeableStream = require('react-dom/server');
       } catch (e) {}
 


### PR DESCRIPTION
## Description

use `try { require(...) } catch(e) {}` instead `import` for react-dom/server in stream ssr

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
