### PR TITLE
fix(doc-core): remove default lang prefix from URL

### DIFF
--- a/.changeset/gorgeous-adults-sort.md
+++ b/.changeset/gorgeous-adults-sort.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): remove default lang prefix from URL
+
+fix(doc-core): 移除 URL 中的默认语言前缀

--- a/packages/cli/doc-core/src/node/mdx/remarkPlugins/normalizeLink.ts
+++ b/packages/cli/doc-core/src/node/mdx/remarkPlugins/normalizeLink.ts
@@ -63,9 +63,17 @@ export function normalizeLangPrefix(
     return rawUrl;
   }
   const url = addLeadingSlash(rawUrl);
-  if (url.startsWith(`/${lang}/`) || lang === defaultLang) {
+  const hasLangPrefix = url.startsWith(`/${lang}/`);
+
+  // If the url has a default lang prefix, then remove the lang prefix
+  if (hasLangPrefix && lang === defaultLang) {
+    return url.replace(`/${lang}`, '');
+  }
+
+  if (hasLangPrefix || lang === defaultLang) {
     return url;
   }
+
   return `/${lang}${url}`;
 }
 

--- a/packages/toolkit/main-doc/en/apis/app/runtime/core/create-app.mdx
+++ b/packages/toolkit/main-doc/en/apis/app/runtime/core/create-app.mdx
@@ -3,7 +3,7 @@ title: createApp
 ---
 # createApp
 
-Used to create custom entries, custom runtime plugins. This API is only required when using [Custom App](/guides/concept/entries#自定义-app).
+Used to create custom entries, custom runtime plugins. This API is only required when using [Custom App](/guides/concept/entries#app).
 
 ## Usage
 

--- a/website/main/modern.config.ts
+++ b/website/main/modern.config.ts
@@ -66,6 +66,9 @@ export default defineConfig({
     icon: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/uhbfnupenuhf/favicon.ico',
     lang: 'zh',
     themeDir: path.join(__dirname, 'src'),
+    markdown: {
+      checkDeadLinks: process.env.NODE_ENV === 'production',
+    },
     head: [
       `
           <script>


### PR DESCRIPTION
## Description

When we refer a relative path markdown, the generated URL when contain a lang prefix ('zh' is the default lang):

<img width="480" alt="Screen Shot 2023-02-16 at 14 27 19" src="https://user-images.githubusercontent.com/7237365/219287838-340c8ecf-11be-4f73-aae1-4c3fedf8be7b.png">

This will cause two problems:

1. The link will be redirected.
2. The checkDeadLinks will be failed.

So I removed the default lang prefix in `normalizeLangPrefix` method.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
