### PR TITLE
feat(module-tools): support sideEffects config and remove error log l…

### DIFF
--- a/.changeset/good-adults-carry.md
+++ b/.changeset/good-adults-carry.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': minor
+---
+
+support sideEffects config and change log level to info
+支持sideEffects配置并将日志级别改为info

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@modern-js/core": "workspace:*",
-    "@modern-js/libuild": "~0.9.0",
+    "@modern-js/libuild": "~0.10.0",
     "@modern-js/new-action": "workspace:*",
     "@modern-js/plugin": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",
@@ -53,8 +53,8 @@
     "@modern-js/utils": "workspace:*",
     "@modern-js/plugin-changeset": "workspace:*",
     "@modern-js/plugin-lint": "workspace:*",
-    "@modern-js/libuild-plugin-svgr": "~0.9.0",
-    "@modern-js/libuild-plugin-swc": "~0.9.0"
+    "@modern-js/libuild-plugin-svgr": "~0.10.0",
+    "@modern-js/libuild-plugin-swc": "~0.10.0"
   },
   "devDependencies": {
     "@modern-js/self": "workspace:@modern-js/module-tools@*",

--- a/packages/solutions/module-tools/src/builder/build.ts
+++ b/packages/solutions/module-tools/src/builder/build.ts
@@ -140,6 +140,7 @@ export const buildLib = async (
     autoExternal,
     dts,
     metafile,
+    sideEffects,
   } = config;
   const { appDirectory } = api.useAppContext();
   const { slash } = await import('@modern-js/utils');
@@ -223,9 +224,9 @@ export const buildLib = async (
     external: externals,
     autoExternal,
     bundle: buildType === 'bundle',
+    sideEffects,
     // outbase for [dir]/[name]
     outbase: sourceDir,
-    logLevel: 'error',
     esbuildOptions: (options: any) => ({
       ...options,
       supported: {

--- a/packages/solutions/module-tools/src/config/schema.ts
+++ b/packages/solutions/module-tools/src/config/schema.ts
@@ -148,6 +148,22 @@ const buildConfigProperties = {
       },
     ],
   },
+  sideEffects: {
+    anyOf: [
+      {
+        type: 'array',
+        items: {
+          instanceof: 'RegExp',
+        },
+      },
+      {
+        type: 'boolean',
+      },
+      {
+        instanceof: 'Function',
+      },
+    ],
+  },
 };
 export const buildConfig = {
   target: 'buildConfig',

--- a/packages/solutions/module-tools/src/constants/build.ts
+++ b/packages/solutions/module-tools/src/constants/build.ts
@@ -45,4 +45,5 @@ export const defaultBuildConfig = Object.freeze<BaseBuildConfig>({
     autoModules: true,
     modules: {},
   },
+  sideEffects: undefined,
 });

--- a/packages/solutions/module-tools/src/types/config/index.ts
+++ b/packages/solutions/module-tools/src/types/config/index.ts
@@ -64,8 +64,9 @@ export type AliasOption =
 
 export type BaseBuildConfig = Omit<
   Required<PartialBaseBuildConfig>,
-  'dts' | 'style' | 'alias'
+  'dts' | 'style' | 'alias' | 'sideEffects'
 > & {
+  sideEffects: LibuildUserConfig['sideEffects'];
   dts: false | DTSOptions;
   style: Omit<Required<LibuildStyle>, 'cleanCss'> & {
     tailwindCss: TailwindCSSConfig;
@@ -96,6 +97,7 @@ export type PartialBaseBuildConfig = {
   umdModuleName?: ((chunkName: string) => string) | string | undefined;
   define?: LibuildUserConfig['define'];
   style?: StyleConfig;
+  sideEffects?: LibuildUserConfig['sideEffects'];
 };
 
 export type BuildConfig = BaseBuildConfig | BaseBuildConfig[];

--- a/packages/solutions/module-tools/src/utils/config.ts
+++ b/packages/solutions/module-tools/src/utils/config.ts
@@ -104,6 +104,7 @@ export const mergeDefaultBaseConfig = async (
       ...pConfig.umdGlobals,
     },
     umdModuleName: pConfig.umdModuleName ?? defaultConfig.umdModuleName,
+    sideEffects: pConfig.sideEffects ?? defaultConfig.sideEffects,
     externals: pConfig.externals ?? defaultConfig.externals,
     sourceDir,
     alias,

--- a/packages/solutions/module-tools/tests/fixtures/sideEffects/config.ts
+++ b/packages/solutions/module-tools/tests/fixtures/sideEffects/config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@modern-js/self/defineConfig';
+
+export default defineConfig({
+  buildConfig: {
+    buildType: 'bundle',
+    sideEffects: false,
+    style: {
+      inject: true,
+    },
+    input: ['index.ts'],
+  },
+});

--- a/packages/solutions/module-tools/tests/fixtures/sideEffects/index.css
+++ b/packages/solutions/module-tools/tests/fixtures/sideEffects/index.css
@@ -1,0 +1,3 @@
+.body {
+  color: black;
+}

--- a/packages/solutions/module-tools/tests/fixtures/sideEffects/index.ts
+++ b/packages/solutions/module-tools/tests/fixtures/sideEffects/index.ts
@@ -1,0 +1,1 @@
+import './index.css';

--- a/packages/solutions/module-tools/tests/fixtures/sideEffects/package.json
+++ b/packages/solutions/module-tools/tests/fixtures/sideEffects/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "source-dir-test",
+  "sideEffects": true
+}

--- a/packages/solutions/module-tools/tests/sideEffects.test.ts
+++ b/packages/solutions/module-tools/tests/sideEffects.test.ts
@@ -1,0 +1,33 @@
+import path from 'path';
+import { fs } from '@modern-js/utils';
+import { runCli, initBeforeTest } from './utils';
+
+initBeforeTest();
+
+beforeAll(() => {
+  jest.mock('../src/utils/onExit.ts', () => {
+    return {
+      __esModule: true,
+      addExitListener: jest.fn(() => 'mocked'),
+    };
+  });
+});
+
+describe('sideEffects', () => {
+  const fixtureDir = path.join(__dirname, './fixtures/sideEffects');
+  it('base usage', async () => {
+    const configFile = path.join(fixtureDir, './config.ts');
+    const { success } = await runCli({
+      argv: ['build'],
+      configFile,
+      appDirectory: fixtureDir,
+    });
+    expect(success).toBeTruthy();
+
+    const distIndexPath = path.join(fixtureDir, './dist/index.js');
+    expect(await fs.pathExists(distIndexPath)).toBeTruthy();
+    expect(
+      (await fs.readFile(distIndexPath, 'utf-8')).length === 0,
+    ).toBeTruthy();
+  });
+});

--- a/packages/toolkit/module-doc/docs/en/api/config/build-config.md
+++ b/packages/toolkit/module-doc/docs/en/api/config/build-config.md
@@ -285,6 +285,44 @@ Generates code for the node environment by default, you can also specify `browse
 - type: `'browser' | 'node'`
 - default: `node`
 
+## sideEffects
+
+Module sideEffects
+
+- Type: `RegExg[] | (filePath: string, isExternal: boolean) => boolean | boolean`
+- Default value: `undefined`
+
+Normally, we configure the module's side effects via the sideEffects field in package.json, but in some cases, such as when we reference a three-party package style file
+
+```js
+import 'other-package/dist/index.css'
+```
+
+But the package.json of this three-party package does not have the style file configured in the sideEffects
+
+```json other-package/package.json
+{
+  "sideEffects": ["dist/index.js"]
+}
+```
+
+This is the time to use this configuration item, which supports regular and functional forms
+
+```js modern.config.ts
+import { defineConfig } from '@modern-js/module-tools';
+export default defineConfig({
+  buildConfig: {
+    sideEffects: [/\.css$/],
+    // or
+    // sideEffects: (filePath, isExternal) => /\.css$/.test(filePath),
+  },
+});
+```
+
+:::tip
+After adding this configuration, the sideEffects field in package.json will no longer be read when packaging
+:::
+
 ## sourceDir
 
 Specify the source directory of the build, default is `src`, which is used to generate the corresponding product directory based on the source directory structure when building `bundleless`.

--- a/packages/toolkit/module-doc/docs/zh/api/config/build-config.md
+++ b/packages/toolkit/module-doc/docs/zh/api/config/build-config.md
@@ -342,6 +342,44 @@ export default defineConfig({
 - 类型： `'browser' | 'node'`
 - 默认值： `node`
 
+## sideEffects
+
+配置模块的副作用
+
+- 类型： `RegExg[] | (filePath: string, isExternal: boolean) => boolean | boolean`
+- 默认值： `undefined`
+
+通常情况下，我们通过 package.json 的 sideEffects 字段来配置模块的副作用，但是在某些情况下，例如我们引用了一个三方包的样式文件
+
+```js
+import 'other-package/dist/index.css'
+```
+
+但是这个三方包的 package.json 里并没有将样式文件配置到 sideEffects 里
+
+```json other-package/package.json
+{
+  "sideEffects": ["dist/index.js"]
+}
+```
+
+这时候就可以使用这个配置项，支持正则和函数形式
+
+```js modern.config.ts
+import { defineConfig } from '@modern-js/module-tools';
+export default defineConfig({
+  buildConfig: {
+    sideEffects: [/\.css$/],
+    // or
+    // sideEffects: (filePath, isExternal) => /\.css$/.test(filePath),
+  },
+});
+```
+
+:::tip
+添加此配置后，打包时将不会再读取 package.json 里的 sideEffects 字段
+:::
+
 ## sourceDir
 
 指定构建的源码目录,默认为 `src`，用于在 `bundleless` 构建时基于源码目录结构生成对应的产物目录。

--- a/packages/toolkit/module-doc/docs/zh/api/config/build-config.md
+++ b/packages/toolkit/module-doc/docs/zh/api/config/build-config.md
@@ -349,13 +349,13 @@ export default defineConfig({
 - 类型： `RegExg[] | (filePath: string, isExternal: boolean) => boolean | boolean`
 - 默认值： `undefined`
 
-通常情况下，我们通过 package.json 的 sideEffects 字段来配置模块的副作用，但是在某些情况下，例如我们引用了一个三方包的样式文件
+通常情况下，我们通过 package.json 的 `"sideEffects"` 字段来配置模块的副作用，但是在某些情况下，例如我们引用了一个三方包的样式文件。
 
 ```js
 import 'other-package/dist/index.css'
 ```
 
-但是这个三方包的 package.json 里并没有将样式文件配置到 sideEffects 里
+但是这个三方包的 package.json 里并没有将样式文件配置到 `"sideEffects"` 里。
 
 ```json other-package/package.json
 {
@@ -363,7 +363,7 @@ import 'other-package/dist/index.css'
 }
 ```
 
-这时候就可以使用这个配置项，支持正则和函数形式
+这时候就可以使用这个配置项，支持正则和函数形式。
 
 ```js modern.config.ts
 import { defineConfig } from '@modern-js/module-tools';
@@ -377,7 +377,7 @@ export default defineConfig({
 ```
 
 :::tip
-添加此配置后，打包时将不会再读取 package.json 里的 sideEffects 字段
+添加此配置后，打包时将不会再读取 package.json 里的 `"sideEffects"` 字段。
 :::
 
 ## sourceDir
@@ -657,7 +657,7 @@ const tailwind = {
 - 类型： `Record<string, string>`
 - 默认值： `{}`
 
-```js modern.config.ts
+```ts modern.config.ts
 import { defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3080,9 +3080,9 @@ importers:
     specifiers:
       '@modern-js/builder-webpack-provider': workspace:*
       '@modern-js/core': workspace:*
-      '@modern-js/libuild': ~0.9.0
-      '@modern-js/libuild-plugin-svgr': ~0.9.0
-      '@modern-js/libuild-plugin-swc': ~0.9.0
+      '@modern-js/libuild': ~0.10.0
+      '@modern-js/libuild-plugin-svgr': ~0.10.0
+      '@modern-js/libuild-plugin-swc': ~0.10.0
       '@modern-js/new-action': workspace:*
       '@modern-js/plugin': workspace:*
       '@modern-js/plugin-changeset': workspace:*
@@ -3105,9 +3105,9 @@ importers:
       typescript: ^4
     dependencies:
       '@modern-js/core': link:../../cli/core
-      '@modern-js/libuild': 0.9.0
-      '@modern-js/libuild-plugin-svgr': 0.9.0
-      '@modern-js/libuild-plugin-swc': 0.9.0
+      '@modern-js/libuild': 0.10.0
+      '@modern-js/libuild-plugin-svgr': 0.10.0
+      '@modern-js/libuild-plugin-swc': 0.10.0
       '@modern-js/new-action': link:../../generator/new-action
       '@modern-js/plugin': link:../../toolkit/plugin
       '@modern-js/plugin-changeset': link:../../cli/plugin-changeset
@@ -10332,8 +10332,8 @@ packages:
       - supports-color
     dev: false
 
-  /@modern-js/libuild-plugin-svgr/0.9.0:
-    resolution: {integrity: sha512-O6CiJ6nbuHtsIBYbxs8fDDGwkS2tyi6woPDVwTwT3jIu+xLEDr2NUYB2tyvGYCTFjC7/3EloGL8rzCU0wc24Qg==}
+  /@modern-js/libuild-plugin-svgr/0.10.0:
+    resolution: {integrity: sha512-unvJ+2SyJuaZE6iSChxc5A1UTzgDJ2B5sQaT2IbBpJJp1tfvGSU8VqWno6F4NtXiUn1SlGXSxHLM5K+ux35XFw==}
     dependencies:
       '@svgr/core': 6.2.0
       '@svgr/plugin-jsx': 6.2.0_@svgr+core@6.2.0
@@ -10343,14 +10343,14 @@ packages:
       - supports-color
     dev: false
 
-  /@modern-js/libuild-plugin-swc/0.9.0:
-    resolution: {integrity: sha512-Vl0JZrq5/SSuHH061yNGlH+rROWXN05VuJSvbdnotG4fx5pbHoHeeoajezC/H5xDlvEvSx3wXugxbplVhE5W7g==}
+  /@modern-js/libuild-plugin-swc/0.10.0:
+    resolution: {integrity: sha512-5Ie2wuEKNkKNDq4kMD4JfVrIYPGGMm+ES2Yi/z42J6Lu6+IC2uo31D3cbu+FCYflGESnHaVDO7C4WAUJKBJdTg==}
     dependencies:
-      '@modern-js/swc-plugins': 0.0.9
+      '@modern-js/swc-plugins': 0.0.12
     dev: false
 
-  /@modern-js/libuild/0.9.0:
-    resolution: {integrity: sha512-BGCqkJvJYQ6k4QGD/lmDoqiJRHo/PHbtliQzgDhn+GdMliloodPza32Y6+LcT0VLouzU/m5EyDQsnwYI7XXdIQ==}
+  /@modern-js/libuild/0.10.0:
+    resolution: {integrity: sha512-tRrrwdrnfM7vjXWZ/6K8GXk/+YqPBN4A/8IM1XhdaKVYcPVdvR1Z7HwKpmCx1Lj5/d9zzrObv483JrtGXWywdQ==}
     hasBin: true
     dependencies:
       '@ast-grep/napi': 0.1.13
@@ -10421,6 +10421,15 @@ packages:
       - supports-color
     dev: false
 
+  /@modern-js/swc-plugins-darwin-arm64/0.0.12:
+    resolution: {integrity: sha512-r5hgWWvi/BveW86LAPtHEL9UIrexqNy7/wE+BRJaa6UIJWW/MEXjgiuE/4efEUdQU1w6EzkIrjKg53ob6Grltg==}
+    engines: {node: '>= 14'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@modern-js/swc-plugins-darwin-arm64/0.0.16:
     resolution: {integrity: sha512-9sEmraLuoHsq1bb8Mv2M+RemY9L6J0B3GqiXvQOYbB6V45zlWmucA24CqM82uM9WThdajZ0D8x/Ny/QBbKzRag==}
     engines: {node: '>=14.12'}
@@ -10430,10 +10439,10 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-darwin-arm64/0.0.9:
-    resolution: {integrity: sha512-NCkV4GLeqHWCn3kL5fY6k4ioIR0swpm8i49hmUSw0YR6N9WkVhWG9c1CkmX82ipmpv4oZ7uE+S3MlJ7Xalp61Q==}
-    engines: {node: '>= 14'}
-    cpu: [arm64]
+  /@modern-js/swc-plugins-darwin-x64/0.0.12:
+    resolution: {integrity: sha512-O62m3Tfgbt/+gwnwfgEsrfHORhb59n67wz+2AlNKr6cye515doberlLyDRJ6nIUZzmW60CVAugu78dNi3dzZqg==}
+    engines: {node: '>= 14.18'}
+    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
@@ -10448,11 +10457,11 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-darwin-x64/0.0.9:
-    resolution: {integrity: sha512-FllFqHAgw3eBAhR3kZ7QIne0SJTHPyVDrPXo3BMtVQvRsDlo7Ekl1I5XlNbMhKlre1eOHazrYjF3pM0QeXP1+g==}
+  /@modern-js/swc-plugins-linux-arm-gnueabihf/0.0.12:
+    resolution: {integrity: sha512-8k9SBEaRegwNEs2Z4kvvFwbXdRCDljFrKz2g078686oMl39K+cIMDrKCxqwDqQ+3gNGm1PzzcXk10JNZea108A==}
     engines: {node: '>= 14.18'}
-    cpu: [x64]
-    os: [darwin]
+    cpu: [arm]
+    os: [linux]
     requiresBuild: true
     dev: false
     optional: true
@@ -10466,10 +10475,10 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-arm-gnueabihf/0.0.9:
-    resolution: {integrity: sha512-gaHFvEx4IJaAcKRgaGYWn/2XoaRciz8E2i/OmNMrZ0UcBQjtQW+0hD+55/VuwXDNIx9GJ9csZnBLOnRhpvYgFA==}
+  /@modern-js/swc-plugins-linux-arm64-gnu/0.0.12:
+    resolution: {integrity: sha512-2qptOqIhBoWTmKdUpRWGqYiR4xnDR1KiOFpyraVIr+7CcjRe8aLt/lJ/b8ZDu3xgZNhoIjaZFkCNvib+iXKEeQ==}
     engines: {node: '>= 14.18'}
-    cpu: [arm]
+    cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
@@ -10484,8 +10493,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-arm64-gnu/0.0.9:
-    resolution: {integrity: sha512-xOaBQVBKxwjv29pBudWVjWtBysgbGGJ74rDL1u4EyOFpKszusXrN6cJ1KHND6wZrsGlkqTuoOOjsKAA0AqxvQQ==}
+  /@modern-js/swc-plugins-linux-arm64-musl/0.0.12:
+    resolution: {integrity: sha512-uvPQTsqU0myNpO6mCJXXpu26G+WPP9sNCGZljH9nZmogPpylBxLqBU+iV0OdEVwB9MRCJCK3Ei/pCN/404q/Iw==}
     engines: {node: '>= 14.18'}
     cpu: [arm64]
     os: [linux]
@@ -10502,10 +10511,10 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-arm64-musl/0.0.9:
-    resolution: {integrity: sha512-PT0t6pqBOkmeGnwJLQX4vq5649+YSgmUA1awQkO6GBEwkwzteL3JTsAeq7H+WMfIQvLRud8/IVt3jBW/gKdhtw==}
+  /@modern-js/swc-plugins-linux-x64-gnu/0.0.12:
+    resolution: {integrity: sha512-hBhO40/FTGCKi1jD7NDF/Y2pDL/rq3jhCDvbK9D9yKwyMpl1LapqKToaizmwOFv74qhpdYcjE/zoGSrnASo6vQ==}
     engines: {node: '>= 14.18'}
-    cpu: [arm64]
+    cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: false
@@ -10520,8 +10529,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-x64-gnu/0.0.9:
-    resolution: {integrity: sha512-52kOAQeN2iK4oNQS6PO9dv13BNoyWaoa3JT3DV5gdGmyrXq98Jhlb7/unFKlKXoyNOxsQh55ypu6rwWGeXH0bQ==}
+  /@modern-js/swc-plugins-linux-x64-musl/0.0.12:
+    resolution: {integrity: sha512-9klbezChI1E68YCRvL6KGjtpNcRzcBZ0DBGpexSEScXb95K5++lx+lHYKWp5E7H5fimRej/YSywceaz76YlEPA==}
     engines: {node: '>= 14.18'}
     cpu: [x64]
     os: [linux]
@@ -10538,11 +10547,11 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-x64-musl/0.0.9:
-    resolution: {integrity: sha512-WpChZNeC0xUHSkt2lLglujUCs42oKnBZOUh/cqBCM9VtV0pPmVdRryfA43NCiiDu2vVKOcFhHNeyV38/zjiLFg==}
+  /@modern-js/swc-plugins-win32-arm64-msvc/0.0.12:
+    resolution: {integrity: sha512-932Qco0V7SW8ZO7eBV77KtzeLKfAiaSQ+lrwIwZe7Ek4Yfp0s3whXIyBgkL82C1sPrS8JwTfiFlE2z5vTG686g==}
     engines: {node: '>= 14.18'}
-    cpu: [x64]
-    os: [linux]
+    cpu: [arm64]
+    os: [win32]
     requiresBuild: true
     dev: false
     optional: true
@@ -10556,19 +10565,19 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-win32-arm64-msvc/0.0.9:
-    resolution: {integrity: sha512-Yf0fhMGnP9jKjUhqdvB+hrEM/UMZBesRmo0ssA/iMq5yixN00BKoW6evyUWzicH6HlR88prwpdp8tLLoYeb3IA==}
+  /@modern-js/swc-plugins-win32-ia32-msvc/0.0.12:
+    resolution: {integrity: sha512-CgJChQRkrRKqdga4Yzf1Qo8du/e3eHRSw4XX9p7CGqw3gAkMzQF/WpcBCiLfcBiGADgqI/4IeuD5I4y8bsILSw==}
     engines: {node: '>= 14.18'}
-    cpu: [arm64]
+    cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-win32-ia32-msvc/0.0.9:
-    resolution: {integrity: sha512-XlGqhXdrak2N7Gv0glQp4wwVC8mzaqsVM+4aHRm8Fvd4PeNIJdBPB8VLuKrkDl6s60tMV82Dbq8UPBkKUtSxdw==}
+  /@modern-js/swc-plugins-win32-x64-msvc/0.0.12:
+    resolution: {integrity: sha512-fZwl86/dIzWIFuu2d9mKEOvYIhpeyjxWn52TAEe4rlIF4vidgyAqpNV7XSxwmBuN6By99O7Vy+vh+NtnOspXeQ==}
     engines: {node: '>= 14.18'}
-    cpu: [ia32]
+    cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: false
@@ -10583,14 +10592,21 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-win32-x64-msvc/0.0.9:
-    resolution: {integrity: sha512-LMGp5jV8Xbh2Zy8OzvDuuAP0Jxhz+fyZEZzcQSa2fdcFz+3SrVsN4djVlMFw5del9rIawNIm3HcB8xXzaValNA==}
-    engines: {node: '>= 14.18'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
+  /@modern-js/swc-plugins/0.0.12:
+    resolution: {integrity: sha512-vuADzYwdGdog5QN7yi3ngQcpvn34X0Ho9IXe1AQoyWCNIoXAglbuzu43zE8Qt/HJZ7+a9DDb7yfjSLst4G0BQg==}
+    engines: {node: '>=14.18.0'}
+    optionalDependencies:
+      '@modern-js/swc-plugins-darwin-arm64': 0.0.12
+      '@modern-js/swc-plugins-darwin-x64': 0.0.12
+      '@modern-js/swc-plugins-linux-arm-gnueabihf': 0.0.12
+      '@modern-js/swc-plugins-linux-arm64-gnu': 0.0.12
+      '@modern-js/swc-plugins-linux-arm64-musl': 0.0.12
+      '@modern-js/swc-plugins-linux-x64-gnu': 0.0.12
+      '@modern-js/swc-plugins-linux-x64-musl': 0.0.12
+      '@modern-js/swc-plugins-win32-arm64-msvc': 0.0.12
+      '@modern-js/swc-plugins-win32-ia32-msvc': 0.0.12
+      '@modern-js/swc-plugins-win32-x64-msvc': 0.0.12
     dev: false
-    optional: true
 
   /@modern-js/swc-plugins/0.0.16:
     resolution: {integrity: sha512-Q46rgnhn6DTySWgr4D3LjobXVVecl2JqD8MSEJswJxSE/tej0ZCoSDhWuxG/IwYGUE7ISNyaxr4xpliD37MQaA==}
@@ -10605,22 +10621,6 @@ packages:
       '@modern-js/swc-plugins-linux-x64-musl': 0.0.16
       '@modern-js/swc-plugins-win32-arm64-msvc': 0.0.16
       '@modern-js/swc-plugins-win32-x64-msvc': 0.0.16
-    dev: false
-
-  /@modern-js/swc-plugins/0.0.9:
-    resolution: {integrity: sha512-XpDh4VdCoSL7KTQyFGDHMDqveaNwiQoUvVrUHjDm6mXbqandViX8atglxRFmb3rpGBSASkewu1NfCCfnpy6ezQ==}
-    engines: {node: '>=14.18.0'}
-    optionalDependencies:
-      '@modern-js/swc-plugins-darwin-arm64': 0.0.9
-      '@modern-js/swc-plugins-darwin-x64': 0.0.9
-      '@modern-js/swc-plugins-linux-arm-gnueabihf': 0.0.9
-      '@modern-js/swc-plugins-linux-arm64-gnu': 0.0.9
-      '@modern-js/swc-plugins-linux-arm64-musl': 0.0.9
-      '@modern-js/swc-plugins-linux-x64-gnu': 0.0.9
-      '@modern-js/swc-plugins-linux-x64-musl': 0.0.9
-      '@modern-js/swc-plugins-win32-arm64-msvc': 0.0.9
-      '@modern-js/swc-plugins-win32-ia32-msvc': 0.0.9
-      '@modern-js/swc-plugins-win32-x64-msvc': 0.0.9
     dev: false
 
   /@modern-js/utils/1.21.5:
@@ -14712,10 +14712,8 @@ packages:
       ajv: 6.12.6
     dev: false
 
-  /ajv-formats/2.1.1_ajv@8.11.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -30570,7 +30568,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1_ajv@8.11.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scmp/2.1.0:


### PR DESCRIPTION
…evel

## Description

一般情况下，sideEffects都通过package.json来决定，但一些三方包对于此并没有做的很好，导致我们想引用一些三方包的样式文件时，被esbuild ignore了导致无法被打包进去，通过配置的形式可以覆盖package.json的配置。
与此同时，把写死的log level从error改成了info，这是因为在很多情况下，warning是非常有用的，例如上面提到的ignore问题，因此将默认级别改回info，或许我们需要提供这个配置以自由控制log信息

<!--- Describe your changes -->

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
