### PR TITLE
Release v2.5.0-beta.0

### DIFF
--- a/packages/builder/builder-rspack-provider/CHANGELOG.md
+++ b/packages/builder/builder-rspack-provider/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @modern-js/builder-rspack-provider
 
+## 2.5.0-beta.0
+
+### Minor Changes
+
+- 28e7dc6: feat: more use bunlder chain to modify bundler config
+  feat: 更多的使用 `bunlder chain` 去修改 bunlder 配置
+
+### Patch Changes
+
+- c4c10e7: refactor: refactor rules for static assets processing with rule.oneOf, reuse svg/font/image/media plugin
+
+  refactor: 使用 oneOf 重构静态资源处理规则 & 复用 svg / font / media / img 插件
+
+- 84c21f9: fix(builder-webpack-provider): correct mistaken compilerOptions usage in ts-loader options
+
+  fix(builder-webpack-provider): 改正 ts-loader options 中错误的 compilerOptions
+
+- Updated dependencies [c4c10e7]
+- Updated dependencies [11c053b]
+- Updated dependencies [28e7dc6]
+  - @modern-js/builder-shared@2.5.0-beta.0
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/server@2.4.1-beta.0
+  - @modern-js/e2e@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Minor Changes

--- a/packages/builder/builder-rspack-provider/package.json
+++ b/packages/builder/builder-rspack-provider/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.4.0",
+  "version": "2.5.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
@@ -57,7 +57,7 @@
     "typescript": "^4"
   },
   "peerDependencies": {
-    "@modern-js/e2e": "workspace:^2.4.0"
+    "@modern-js/e2e": "workspace:^2.4.1-beta.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/e2e": {

--- a/packages/builder/builder-shared/CHANGELOG.md
+++ b/packages/builder/builder-shared/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @modern-js/builder-shared
 
+## 2.5.0-beta.0
+
+### Minor Changes
+
+- 28e7dc6: feat: more use bunlder chain to modify bundler config
+  feat: 更多的使用 `bunlder chain` 去修改 bunlder 配置
+
+### Patch Changes
+
+- c4c10e7: refactor: refactor rules for static assets processing with rule.oneOf, reuse svg/font/image/media plugin
+
+  refactor: 使用 oneOf 重构静态资源处理规则 & 复用 svg / font / media / img 插件
+
+- 11c053b: feat: ssr support deploy worker
+
+  feat: ssr 支持边缘部署
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/server@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Minor Changes

--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.4.0",
+  "version": "2.5.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/builder-webpack-provider/CHANGELOG.md
+++ b/packages/builder/builder-webpack-provider/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @modern-js/builder-webpack-provider
 
+## 2.5.0-beta.0
+
+### Minor Changes
+
+- 28e7dc6: feat: more use bunlder chain to modify bundler config
+  feat: 更多的使用 `bunlder chain` 去修改 bunlder 配置
+
+### Patch Changes
+
+- c4c10e7: refactor: refactor rules for static assets processing with rule.oneOf, reuse svg/font/image/media plugin
+
+  refactor: 使用 oneOf 重构静态资源处理规则 & 复用 svg / font / media / img 插件
+
+- 11c053b: feat: ssr support deploy worker
+
+  feat: ssr 支持边缘部署
+
+- Updated dependencies [c4c10e7]
+- Updated dependencies [11c053b]
+- Updated dependencies [28e7dc6]
+  - @modern-js/builder-shared@2.5.0-beta.0
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/server@2.4.1-beta.0
+  - @modern-js/babel-preset-app@2.4.1-beta.0
+  - @modern-js/e2e@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Minor Changes

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.4.0",
+  "version": "2.5.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
@@ -115,7 +115,7 @@
     "typescript": "^4"
   },
   "peerDependencies": {
-    "@modern-js/e2e": "workspace:^2.4.0"
+    "@modern-js/e2e": "workspace:^2.4.1-beta.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/e2e": {

--- a/packages/builder/builder/CHANGELOG.md
+++ b/packages/builder/builder/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @modern-js/builder
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- c4c10e7: refactor: refactor rules for static assets processing with rule.oneOf, reuse svg/font/image/media plugin
+
+  refactor: 使用 oneOf 重构静态资源处理规则 & 复用 svg / font / media / img 插件
+
+- Updated dependencies [c4c10e7]
+- Updated dependencies [11c053b]
+- Updated dependencies [28e7dc6]
+  - @modern-js/builder-shared@2.5.0-beta.0
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/builder/builder/package.json
+++ b/packages/builder/builder/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-esbuild/CHANGELOG.md
+++ b/packages/builder/plugin-esbuild/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/builder-plugin-esbuild
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [c4c10e7]
+- Updated dependencies [11c053b]
+- Updated dependencies [28e7dc6]
+  - @modern-js/builder-shared@2.5.0-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/builder/plugin-esbuild/package.json
+++ b/packages/builder/plugin-esbuild/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-image-compress/CHANGELOG.md
+++ b/packages/builder/plugin-image-compress/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/builder-plugin-image-compress
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/builder/plugin-image-compress/package.json
+++ b/packages/builder/plugin-image-compress/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-node-polyfill/CHANGELOG.md
+++ b/packages/builder/plugin-node-polyfill/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/builder-plugin-node-polyfill
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- 11c053b: feat: ssr support deploy worker
+
+  feat: ssr 支持边缘部署
+
 ## 2.4.0
 
 ## 2.3.0

--- a/packages/builder/plugin-node-polyfill/package.json
+++ b/packages/builder/plugin-node-polyfill/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-stylus/CHANGELOG.md
+++ b/packages/builder/plugin-stylus/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/builder-plugin-stylus
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [c4c10e7]
+- Updated dependencies [11c053b]
+- Updated dependencies [28e7dc6]
+  - @modern-js/builder-shared@2.5.0-beta.0
+  - @modern-js/builder-webpack-provider@2.5.0-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/builder/plugin-stylus/package.json
+++ b/packages/builder/plugin-stylus/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-swc/CHANGELOG.md
+++ b/packages/builder/plugin-swc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/builder-plugin-swc
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [c4c10e7]
+- Updated dependencies [11c053b]
+- Updated dependencies [28e7dc6]
+  - @modern-js/builder-shared@2.5.0-beta.0
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/builder/plugin-swc/package.json
+++ b/packages/builder/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/builder-plugin-swc",
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "description": "SWC plugin for builder in Modern.js",
   "main": "./dist/index.js",
   "types": "./src/index.ts",

--- a/packages/cli/babel-preset-app/CHANGELOG.md
+++ b/packages/cli/babel-preset-app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/babel-preset-app
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/babel-preset-base@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/babel-preset-app/package.json
+++ b/packages/cli/babel-preset-app/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/babel-preset-base/CHANGELOG.md
+++ b/packages/cli/babel-preset-base/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/babel-preset-base
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/babel-preset-base/package.json
+++ b/packages/cli/babel-preset-base/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/cli/babel-preset-lib/CHANGELOG.md
+++ b/packages/cli/babel-preset-lib/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/babel-preset-lib
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/babel-preset-base@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/babel-preset-lib/package.json
+++ b/packages/cli/babel-preset-lib/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/babel-preset-module/CHANGELOG.md
+++ b/packages/cli/babel-preset-module/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/babel-preset-module
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/babel-preset-lib@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/babel-preset-module/package.json
+++ b/packages/cli/babel-preset-module/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/core/CHANGELOG.md
+++ b/packages/cli/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/core
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/node-bundle-require@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/cli/doc-core/package.json
+++ b/packages/cli/doc-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/doc-core",
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
@@ -102,7 +102,7 @@
     "node-fetch": "3.3.0"
   },
   "peerDependencies": {
-    "@modern-js/core": "workspace:^2.4.0",
+    "@modern-js/core": "workspace:^2.4.1-beta.0",
     "react": ">=17"
   },
   "devDependencies": {

--- a/packages/cli/doc-plugin-auto-sidebar/package.json
+++ b/packages/cli/doc-plugin-auto-sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/doc-plugin-auto-sidebar",
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
@@ -30,7 +30,7 @@
     "dist/"
   ],
   "peerDependencies": {
-    "@modern-js/doc-tools": "workspace:^2.4.0",
+    "@modern-js/doc-tools": "workspace:^2.4.1-beta.0",
     "react": ">=17"
   },
   "devDependencies": {

--- a/packages/cli/plugin-bff/CHANGELOG.md
+++ b/packages/cli/plugin-bff/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/plugin-bff
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/server-utils@2.4.1-beta.0
+  - @modern-js/bff-core@2.4.1-beta.0
+  - @modern-js/create-request@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/plugin-bff/package.json
+++ b/packages/cli/plugin-bff/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/cli.ts",
   "types": "./src/cli.ts",
   "main": "./dist/js/node/cli.js",

--- a/packages/cli/plugin-changeset/CHANGELOG.md
+++ b/packages/cli/plugin-changeset/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/plugin-changeset
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/plugin-i18n@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/plugin-changeset/package.json
+++ b/packages/cli/plugin-changeset/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-data-loader/package.json
+++ b/packages/cli/plugin-data-loader/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-i18n/CHANGELOG.md
+++ b/packages/cli/plugin-i18n/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/plugin-i18n
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/plugin-i18n/package.json
+++ b/packages/cli/plugin-i18n/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-lint/CHANGELOG.md
+++ b/packages/cli/plugin-lint/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/plugin-lint
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/plugin-lint/package.json
+++ b/packages/cli/plugin-lint/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-module-babel/package.json
+++ b/packages/cli/plugin-module-babel/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "3.0.0-beta.0",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "@modern-js/module-tools": "workspace:*"
   },
   "peerDependencies": {
-    "@modern-js/module-tools": "workspace:^2.4.0"
+    "@modern-js/module-tools": "workspace:^2.5.0-beta.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/cli/plugin-module-main-fields/package.json
+++ b/packages/cli/plugin-module-main-fields/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "3.0.0-beta.0",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
     "@modern-js/module-tools": "workspace:*"
   },
   "peerDependencies": {
-    "@modern-js/module-tools": "workspace:^2.4.0"
+    "@modern-js/module-tools": "workspace:^2.5.0-beta.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/cli/plugin-module-polyfill/package.json
+++ b/packages/cli/plugin-module-polyfill/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "3.0.0-beta.0",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
     "@modern-js/module-tools": "workspace:*"
   },
   "peerDependencies": {
-    "@modern-js/module-tools": "workspace:^2.4.0",
+    "@modern-js/module-tools": "workspace:^2.5.0-beta.0",
     "core-js-pure": "^3.25.0"
   },
   "dependencies": {

--- a/packages/cli/plugin-module-target/package.json
+++ b/packages/cli/plugin-module-target/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "3.0.0-beta.0",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
     "@modern-js/module-tools": "workspace:*"
   },
   "peerDependencies": {
-    "@modern-js/module-tools": "workspace:^2.4.0"
+    "@modern-js/module-tools": "workspace:^2.5.0-beta.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/cli/plugin-proxy/CHANGELOG.md
+++ b/packages/cli/plugin-proxy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/plugin-proxy
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/plugin-proxy/package.json
+++ b/packages/cli/plugin-proxy/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-ssg/CHANGELOG.md
+++ b/packages/cli/plugin-ssg/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/plugin-ssg
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/plugin-ssg/package.json
+++ b/packages/cli/plugin-ssg/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/plugin-storybook/CHANGELOG.md
+++ b/packages/cli/plugin-storybook/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @modern-js/plugin-storybook
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [c4c10e7]
+- Updated dependencies [7a25271]
+- Updated dependencies [11c053b]
+- Updated dependencies [28e7dc6]
+- Updated dependencies [6960cea]
+- Updated dependencies [a0f2ab1]
+  - @modern-js/builder@2.4.1-beta.0
+  - @modern-js/builder-shared@2.5.0-beta.0
+  - @modern-js/builder-webpack-provider@2.5.0-beta.0
+  - @modern-js/runtime@2.4.1-beta.0
+  - @modern-js/builder-plugin-node-polyfill@2.4.1-beta.0
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/plugin-router-v5@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/plugin-storybook/package.json
+++ b/packages/cli/plugin-storybook/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -85,8 +85,8 @@
     "webpack-chain": "^6.5.1"
   },
   "peerDependencies": {
-    "@modern-js/runtime": "workspace:^2.4.0",
-    "@modern-js/plugin-router-v5": "workspace:^2.4.0",
+    "@modern-js/runtime": "workspace:^2.4.1-beta.0",
+    "@modern-js/plugin-router-v5": "workspace:^2.4.1-beta.0",
     "react": ">=17",
     "react-dom": ">=17"
   },

--- a/packages/cli/plugin-swc/CHANGELOG.md
+++ b/packages/cli/plugin-swc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/core
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/builder-plugin-swc@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/plugin-swc/package.json
+++ b/packages/cli/plugin-swc/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/cli/plugin-tailwind/CHANGELOG.md
+++ b/packages/cli/plugin-tailwind/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/plugin-tailwindcss
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [7a25271]
+- Updated dependencies [11c053b]
+- Updated dependencies [a0f2ab1]
+  - @modern-js/runtime@2.4.1-beta.0
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/cli/plugin-tailwind/package.json
+++ b/packages/cli/plugin-tailwind/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "tailwindcss": ">= 2.0.0 || >= 3.0.0",
-    "@modern-js/runtime": "workspace:^2.4.0"
+    "@modern-js/runtime": "workspace:^2.4.1-beta.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/runtime": {

--- a/packages/generator/generator-cases/CHANGELOG.md
+++ b/packages/generator/generator-cases/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/generator-cases
 
+## 3.0.7-beta.0
+
+### Patch Changes
+
+- @modern-js/generator-common@3.0.7-beta.0
+
 ## 3.0.6
 
 ### Patch Changes

--- a/packages/generator/generator-cases/package.json
+++ b/packages/generator/generator-cases/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.6",
+  "version": "3.0.7-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/generator-common/CHANGELOG.md
+++ b/packages/generator/generator-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/generator-common
 
+## 3.0.7-beta.0
+
+### Patch Changes
+
+- @modern-js/plugin-i18n@2.4.1-beta.0
+
 ## 3.0.6
 
 ### Patch Changes

--- a/packages/generator/generator-common/package.json
+++ b/packages/generator/generator-common/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.6",
+  "version": "3.0.7-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/generator-plugin/CHANGELOG.md
+++ b/packages/generator/generator-plugin/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @modern-js/generator-plugin
 
+## 3.0.7-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/plugin-i18n@2.4.1-beta.0
+  - @modern-js/generator-common@3.0.7-beta.0
+  - @modern-js/generator-utils@3.0.7-beta.0
+  - @modern-js/new-action@2.4.1-beta.0
+
 ## 3.0.6
 
 ### Patch Changes

--- a/packages/generator/generator-plugin/package.json
+++ b/packages/generator/generator-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/generator-plugin",
-  "version": "3.0.6",
+  "version": "3.0.7-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/generator-utils/CHANGELOG.md
+++ b/packages/generator/generator-utils/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/generator-utils
 
+## 3.0.7-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/plugin-i18n@2.4.1-beta.0
+  - @modern-js/generator-common@3.0.7-beta.0
+
 ## 3.0.6
 
 ### Patch Changes

--- a/packages/generator/generator-utils/package.json
+++ b/packages/generator/generator-utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.6",
+  "version": "3.0.7-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/generator/new-action/CHANGELOG.md
+++ b/packages/generator/new-action/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/new-action
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/generator-common@3.0.7-beta.0
+  - @modern-js/generator-utils@3.0.7-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/generator/new-action/package.json
+++ b/packages/generator/new-action/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/review/eslint-config-app/CHANGELOG.md
+++ b/packages/review/eslint-config-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js-app/eslint-config
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- @modern-js/babel-preset-app@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/review/eslint-config-app/package.json
+++ b/packages/review/eslint-config-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js-app/eslint-config",
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "description": "A Progressive React Framework for modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/review/eslint-config/CHANGELOG.md
+++ b/packages/review/eslint-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/eslint-config
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- @modern-js-app/eslint-config@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/review/eslint-config/package.json
+++ b/packages/review/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/eslint-config",
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "description": "A Progressive React Framework for modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/runtime/plugin-garfish/CHANGELOG.md
+++ b/packages/runtime/plugin-garfish/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/plugin-garfish
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [7a25271]
+- Updated dependencies [11c053b]
+- Updated dependencies [a0f2ab1]
+  - @modern-js/runtime@2.4.1-beta.0
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/cli/index.ts",
   "types": "./src/cli/index.ts",
   "typesVersions": {
@@ -74,7 +74,7 @@
     "react-loadable": "^5.5.0"
   },
   "peerDependencies": {
-    "@modern-js/runtime": "workspace:^2.4.0"
+    "@modern-js/runtime": "workspace:^2.4.1-beta.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/runtime": {

--- a/packages/runtime/plugin-router-v5/package.json
+++ b/packages/runtime/plugin-router-v5/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/cli/index.ts",
   "main": "./dist/js/node/cli/index.js",

--- a/packages/runtime/plugin-runtime/CHANGELOG.md
+++ b/packages/runtime/plugin-runtime/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @modern-js/runtime
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- 7a25271: feat: support NoSSR component fallback UI
+  feat: 支持 NoSSR 组件 fallback UI
+- 11c053b: feat: ssr support deploy worker
+
+  feat: ssr 支持边缘部署
+
+- a0f2ab1: fix: ssg new Headers() error
+
+  fix: 修复 ssg 渲染是 new Headers() 报错问题
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "engines": {
     "node": ">=14.17.6"
   },

--- a/packages/runtime/plugin-testing/CHANGELOG.md
+++ b/packages/runtime/plugin-testing/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @modern-js/plugin-testing
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [7a25271]
+- Updated dependencies [11c053b]
+- Updated dependencies [a0f2ab1]
+  - @modern-js/runtime@2.4.1-beta.0
+  - @modern-js/prod-server@2.4.1-beta.0
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/babel-preset-app@2.4.1-beta.0
+  - @modern-js/babel-compiler@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/cli/index.ts",
   "types": "./src/cli/index.ts",
   "main": "./dist/js/node/cli/index.js",
@@ -123,7 +123,7 @@
   "peerDependencies": {
     "react": ">=17",
     "react-dom": ">=17",
-    "@modern-js/runtime": "workspace:^2.4.0"
+    "@modern-js/runtime": "workspace:^2.4.1-beta.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/runtime": {

--- a/packages/server/bff-core/CHANGELOG.md
+++ b/packages/server/bff-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/bff-core
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/server/bff-core/package.json
+++ b/packages/server/bff-core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/core/CHANGELOG.md
+++ b/packages/server/core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @modern-js/server-plugin
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- 11c053b: feat: ssr support deploy worker
+
+  feat: ssr 支持边缘部署
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/create-request/CHANGELOG.md
+++ b/packages/server/create-request/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/create-request
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/server/create-request/package.json
+++ b/packages/server/create-request/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-egg/CHANGELOG.md
+++ b/packages/server/plugin-egg/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/plugin-egg
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/bff-core@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/server/plugin-egg/package.json
+++ b/packages/server/plugin-egg/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/plugin-express/CHANGELOG.md
+++ b/packages/server/plugin-express/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/plugin-express
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/bff-core@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/server/plugin-express/package.json
+++ b/packages/server/plugin-express/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/cli",
   "main": "./dist/js/node/cli/index.js",

--- a/packages/server/plugin-koa/CHANGELOG.md
+++ b/packages/server/plugin-koa/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/plugin-koa
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/bff-core@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/server/plugin-koa/package.json
+++ b/packages/server/plugin-koa/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/cli",
   "main": "./dist/js/node/cli/index.js",

--- a/packages/server/plugin-nest/CHANGELOG.md
+++ b/packages/server/plugin-nest/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/plugin-nest
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/bff-core@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/server/plugin-nest/package.json
+++ b/packages/server/plugin-nest/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/server/plugin-polyfill/CHANGELOG.md
+++ b/packages/server/plugin-polyfill/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/plugin-polyfill
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/server/plugin-polyfill/package.json
+++ b/packages/server/plugin-polyfill/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/cli.ts",
   "types": "./src/cli.ts",
   "main": "./dist/js/node/cli.js",

--- a/packages/server/plugin-server/CHANGELOG.md
+++ b/packages/server/plugin-server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/plugin-server
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/server-utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/server/plugin-server/package.json
+++ b/packages/server/plugin-server/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "types": "./src/cli",
   "jsnext:source": "./src/cli",
   "main": "./dist/js/node/cli.js",

--- a/packages/server/plugin-worker/package.json
+++ b/packages/server/plugin-worker/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.3.0",
+  "version": "2.3.1-beta.0",
   "types": "./src",
   "jsnext:source": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/prod-server/CHANGELOG.md
+++ b/packages/server/prod-server/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/prod-server
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- 11c053b: feat: ssr support deploy worker
+
+  feat: ssr 支持边缘部署
+
+- Updated dependencies [11c053b]
+  - @modern-js/server-core@2.4.1-beta.0
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/server/prod-server/package.json
+++ b/packages/server/prod-server/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/server/CHANGELOG.md
+++ b/packages/server/server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/server
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/prod-server@2.4.1-beta.0
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/server-utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/server/utils/CHANGELOG.md
+++ b/packages/server/utils/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/server-utils
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/babel-preset-lib@2.4.1-beta.0
+  - @modern-js/babel-compiler@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/solutions/app-tools/CHANGELOG.md
+++ b/packages/solutions/app-tools/CHANGELOG.md
@@ -1,5 +1,36 @@
 # @modern-js/app-tools
 
+## 3.0.0-beta.0
+
+### Patch Changes
+
+- 840142c: fix: the `@modern-js/app-tools` hooks should set `webpack` as default type.
+  fix: `@modern-js/app-tools` hooks 应该将 'webpack' 设置为默认类型
+- 11c053b: feat: ssr support deploy worker
+
+  feat: ssr 支持边缘部署
+
+- Updated dependencies [c4c10e7]
+- Updated dependencies [84c21f9]
+- Updated dependencies [11c053b]
+- Updated dependencies [28e7dc6]
+  - @modern-js/builder@2.4.1-beta.0
+  - @modern-js/builder-rspack-provider@2.5.0-beta.0
+  - @modern-js/builder-shared@2.5.0-beta.0
+  - @modern-js/builder-webpack-provider@2.5.0-beta.0
+  - @modern-js/builder-plugin-node-polyfill@2.4.1-beta.0
+  - @modern-js/prod-server@2.4.1-beta.0
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/builder-plugin-esbuild@2.4.1-beta.0
+  - @modern-js/core@2.4.1-beta.0
+  - @modern-js/plugin-data-loader@2.4.1-beta.0
+  - @modern-js/server@2.4.1-beta.0
+  - @modern-js/plugin-i18n@2.4.1-beta.0
+  - @modern-js/plugin-lint@2.4.1-beta.0
+  - @modern-js/new-action@2.4.1-beta.0
+  - @modern-js/node-bundle-require@2.4.1-beta.0
+  - @modern-js/upgrade@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Minor Changes

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "3.0.0-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",
@@ -104,7 +104,7 @@
     "webpack": "^5.75.0"
   },
   "peerDependencies": {
-    "@modern-js/builder-rspack-provider": "workspace:^2.4.0"
+    "@modern-js/builder-rspack-provider": "workspace:^2.5.0-beta.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/builder-rspack-provider": {

--- a/packages/solutions/doc-tools/package.json
+++ b/packages/solutions/doc-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modern-js/doc-tools",
   "description": "The doc generator for Modern.js",
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/packages/solutions/module-tools/CHANGELOG.md
+++ b/packages/solutions/module-tools/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @modern-js/module-tools
 
+## 2.5.0-beta.0
+
+### Minor Changes
+
+- 0bbc91a: support sideEffects config and change log level to info
+  支持 sideEffects 配置并将日志级别改为 info
+
+### Patch Changes
+
+- 59172e9: feat: report size and info after build
+  feat: 构建后报告文件大小和信息
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/core@2.4.1-beta.0
+  - @modern-js/plugin-changeset@2.4.1-beta.0
+  - @modern-js/plugin-i18n@2.4.1-beta.0
+  - @modern-js/plugin-lint@2.4.1-beta.0
+  - @modern-js/new-action@2.4.1-beta.0
+  - @modern-js/upgrade@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -11,7 +11,7 @@
     "module-tools",
     "lib-tools"
   ],
-  "version": "2.4.0",
+  "version": "2.5.0-beta.0",
   "bin": {
     "modern": "./bin/modern.js",
     "modern-module": "./bin/modern.js"

--- a/packages/solutions/monorepo-tools/CHANGELOG.md
+++ b/packages/solutions/monorepo-tools/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @modern-js/monorepo-tools
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+  - @modern-js/core@2.4.1-beta.0
+  - @modern-js/plugin-changeset@2.4.1-beta.0
+  - @modern-js/plugin-i18n@2.4.1-beta.0
+  - @modern-js/plugin-lint@2.4.1-beta.0
+  - @modern-js/new-action@2.4.1-beta.0
+  - @modern-js/upgrade@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/solutions/monorepo-tools/package.json
+++ b/packages/solutions/monorepo-tools/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/toolkit/compiler/babel/CHANGELOG.md
+++ b/packages/toolkit/compiler/babel/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/babel-compiler
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/toolkit/compiler/babel/package.json
+++ b/packages/toolkit/compiler/babel/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/toolkit/e2e/package.json
+++ b/packages/toolkit/e2e/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@modern-js/e2e",
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "build": "tsc",

--- a/packages/toolkit/module-doc/package.json
+++ b/packages/toolkit/module-doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/module-tools-docs",
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "description": "docs",
   "main": "index.js",
   "scripts": {

--- a/packages/toolkit/node-bundle-require/CHANGELOG.md
+++ b/packages/toolkit/node-bundle-require/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/node-bundle-require
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- Updated dependencies [11c053b]
+  - @modern-js/utils@2.4.1-beta.0
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/toolkit/node-bundle-require/package.json
+++ b/packages/toolkit/node-bundle-require/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/node-bundle-require",
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "description": "A Progressive React Framework for modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/toolkit/upgrade/package.json
+++ b/packages/toolkit/upgrade/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/toolkit/utils/CHANGELOG.md
+++ b/packages/toolkit/utils/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/utils
 
+## 2.4.1-beta.0
+
+### Patch Changes
+
+- 11c053b: feat: ssr support deploy worker
+
+  feat: ssr 支持边缘部署
+
 ## 2.4.0
 
 ### Patch Changes

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/scripts/vitest-config/package.json
+++ b/scripts/vitest-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/vitest-config",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/website/main/package.json
+++ b/website/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/main-doc-website",
-  "version": "2.4.0",
+  "version": "2.4.1-beta.0",
   "private": true,
   "scripts": {
     "dev": "modern dev",


### PR DESCRIPTION

# Release v2.5.0-beta.0



## Features:

- [#2843](https://github.com/modern-js-dev/modern.js/pull/2843) 

  feat: report size and info after build

  feat: 构建后报告文件大小和信息

- [#2845](https://github.com/modern-js-dev/modern.js/pull/2845) 

  feat: search server

  feat: 对接搜索服务端

- [#2826](https://github.com/modern-js-dev/modern.js/pull/2826) 

  support sideEffects config and change log level to info

  支持sideEffects配置并将日志级别改为info

- [#2704](https://github.com/modern-js-dev/modern.js/pull/2704) 

  refactor: refactor rules for static assets processing with rule.oneOf, reuse svg/font/image/media plugin

  refactor: 使用 oneOf 重构静态资源处理规则 & 复用 svg / font / media / img 插件

- [#2844](https://github.com/modern-js-dev/modern.js/pull/2844) 

  feat: support NoSSR component fallback UI

  feat: 支持 NoSSR 组件 fallback UI

- [#2794](https://github.com/modern-js-dev/modern.js/pull/2794) 

  feat: ssr support deploy worker

  feat: ssr 支持边缘部署

- [#2838](https://github.com/modern-js-dev/modern.js/pull/2838) 

  feat: more use bunlder chain to modify bundler config

  feat: 更多的使用 `bunlder chain` 去修改 bunlder 配置


  feat(plugin-router-v5): support custom create router function

  feat(plugin-router-v5): 支持自定义路由创建函数

## Bug Fix:

- [#2839](https://github.com/modern-js-dev/modern.js/pull/2839) 

  fix(builder-webpack-provider): correct mistaken compilerOptions usage in ts-loader options

  fix(builder-webpack-provider): 改正 ts-loader options 中错误的 compilerOptions

- [#2835](https://github.com/modern-js-dev/modern.js/pull/2835) 

  fix: the `@modern-js/app-tools` hooks should set `webpack` as default type.

  fix: `@modern-js/app-tools` hooks 应该将 'webpack' 设置为默认类型

- [#2850](https://github.com/modern-js-dev/modern.js/pull/2850) 

  fix: ssg new Headers() error

  fix: 修复 ssg 渲染是 new Headers() 报错问题

