### PR TITLE
feat(builder): support mergeConfig util in tools.webpack

### DIFF
--- a/.changeset/tall-spoons-draw.md
+++ b/.changeset/tall-spoons-draw.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-doc': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-webpack-provider': patch
+---
+
+feat(builder): support mergeConfig util in tools.webpack
+
+feat(builder): 支持在 tools.webpack 中使用 mergeConfig 工具函数

--- a/packages/builder/builder-doc/docs/en/config/tools/webpack.md
+++ b/packages/builder/builder-doc/docs/en/config/tools/webpack.md
@@ -7,7 +7,7 @@
 
 ### Object Type
 
-You can configure it as an object, which will be merged with the original webpack configuration through `webpack-merge`. For example:
+You can configure it as an object, which will be merged with the original webpack configuration through [webpack-merge](https://github.com/survivejs/webpack-merge). For example:
 
 ```js
 export default {
@@ -265,6 +265,24 @@ export default {
   tools: {
     webpack: (config, { removePlugin }) => {
       removePlugin('ForkTsCheckerWebpackPlugin');
+    },
+  },
+};
+```
+
+### mergeConfig
+
+- **类型：** `(...configs: WebpackConfig[]) => WebpackConfig`
+
+Used to merge multiple webpack configs, same as [webpack-merge](https://github.com/survivejs/webpack-merge)。
+
+```ts
+export default {
+  tools: {
+    webpack: (config, { mergeConfig }) => {
+      return mergeConfig(config, {
+        devtool: 'eval',
+      });
     },
   },
 };

--- a/packages/builder/builder-doc/docs/zh/config/tools/webpack.md
+++ b/packages/builder/builder-doc/docs/zh/config/tools/webpack.md
@@ -7,7 +7,7 @@
 
 ### Object 类型
 
-你可以配置为一个对象，这个对象将会和原始的 webpack 配置通过 `webpack-merge` 进行合并。比如：
+你可以配置为一个对象，这个对象将会和原始的 webpack 配置通过 [webpack-merge](https://github.com/survivejs/webpack-merge) 进行合并。比如：
 
 ```js
 export default {
@@ -265,6 +265,24 @@ export default {
   tools: {
     webpack: (config, { removePlugin }) => {
       removePlugin('ForkTsCheckerWebpackPlugin');
+    },
+  },
+};
+```
+
+### mergeConfig
+
+- **类型：** `(...configs: WebpackConfig[]) => WebpackConfig`
+
+用于合并多份 webpack 配置，等价于 [webpack-merge](https://github.com/survivejs/webpack-merge)。
+
+```ts
+export default {
+  tools: {
+    webpack: (config, { mergeConfig }) => {
+      return mergeConfig(config, {
+        devtool: 'eval',
+      });
     },
   },
 };

--- a/packages/builder/builder-rspack-provider/src/core/rspackConfig.ts
+++ b/packages/builder/builder-rspack-provider/src/core/rspackConfig.ts
@@ -1,14 +1,15 @@
 import {
   debug,
+  BundlerConfig,
+  modifyBundlerChain,
   type NodeEnv,
   type BuilderTarget,
-  modifyBundlerChain,
-  BundlerConfig,
+  type ModifyChainUtils,
 } from '@modern-js/builder-shared';
 import { castArray, omitBy, isUndefined } from '@modern-js/utils/lodash';
 import { getCompiledPath } from '../shared';
-import type { Context, RspackConfig, ModifyRspackConfigUtils } from '../types';
 import { formatRule, formatSplitChunks } from './formatConfig';
+import type { Context, RspackConfig, ModifyRspackConfigUtils } from '../types';
 
 async function modifyRspackConfig(
   context: Context,
@@ -23,13 +24,12 @@ async function modifyRspackConfig(
 
   if (context.config.tools?.rspack) {
     const { applyOptionsChain } = await import('@modern-js/utils');
-    const { merge } = await import('../../compiled/webpack-merge');
 
     modifiedConfig = applyOptionsChain(
       modifiedConfig,
       context.config.tools.rspack,
       utils,
-      merge,
+      utils.mergeConfig,
     );
   }
 
@@ -37,17 +37,16 @@ async function modifyRspackConfig(
   return modifiedConfig;
 }
 
-type ChainUtils = Omit<
-  ModifyRspackConfigUtils,
-  'addRules' | 'prependPlugins' | 'appendPlugins' | 'removePlugin'
->;
-
-function getConfigUtils(
+async function getConfigUtils(
   config: RspackConfig,
-  chainUtils: ChainUtils,
-): ModifyRspackConfigUtils {
+  chainUtils: ModifyChainUtils,
+): Promise<ModifyRspackConfigUtils> {
+  const { merge } = await import('../../compiled/webpack-merge');
+
   return {
     ...chainUtils,
+
+    mergeConfig: merge,
 
     addRules(rules) {
       const ruleArr = castArray(rules);
@@ -84,7 +83,7 @@ function getConfigUtils(
   };
 }
 
-async function getChainUtils(target: BuilderTarget): Promise<ChainUtils> {
+async function getChainUtils(target: BuilderTarget): Promise<ModifyChainUtils> {
   const nodeEnv = process.env.NODE_ENV as NodeEnv;
   const { CHAIN_ID } = await import('@modern-js/utils');
 
@@ -153,7 +152,7 @@ export async function generateRspackConfig({
   rspackConfig = await modifyRspackConfig(
     context,
     rspackConfig,
-    getConfigUtils(rspackConfig, chainUtils),
+    await getConfigUtils(rspackConfig, chainUtils),
   );
 
   return rspackConfig;

--- a/packages/builder/builder-rspack-provider/src/types/hooks.ts
+++ b/packages/builder/builder-rspack-provider/src/types/hooks.ts
@@ -14,6 +14,7 @@ export type ModifyRspackConfigUtils = ModifyChainUtils & {
     plugins: RspackPluginInstance | RspackPluginInstance[],
   ) => void;
   removePlugin: (pluginName: string) => void;
+  mergeConfig: typeof import('../../compiled/webpack-merge').merge;
 };
 
 export type ModifyRspackConfigFn = (

--- a/packages/builder/builder-webpack-provider/src/core/webpackConfig.ts
+++ b/packages/builder/builder-webpack-provider/src/core/webpackConfig.ts
@@ -48,7 +48,6 @@ async function modifyWebpackConfig(
 ) {
   debug('modify webpack config');
   const { applyOptionsChain } = await import('@modern-js/utils');
-  const { merge } = await import('../../compiled/webpack-merge');
 
   let [modifiedConfig] = await context.hooks.modifyWebpackConfigHook.call(
     webpackConfig,
@@ -60,7 +59,7 @@ async function modifyWebpackConfig(
       modifiedConfig,
       context.config.tools.webpack,
       utils,
-      merge,
+      utils.mergeConfig,
     );
   }
 
@@ -99,12 +98,16 @@ async function getChainUtils(
   };
 }
 
-function getConfigUtils(
+async function getConfigUtils(
   config: WebpackConfig,
   chainUtils: ModifyWebpackChainUtils,
-): ModifyWebpackConfigUtils {
+): Promise<ModifyWebpackConfigUtils> {
+  const { merge } = await import('../../compiled/webpack-merge');
+
   return {
     ...chainUtils,
+
+    mergeConfig: merge,
 
     addRules(rules: RuleSetRule | RuleSetRule[]) {
       const ruleArr = castArray(rules);
@@ -167,7 +170,7 @@ export async function generateWebpackConfig({
   webpackConfig = await modifyWebpackConfig(
     context,
     webpackConfig,
-    getConfigUtils(webpackConfig, chainUtils),
+    await getConfigUtils(webpackConfig, chainUtils),
   );
 
   return webpackConfig;

--- a/packages/builder/builder-webpack-provider/src/types/hooks.ts
+++ b/packages/builder/builder-webpack-provider/src/types/hooks.ts
@@ -20,6 +20,7 @@ export type ModifyWebpackConfigUtils = ModifyWebpackChainUtils & {
     plugins: WebpackPluginInstance | WebpackPluginInstance[],
   ) => void;
   removePlugin: (pluginName: string) => void;
+  mergeConfig: typeof import('../../compiled/webpack-merge').merge;
 };
 
 export type ModifyWebpackChainFn = (

--- a/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -146,3 +146,25 @@ exports[`webpackConfig > should allow tools.webpackChain to be an array 1`] = `
   },
 }
 `;
+
+exports[`webpackConfig > should provide mergeConfig util in tools.webpack function 1`] = `
+{
+  "context": "<ROOT>",
+  "devtool": "eval",
+  "infrastructureLogging": {
+    "level": "error",
+  },
+  "mode": "development",
+  "module": {
+    "parser": {
+      "javascript": {
+        "exportsPresence": "error",
+      },
+    },
+  },
+  "performance": {
+    "maxAssetSize": 3000000,
+    "maxEntrypointSize": 3000000,
+  },
+}
+`;

--- a/packages/builder/builder-webpack-provider/tests/webpackConfig.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/webpackConfig.test.ts
@@ -75,6 +75,24 @@ describe('webpackConfig', () => {
     expect(config).toMatchSnapshot();
   });
 
+  it('should provide mergeConfig util in tools.webpack function', async () => {
+    const builder = await createStubBuilder({
+      plugins: [builderPluginBasic()],
+      builderConfig: {
+        tools: {
+          webpack: (config, { mergeConfig }) => {
+            return mergeConfig(config, {
+              devtool: 'eval',
+            });
+          },
+        },
+      },
+    });
+
+    const config = await builder.unwrapWebpackConfig();
+    expect(config).toMatchSnapshot();
+  });
+
   it('should allow to use tools.webpackChain to modify config', async () => {
     const builder = await createStubBuilder({
       plugins: [builderPluginBasic()],


### PR DESCRIPTION
## Description

Support mergeConfig util in tools.webpack.


```ts
export default {
  tools: {
    webpack: (config, { mergeConfig }) => {
      return mergeConfig(config, {
        devtool: 'eval',
      });
    },
  },
};
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
