### PR TITLE
docs: fix missing sidebar items of configration page

### DIFF
--- a/packages/cli/doc-core/src/theme-default/components/Search/index.module.scss
+++ b/packages/cli/doc-core/src/theme-default/components/Search/index.module.scss
@@ -74,7 +74,7 @@
   height: 40px;
   width: 100%;
   background-color: var(--modern-c-bg-alt);
-  transition: all 0.3s;
+  transition: border-color 0.3s;
   border: 1px solid transparent;
 
   & > button {

--- a/packages/toolkit/main-doc/en/configure/app/bff/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/bff/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "bff",
+  "position": 5
+}

--- a/packages/toolkit/main-doc/en/configure/app/deploy/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/deploy/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "deploy",
+  "position": 8
+}

--- a/packages/toolkit/main-doc/en/configure/app/dev/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/dev/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "dev",
+  "position": 7
+}

--- a/packages/toolkit/main-doc/en/configure/app/experiments/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/experiments/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "experiments",
+  "position": 15
+}

--- a/packages/toolkit/main-doc/en/configure/app/html/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/html/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "html",
+  "position": 2
+}

--- a/packages/toolkit/main-doc/en/configure/app/output/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/output/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "output",
+  "position": 2
+}

--- a/packages/toolkit/main-doc/en/configure/app/performance/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/performance/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "performance",
+  "position": 13
+}

--- a/packages/toolkit/main-doc/en/configure/app/runtime/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/runtime/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "runtime",
+  "position": 3
+}

--- a/packages/toolkit/main-doc/en/configure/app/security/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/security/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "security",
+  "position": 14
+}

--- a/packages/toolkit/main-doc/en/configure/app/server/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/server/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "server",
+  "position": 4
+}

--- a/packages/toolkit/main-doc/en/configure/app/source/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/source/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "source",
+  "position": 1
+}

--- a/packages/toolkit/main-doc/en/configure/app/testing/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/testing/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "testing",
+  "position": 8
+}

--- a/packages/toolkit/main-doc/en/configure/app/tools/_category_.json
+++ b/packages/toolkit/main-doc/en/configure/app/tools/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "tools",
+  "position": 12
+}

--- a/packages/toolkit/main-doc/en/configure/app/usage.mdx
+++ b/packages/toolkit/main-doc/en/configure/app/usage.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 0
 ---
 
-# Configure to use
+# Configuring Modern.js
 
 There are two configurations in the Modern.js, a compile configuration and a server runtime configuration.
 


### PR DESCRIPTION
## Description

Fix missing sidebar items of configure page.

### Before

<img width="253" alt="截屏2023-02-14 11 40 18" src="https://user-images.githubusercontent.com/7237365/218634112-183fe661-ed52-424c-9214-09902e907b2a.png">

### After

<img width="281" alt="截屏2023-02-14 11 43 16" src="https://user-images.githubusercontent.com/7237365/218634131-70d1feca-0aea-4e44-8c5f-808a46ba99ee.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [x] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
