### PR TITLE
fix(runtime): document param output get undefined in default template

### DIFF
--- a/.changeset/underfin-is-awesome.md
+++ b/.changeset/underfin-is-awesome.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: document param output get undefined in default template
+fix: 修复 Document param 中 output 参数取值问题

--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -92,7 +92,7 @@ export default (): CliPlugin<AppTools> => ({
 
       return async ({ htmlWebpackPlugin }: { [option: string]: any }) => {
         const documentParams = getDocParams({
-          config: api.useConfigContext(),
+          config: api.useResolvedConfigContext(),
           entryName,
           templateParameters,
         });

--- a/packages/runtime/plugin-runtime/tests/document/cli.test.tsx
+++ b/packages/runtime/plugin-runtime/tests/document/cli.test.tsx
@@ -35,7 +35,9 @@ describe('plugin runtime cli', () => {
           },
         ],
       })),
-      useResolvedConfigContext: jest.fn(),
+      useResolvedConfigContext: jest.fn((): any => ({
+        output: {},
+      })),
     };
     const cloned = manager.clone(mockAPI);
     cloned.usePlugin(plugin);

--- a/packages/runtime/plugin-runtime/tests/document/cli.test.tsx
+++ b/packages/runtime/plugin-runtime/tests/document/cli.test.tsx
@@ -35,9 +35,6 @@ describe('plugin runtime cli', () => {
           },
         ],
       })),
-      useResolvedConfigContext: jest.fn((): any => ({
-        output: {},
-      })),
     };
     const cloned = manager.clone(mockAPI);
     cloned.usePlugin(plugin);


### PR DESCRIPTION
## Description

默认配置文档里面，这个地方应该去 normalizedConfig 之后的值，不然 output 这里取到的值会是 undefined，例如在官网 demo 中:

![image](https://user-images.githubusercontent.com/32598811/219362464-20ef76f6-f4e0-4d9f-bf1c-ba5b11a13fab.png)

这个地方取到 undefined 了，那么下面是会直接抛错的

顺便一提，这里 output 这个配置对象里面没有 title 这个属性？按照文档表述，这里是个 `Output` 配置对象，这里示例里面当成 htmlConfig 在使用？

![image](https://user-images.githubusercontent.com/32598811/219362811-6a3675a5-2fd4-45b3-9ba7-97982cabcf4d.png)



## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
