### PR TITLE
feat(builder): enable postcss plugins based on browserslist

### DIFF
--- a/.changeset/warm-shrimps-type.md
+++ b/.changeset/warm-shrimps-type.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+feat(builder): enable postcss plugins based on browserslist
+
+feat(builder): 基于 browserslist 来启用需要的 postcss 插件

--- a/packages/builder/builder-rspack-provider/src/plugins/css.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/css.ts
@@ -7,6 +7,7 @@ import {
   type BuilderContext,
   BundlerChain,
   ModifyBundlerChainUtils,
+  getCssSupport,
 } from '@modern-js/builder-shared';
 import type { BuilderPlugin, NormalizedConfig } from '../types';
 import type { AcceptedPlugin } from 'postcss';
@@ -77,16 +78,22 @@ export async function applyBaseCSSRule(
     };
     const enableCssMinify = !enableExtractCSS && isProd;
 
+    const cssSupport = getCssSupport(browserslist);
+
     const mergedConfig = applyOptionsChain(
       {
         postcssOptions: {
           plugins: [
             require(getCompiledPath('postcss-flexbugs-fixes')),
-            require(getCompiledPath('postcss-custom-properties')),
-            require(getCompiledPath('postcss-initial')),
-            require(getCompiledPath('postcss-page-break')),
-            require(getCompiledPath('postcss-font-variant')),
-            require(getCompiledPath('postcss-media-minmax')),
+            !cssSupport.customProperties &&
+              require(getCompiledPath('postcss-custom-properties')),
+            !cssSupport.initial && require(getCompiledPath('postcss-initial')),
+            !cssSupport.pageBreak &&
+              require(getCompiledPath('postcss-page-break')),
+            !cssSupport.fontVariant &&
+              require(getCompiledPath('postcss-font-variant')),
+            !cssSupport.mediaMinmax &&
+              require(getCompiledPath('postcss-media-minmax')),
             require(getCompiledPath('postcss-nesting')),
             require(getCompiledPath('autoprefixer'))(
               applyOptionsChain(

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/css.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/css.test.ts.snap
@@ -21,10 +21,6 @@ exports[`plugins/css > should override browserslist of autoprefixer when using o
                   [Function],
                   [Function],
                   [Function],
-                  [Function],
-                  [Function],
-                  [Function],
-                  [Function],
                   {
                     "browsers": [
                       "Chrome 80",

--- a/packages/builder/builder-shared/src/getBrowserslist.ts
+++ b/packages/builder/builder-shared/src/getBrowserslist.ts
@@ -32,7 +32,7 @@ export async function getBrowserslistWithDefault(
     if (Array.isArray(overrideBrowserslist)) {
       return overrideBrowserslist;
     }
-    return overrideBrowserslist[target];
+    return overrideBrowserslist[target] || DEFAULT_BROWSERSLIST[target];
   }
 
   const result = await getBrowserslist(path);

--- a/packages/builder/builder-shared/src/getCssSupport.ts
+++ b/packages/builder/builder-shared/src/getCssSupport.ts
@@ -1,0 +1,94 @@
+import browserslist from '@modern-js/utils/browserslist';
+
+const CSS_FEATURES_BROWSER = {
+  customProperties: {
+    and_chr: '49',
+    and_ff: '31',
+    android: '50',
+    chrome: '49',
+    edge: '15',
+    firefox: '31',
+    ios_saf: '9.3',
+    op_mob: '36',
+    opera: '36',
+    safari: '9.1',
+    samsung: '5.0',
+  },
+  initial: {
+    and_chr: '37',
+    and_ff: '27',
+    android: '37',
+    chrome: '37',
+    edge: '79',
+    firefox: '27',
+    ios_saf: '9.3',
+    op_mob: '24',
+    opera: '24',
+    safari: '9.1',
+    samsung: '3.0',
+  },
+  pageBreak: {
+    and_chr: '51',
+    and_ff: '92',
+    android: '51',
+    chrome: '51',
+    edge: '12',
+    firefox: '92',
+    ios_saf: '10',
+    op_mob: '37',
+    opera: '11.1',
+    safari: '10',
+    samsung: '5.0',
+  },
+  fontVariant: {
+    and_chr: '18',
+    and_ff: '34',
+    android: '4.4',
+    chrome: '1',
+    edge: '12',
+    firefox: '34',
+    ios_saf: '9.3',
+    op_mob: '12',
+    opera: '10',
+    safari: '9.1',
+    samsung: '1.0',
+  },
+  mediaMinmax: {
+    and_chr: '104',
+    and_ff: '109',
+    android: '104',
+    chrome: '104',
+    edge: '104',
+    firefox: '63',
+    opera: '91',
+  },
+};
+
+type CssFeatures = keyof typeof CSS_FEATURES_BROWSER;
+
+const getCssFeatureBrowsers = (feature: CssFeatures) => {
+  const featureBrowsers = CSS_FEATURES_BROWSER[feature];
+  return browserslist(
+    Object.entries(featureBrowsers).map(([key, value]) => `${key} >= ${value}`),
+  );
+};
+
+const isFeatureSupported = (
+  projectBrowsers: string[],
+  featureBrowsers: string[],
+) => projectBrowsers.every(item => featureBrowsers.includes(item));
+
+export function getCssSupport(projectBrowserslist: string[]) {
+  const projectBrowsers = browserslist(projectBrowserslist);
+
+  return (Object.keys(CSS_FEATURES_BROWSER) as CssFeatures[]).reduce(
+    (acc, key) => {
+      acc[key] = isFeatureSupported(
+        projectBrowsers,
+        getCssFeatureBrowsers(key),
+      );
+      return acc;
+    },
+    {} as Record<CssFeatures, boolean>,
+  );
+}

--- a/packages/builder/builder-shared/src/index.ts
+++ b/packages/builder/builder-shared/src/index.ts
@@ -6,6 +6,7 @@ export * from './createContext';
 export * from './utils';
 export * from './fs';
 export * from './getBrowserslist';
+export * from './getCssSupport';
 export * from './logger';
 export * from './mergeBuilderConfig';
 export * from './onExitProcess';

--- a/packages/builder/builder-webpack-provider/src/plugins/css.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/css.ts
@@ -2,12 +2,13 @@ import path from 'path';
 import assert from 'assert';
 import {
   CSS_REGEX,
+  getCssSupport,
+  ModifyChainUtils,
   isUseCssSourceMap,
   isLooseCssModules,
   getBrowserslistWithDefault,
   type BuilderTarget,
   type BuilderContext,
-  ModifyChainUtils,
 } from '@modern-js/builder-shared';
 import { merge as deepMerge } from '@modern-js/utils/lodash';
 import type {
@@ -95,16 +96,22 @@ export async function applyBaseCSSRule(
 
     const enableCssMinify = !enableExtractCSS && isProd;
 
+    const cssSupport = getCssSupport(browserslist);
+
     const mergedConfig = applyOptionsChain(
       {
         postcssOptions: {
           plugins: [
             require(getCompiledPath('postcss-flexbugs-fixes')),
-            require(getCompiledPath('postcss-custom-properties')),
-            require(getCompiledPath('postcss-initial')),
-            require(getCompiledPath('postcss-page-break')),
-            require(getCompiledPath('postcss-font-variant')),
-            require(getCompiledPath('postcss-media-minmax')),
+            !cssSupport.customProperties &&
+              require(getCompiledPath('postcss-custom-properties')),
+            !cssSupport.initial && require(getCompiledPath('postcss-initial')),
+            !cssSupport.pageBreak &&
+              require(getCompiledPath('postcss-page-break')),
+            !cssSupport.fontVariant &&
+              require(getCompiledPath('postcss-font-variant')),
+            !cssSupport.mediaMinmax &&
+              require(getCompiledPath('postcss-media-minmax')),
             require(getCompiledPath('postcss-nesting')),
             require(getCompiledPath('autoprefixer'))(
               applyOptionsChain(

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/css.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/css.test.ts.snap
@@ -62,10 +62,6 @@ exports[`plugins/css > should override browserslist of autoprefixer when using o
                   [Function],
                   [Function],
                   [Function],
-                  [Function],
-                  [Function],
-                  [Function],
-                  [Function],
                   {
                     "browsers": [
                       "Chrome 80",
@@ -75,6 +71,63 @@ exports[`plugins/css > should override browserslist of autoprefixer when using o
                       "flexbox": "no-2009",
                       "overrideBrowserslist": [
                         "Chrome 80",
+                      ],
+                    },
+                    "postcssPlugin": "autoprefixer",
+                    "prepare": [Function],
+                  },
+                ],
+              },
+              "sourceMap": true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`plugins/css > should remove some postcss plugins based on browserslist 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "use": [
+          {
+            "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/mini-css-extract-plugin/dist/loader.js",
+          },
+          {
+            "loader": "<ROOT>/compiled/css-loader",
+            "options": {
+              "importLoaders": 1,
+              "modules": {
+                "auto": true,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]--[hash:base64:5]",
+              },
+              "sourceMap": true,
+            },
+          },
+          {
+            "loader": "<ROOT>/compiled/postcss-loader",
+            "options": {
+              "postcssOptions": {
+                "plugins": [
+                  [Function],
+                  [Function],
+                  [Function],
+                  {
+                    "browsers": [
+                      "Chrome 100",
+                    ],
+                    "info": [Function],
+                    "options": {
+                      "flexbox": "no-2009",
+                      "overrideBrowserslist": [
+                        "Chrome 100",
                       ],
                     },
                     "postcssPlugin": "autoprefixer",

--- a/packages/builder/builder-webpack-provider/tests/plugins/css.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/css.test.ts
@@ -248,6 +248,20 @@ describe('plugins/css', () => {
       '"localIdentName":"[hash:base64]"',
     );
   });
+
+  it('should remove some postcss plugins based on browserslist', async () => {
+    const builder = await createStubBuilder({
+      plugins: [builderPluginCss()],
+      builderConfig: {
+        output: {
+          overrideBrowserslist: ['Chrome 100'],
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
 });
 
 describe('normalizeCssLoaderOptions', () => {


### PR DESCRIPTION
## Description

Enable postcss plugins based on browserslist, this change can remove some unnecessary postcss plugins when the browserslist only contains modern browsers.

This change can reduce the CSS size and improve compile speed of modern projects.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
