### PR TITLE
feat: support render after server

### DIFF
--- a/.changeset/modern-jokes-drop.md
+++ b/.changeset/modern-jokes-drop.md
@@ -1,0 +1,10 @@
+---
+'@modern-js/plugin-bff': patch
+'@modern-js/server-core': patch
+'@modern-js/plugin-koa': patch
+'@modern-js/prod-server': patch
+'@modern-js/server': patch
+---
+
+feat: support bff handle complete server, include page render
+feat: 支持 bff 处理整个服务，包括页面渲染

--- a/packages/cli/plugin-bff/src/cli.ts
+++ b/packages/cli/plugin-bff/src/cli.ts
@@ -92,6 +92,19 @@ export default (): CliPlugin<AppTools> => ({
           // FIXME: })) as IAppContext[`serverRoutes`];
         })) as ServerRoute[];
 
+        if (bff?.enableHandleWeb) {
+          return {
+            routes: (
+              routes.map(route => {
+                return {
+                  ...route,
+                  isApi: true,
+                };
+              }) as ServerRoute[]
+            ).concat(apiServerRoutes),
+          };
+        }
+
         return { routes: routes.concat(apiServerRoutes) };
       },
 

--- a/packages/cli/plugin-bff/tests/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/plugin-bff/tests/__snapshots__/cli.test.ts.snap
@@ -48,3 +48,22 @@ Array [
   ],
 ]
 `;
+
+exports[`bff cli plugin schema 2`] = `
+Object {
+  "routes": Array [
+    Object {
+      "entryPath": "",
+      "isApi": true,
+      "urlPath": "/",
+    },
+    Object {
+      "entryPath": "",
+      "isApi": true,
+      "isSPA": false,
+      "isSSR": false,
+      "urlPath": "/api",
+    },
+  ],
+}
+`;

--- a/packages/cli/plugin-bff/tests/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/plugin-bff/tests/__snapshots__/cli.test.ts.snap
@@ -16,6 +16,25 @@ Array [
 ]
 `;
 
+exports[`bff cli plugin routes 1`] = `
+Object {
+  "routes": Array [
+    Object {
+      "entryPath": "",
+      "isApi": true,
+      "urlPath": "/",
+    },
+    Object {
+      "entryPath": "",
+      "isApi": true,
+      "isSPA": false,
+      "isSSR": false,
+      "urlPath": "/api",
+    },
+  ],
+}
+`;
+
 exports[`bff cli plugin schema 1`] = `
 Array [
   Array [
@@ -47,23 +66,4 @@ Array [
     },
   ],
 ]
-`;
-
-exports[`bff cli plugin schema 2`] = `
-Object {
-  "routes": Array [
-    Object {
-      "entryPath": "",
-      "isApi": true,
-      "urlPath": "/",
-    },
-    Object {
-      "entryPath": "",
-      "isApi": true,
-      "isSPA": false,
-      "isSSR": false,
-      "urlPath": "/api",
-    },
-  ],
-}
 `;

--- a/packages/server/core/src/plugin.ts
+++ b/packages/server/core/src/plugin.ts
@@ -21,8 +21,8 @@ import type {
   ISAppContext,
   ServerRoute,
 } from '@modern-js/types';
-import type { Options } from 'http-proxy-middleware';
-import type { ServerOptions, UserConfig } from './types/config';
+
+import type { BffUserConfig, ServerOptions, UserConfig } from './types/config';
 
 // collect all middleware register in server plugins
 const gather = createParallelWorkflow<{
@@ -67,6 +67,11 @@ export type APIServerStartInput = {
   config?: {
     middleware?: Array<any>;
   };
+  render?: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    url?: string,
+  ) => Promise<string | null>;
 };
 
 type Change = {
@@ -77,6 +82,8 @@ type Change = {
 const prepareApiServer = createAsyncPipeline<APIServerStartInput, Adapter>();
 
 const onApiChange = createWaterfall<Change[]>();
+
+const repack = createWaterfall();
 
 const beforeDevServer = createParallelWorkflow<ServerOptions, any>();
 
@@ -181,6 +188,7 @@ const serverHooks = {
   preparebeforeRouteHandler,
   prepareWebServer,
   prepareApiServer,
+  repack,
   onApiChange,
   beforeDevServer,
   setupCompiler,
@@ -228,9 +236,7 @@ export type ServerPlugin = PluginOptions<
 >;
 
 export type ServerConfig = {
-  bff?: Partial<{
-    proxy: Record<string, Options>;
-  }>;
+  bff?: BffUserConfig;
   plugins?: ServerPlugin[];
 };
 

--- a/packages/server/core/src/types/config/bff.ts
+++ b/packages/server/core/src/types/config/bff.ts
@@ -1,6 +1,9 @@
+import type { Options } from 'http-proxy-middleware';
+
 export interface BffUserConfig {
   prefix?: string;
-  proxy?: Record<string, string>;
+  proxy?: Record<string, Options>;
+  enableHandleWeb?: boolean;
 }
 
 export type BffNormalizedConfig = BffUserConfig;

--- a/packages/server/plugin-koa/tests/api.test.ts
+++ b/packages/server/plugin-koa/tests/api.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { serverManager } from '@modern-js/server-core';
+import { ConfigContext, serverManager } from '@modern-js/server-core';
 import request from 'supertest';
 import plugin from '../src/plugin';
 import { APIPlugin } from './helpers';
@@ -15,10 +15,22 @@ describe('support Api function', () => {
       .clone()
       .usePlugin(APIPlugin, plugin)
       .init();
+    ConfigContext.set({
+      bff: {
+        enableHandleWeb: true,
+      },
+    });
 
     apiHandler = await runner.prepareApiServer({
       pwd,
       prefix,
+      render: async req => {
+        if (req.url === '/render-page') {
+          return 'Hello Modern Render';
+        } else {
+          return null;
+        }
+      },
     });
   });
 
@@ -66,5 +78,11 @@ describe('support Api function', () => {
     const res = await request(apiHandler).get(`${prefix}/user`);
     expect(res.status).toBe(302);
     expect(res.redirect).toBe(true);
+  });
+
+  test('should support render web', async () => {
+    const res = await request(apiHandler).get(`/render-page`);
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('Hello Modern Render');
   });
 });

--- a/packages/server/plugin-koa/tests/helpers.ts
+++ b/packages/server/plugin-koa/tests/helpers.ts
@@ -19,6 +19,7 @@ export const APIPlugin = createPlugin(api => ({
       apiHandlerInfos,
       apiMode,
     });
+
     return next(props);
   },
 }));

--- a/packages/server/prod-server/src/server/modern-server.ts
+++ b/packages/server/prod-server/src/server/modern-server.ts
@@ -244,8 +244,8 @@ export class ModernServer implements ModernServerInterface {
   }
 
   public async render(req: IncomingMessage, res: ServerResponse, url?: string) {
-    req.logger = this.logger;
-    req.metrics = this.metrics;
+    req.logger = req.logger || this.logger;
+    req.metrics = req.metrics || this.metrics;
     const context = createContext(req, res);
     const matched = this.router.match(url || context.path);
     if (!matched) {
@@ -375,6 +375,7 @@ export class ModernServer implements ModernServerInterface {
         pwd: workDir,
         config: extension,
         prefix: Array.isArray(prefix) ? prefix[0] : prefix,
+        render: this.render.bind(this),
       },
       { onLast: () => null as any },
     );
@@ -423,8 +424,9 @@ export class ModernServer implements ModernServerInterface {
 
     bundles.forEach(bundle => {
       const filepath = path.join(distDir, bundle as string);
-      // if error, just throw and let process die
-      require(filepath);
+      if (fs.existsSync(filepath)) {
+        require(filepath);
+      }
     });
   }
 
@@ -647,8 +649,8 @@ export class ModernServer implements ModernServerInterface {
     },
   ) {
     res.statusCode = 200;
-    req.logger = this.logger;
-    req.metrics = this.metrics;
+    req.logger = req.logger || this.logger;
+    req.metrics = req.metrics || this.metrics;
     let context: ModernServerContext;
     try {
       context = this.createContext(req, res);

--- a/packages/server/server/src/server/dev-server.ts
+++ b/packages/server/server/src/server/dev-server.ts
@@ -214,6 +214,8 @@ export class ModernDevServer extends ModernServer {
     // reset static file
     this.reader.updateFile();
 
+    this.runner.repack();
+
     super.onRepack(options);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14886,10 +14886,8 @@ packages:
       ajv: 6.12.6
     dev: false
 
-  /ajv-formats/2.1.1_ajv@8.11.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -30790,7 +30788,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1_ajv@8.11.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scmp/2.1.0:


### PR DESCRIPTION
## Description

Before this feature, the traffic of front-end pages and BFF in the Modern.js was separate. Front-end pages can only be extended at the server level by customizing the Web Server. If you want the BFF and the page to share a set of middleware, there is some trouble here.

Now we provide a way to perform page rendering at the end of the BFF.

You only need to enable the following configuration, currently only Koa is supported.

```ts
export default {
  bff: {
    enableHandleWeb: true
  }
}
```

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
