### PR TITLE
fix(builder): should not open startUrl multiple times

### DIFF
--- a/.changeset/four-pants-pay.md
+++ b/.changeset/four-pants-pay.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder': patch
+---
+
+fix(builder): should not open startUrl multiple times
+
+fix(builder): 修复 startUrl 被重复打开的问题

--- a/packages/builder/builder/src/plugins/startUrl.ts
+++ b/packages/builder/builder/src/plugins/startUrl.ts
@@ -4,6 +4,8 @@ import type { DefaultBuilderPlugin } from '@modern-js/builder-shared';
 export const replacePlaceholder = (url: string, port: number) =>
   url.replace(/<port>/g, String(port));
 
+const openedURLs: string[] = [];
+
 export function builderPluginStartUrl(): DefaultBuilderPlugin {
   return {
     name: 'builder-plugin-start-url',
@@ -42,7 +44,14 @@ export function builderPluginStartUrl(): DefaultBuilderPlugin {
         const { openBrowser } = await import('@modern-js/builder-shared');
 
         for (const url of urls) {
-          await openBrowser(url);
+          /**
+           * If a URL has been opened in current process, we will not open it again.
+           * It can prevent opening the same URL multiple times.
+           */
+          if (!openedURLs.includes(url)) {
+            await openBrowser(url);
+            openedURLs.push(url);
+          }
         }
       });
     },


### PR DESCRIPTION
## Description

Fix the `startUrl` may be opened multiple times.

For example, the developer is updating the `modern.config.ts`, then the CLI will be restarted and the `startUrl` will be opened again. This causes the browser to be opened frequently.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
