### PR TITLE
docs: make v2 docs as default

### DIFF
--- a/.changeset/brave-spies-vanish.md
+++ b/.changeset/brave-spies-vanish.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-doc': patch
+'@modern-js/main-doc-website': patch
+---
+
+docs: make v2 docs as default
+
+docs: 将 Modern.js v2 文档作为默认文档

--- a/.github/workflows/build-main-website.yml
+++ b/.github/workflows/build-main-website.yml
@@ -55,5 +55,8 @@ jobs:
         with:
           branch: gh-pages
           folder: website/main/doc_build
-          target-folder: v2
           clean: true
+          clean-exclude: |
+            v1/**/*
+            builder/**/*
+            module-tools/**/*

--- a/packages/builder/builder-doc/docs/en/guide/basic/html-template.md
+++ b/packages/builder/builder-doc/docs/en/guide/basic/html-template.md
@@ -8,7 +8,7 @@ Builder provides some configs to set the HTML template. Through this chapter, yo
 
 HTML templates are usually predefined by the upper framework.
 
-For example, in the Modern.js framework, the HTML template is preset by default, and users can also customize the content of the template. You can read the ["Modern.js - HTML Templates"](https://modernjs.dev/v2/docs/guides/basic-features/html) chapter to learn about it.
+For example, in the Modern.js framework, the HTML template is preset by default, and users can also customize the content of the template. You can read the ["Modern.js - HTML Templates"](https://modernjs.dev/docs/guides/basic-features/html) chapter to learn about it.
 
 In Builder, you can use [html.template](/en/api/config-html.html#htmltemplate) and [html.templateByEntries](/en/api/config-html.html#htmltemplatebyentries) configs to define the path to the custom HTML template.
 

--- a/packages/builder/builder-doc/docs/zh/guide/basic/html-template.md
+++ b/packages/builder/builder-doc/docs/zh/guide/basic/html-template.md
@@ -8,7 +8,7 @@ Builder 提供了一些配置项来对 HTML 模板进行设置。通过本章节
 
 通常来说，HTML 模板文件是由上层框架预先定义的。
 
-比如在 Modern.js 框架中，默认会预设一份 HTML 模板，同时也支持用户自定义模板的内容。你可以阅读 [「Modern.js - HTML 模板」](https://modernjs.dev/v2/docs/guides/basic-features/html) 章节来了解相关内容。
+比如在 Modern.js 框架中，默认会预设一份 HTML 模板，同时也支持用户自定义模板的内容。你可以阅读 [「Modern.js - HTML 模板」](https://modernjs.dev/docs/guides/basic-features/html) 章节来了解相关内容。
 
 在 Builder 中，你可以使用 [html.template](/api/config-html.html#htmltemplate) 和 [html.templateByEntries](/api/config-html.html#htmltemplatebyentries) 配置项来设置自定义的 HTML 模板文件。
 

--- a/website/main/modern.config.ts
+++ b/website/main/modern.config.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import docTools, { defineConfig, type NavItem } from '@modern-js/doc-tools';
 import { pluginAutoSidebar } from '@modern-js/doc-plugin-auto-sidebar';
 
 const rootCategories = [
@@ -10,10 +10,11 @@ const rootCategories = [
   'blog',
 ];
 
-const docPath = path.join(__dirname, '../../packages/toolkit/main-doc');
-const isProd = process.env.NODE_ENV !== 'development';
+const { version } = require('./package.json');
 
-const getNavbar = (lang: string) => {
+const docPath = path.join(__dirname, '../../packages/toolkit/main-doc');
+
+const getNavbar = (lang: string): NavItem[] => {
   const cn = lang === 'zh';
   const prefix = cn ? '' : '/en';
   const getLink = (str: string) => `${prefix}${str}`;
@@ -34,17 +35,24 @@ const getNavbar = (lang: string) => {
       link: getLink('/configure/app/usage'),
       activeMatch: '/configure/app',
     },
-
     {
       text: getText('API', 'API'),
       link: getLink('/apis/app/commands/dev'),
       activeMatch: '/apis/',
     },
-
     {
       text: getText('博客', 'Blog'),
       link: getLink('/blog/index'),
       activeMatch: '/blog/',
+    },
+    {
+      text: `v${version}`,
+      items: [
+        {
+          text: 'v1',
+          link: 'https://modernjs.dev/v1/',
+        },
+      ],
     },
   ];
 };
@@ -52,7 +60,7 @@ const getNavbar = (lang: string) => {
 export default defineConfig({
   doc: {
     root: docPath,
-    base: isProd ? '/v2/' : '',
+    base: '/',
     logo: 'https://lf-cdn-tos.bytescm.com/obj/static/webinfra/modern-js-website/assets/images/images/modernjs-logo.svg',
     icon: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/uhbfnupenuhf/favicon.ico',
     lang: 'zh',
@@ -183,10 +191,8 @@ export default defineConfig({
         svgDefaultExport: 'component',
         dataUriLimit: 0,
       },
-      tools: {
-        // experiments: {
-        //   lazyCompilation: true,
-        // },
+      dev: {
+        startUrl: true,
       },
       source: {
         alias: {

--- a/website/main/modern.config.ts
+++ b/website/main/modern.config.ts
@@ -40,11 +40,12 @@ const getNavbar = (lang: string): NavItem[] => {
       link: getLink('/apis/app/commands/dev'),
       activeMatch: '/apis/',
     },
-    {
-      text: getText('博客', 'Blog'),
-      link: getLink('/blog/index'),
-      activeMatch: '/blog/',
-    },
+    // TODO enabled after we write the v2 release blog
+    // {
+    //   text: getText('博客', 'Blog'),
+    //   link: getLink('/blog/index'),
+    //   activeMatch: '/blog/',
+    // },
     {
       text: `v${version}`,
       items: [


### PR DESCRIPTION
## Description

Make v2 docs as default.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [x] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
