### PR TITLE
fix(builder-webpack-provider): adjust @babel/core to dependency

### DIFF
--- a/.changeset/rich-baboons-reflect.md
+++ b/.changeset/rich-baboons-reflect.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix: adjust @babel/core to dependencies instead of devDependencies.
+fix: 调整 `@babel/core` 为 `dependencies` 而不是 `devDependencies`.

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -86,6 +86,7 @@
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.9",
+    "@babel/core": "7.18.0",
     "acorn": "^8.8.1",
     "caniuse-lite": "^1.0.30001451",
     "cheerio": "1.0.0-rc.12",
@@ -103,7 +104,6 @@
     "webpack": "^5.75.0"
   },
   "devDependencies": {
-    "@babel/core": "7.18.0",
     "@babel/preset-env": "7.18.0",
     "@modern-js/e2e": "workspace:*",
     "@scripts/vitest-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,7 @@ importers:
       typescript: ^4
       webpack: ^5.75.0
     dependencies:
+      '@babel/core': 7.18.0
       '@modern-js/babel-preset-app': link:../../cli/babel-preset-app
       '@modern-js/builder-shared': link:../builder-shared
       '@modern-js/inspector-webpack-plugin': 1.0.5
@@ -234,7 +235,6 @@ importers:
       ts-loader: 9.4.1_vfotqvx6lgcbf3upbs6hgaza4q
       webpack: 5.75.0
     devDependencies:
-      '@babel/core': 7.18.0
       '@babel/preset-env': 7.18.0_@babel+core@7.18.0
       '@modern-js/e2e': link:../../toolkit/e2e
       '@scripts/vitest-config': link:../../../scripts/vitest-config
@@ -6132,7 +6132,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/core/7.20.5:
     resolution: {integrity: sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==}
@@ -6255,7 +6254,6 @@ packages:
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
       semver: 6.3.0
-    dev: true
 
   /@babel/helper-compilation-targets/7.20.0_@babel+core@7.20.5:
     resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Builder-webpack-proivder would found low verson @babel/core,

Because some users use monorepo that have many version of @babel/core with modern.js.

So adjust the @babel/core to dependencies instead of devDependencies


## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
