### PR TITLE
chore(CI): fix build main website clean exclude

### DIFF
--- a/.github/workflows/build-main-website.yml
+++ b/.github/workflows/build-main-website.yml
@@ -57,6 +57,9 @@ jobs:
           folder: website/main/doc_build
           clean: true
           clean-exclude: |
+            v1/*
             v1/**/*
+            builder/*
             builder/**/*
+            module-tools/*
             module-tools/**/*


### PR DESCRIPTION
## Description

Fix `Build Main Website` CI should not clean some used files such as `v1/index.html`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
