### PR TITLE
fix(builder): should not generate HTML for service-worker target

### DIFF
--- a/.changeset/dull-rice-compete.md
+++ b/.changeset/dull-rice-compete.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): should not generate HTML for service-worker target
+
+fix(builder): 修复 target 为 service-worker 时会生成 HTML 的问题

--- a/packages/builder/builder-shared/src/apply/html.ts
+++ b/packages/builder/builder-shared/src/apply/html.ts
@@ -157,7 +157,8 @@ export const isHtmlDisabled = (
 ) =>
   (config.tools as { htmlPlugin: boolean }).htmlPlugin === false ||
   target === 'node' ||
-  target === 'web-worker';
+  target === 'web-worker' ||
+  target === 'service-worker';
 
 async function getChunks(entryName: string, entryValue: string | string[]) {
   const { isPlainObject } = await import('@modern-js/utils');

--- a/packages/builder/builder-webpack-provider/tests/plugins/html.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/html.test.ts
@@ -39,6 +39,17 @@ describe('plugins/html', () => {
     expect(await builder.matchWebpackPlugin('HtmlWebpackPlugin')).toBeFalsy();
   });
 
+  it('should not register html plugin when target is service-worker', async () => {
+    const builder = await createStubBuilder({
+      plugins: [builderPluginEntry(), builderPluginHtml()],
+      target: 'service-worker',
+      entry: {
+        main: './src/main.ts',
+      },
+    });
+    expect(await builder.matchWebpackPlugin('HtmlWebpackPlugin')).toBeFalsy();
+  });
+
   it('should register crossorigin plugin when using html.crossorigin', async () => {
     const builder = await createStubBuilder({
       plugins: [builderPluginEntry(), builderPluginHtml()],


### PR DESCRIPTION
## Description

Should not generate HTML for service-worker target.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
