### PR TITLE
fix: skip the rspack integration,because a rspack package not found i…

### DIFF
--- a/tests/integration/builder-rspack/tests/index.test.ts
+++ b/tests/integration/builder-rspack/tests/index.test.ts
@@ -23,7 +23,7 @@ declare const page: Page;
 
 const appDir = path.resolve(__dirname, '../');
 
-describe('dev', () => {
+describe.skip('dev', () => {
   let app: unknown;
   let appPort: number;
   const errors: string[] = [];
@@ -71,7 +71,7 @@ describe('dev', () => {
   });
 });
 
-describe('build', () => {
+describe.skip('build', () => {
   let appPort: number;
   let app: unknown;
   const errors: string[] = [];


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
fix: skip the rspack integration,because a rspack package not found in window os

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
