### PR TITLE
feat: check changeset

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3538,10 +3538,12 @@ importers:
   scripts/check-changeset:
     specifiers:
       '@changesets/read': ^0.5.5
+      '@manypkg/get-packages': ^1.1.3
       '@types/node': ^18.0.1
       tsx: ^3.7.1
     dependencies:
       '@changesets/read': 0.5.5
+      '@manypkg/get-packages': 1.1.3
     devDependencies:
       '@types/node': 18.11.17
       tsx: 3.7.1

--- a/scripts/check-changeset/package.json
+++ b/scripts/check-changeset/package.json
@@ -8,7 +8,8 @@
     "start": "tsx ./src/index.ts"
   },
   "dependencies": {
-    "@changesets/read": "^0.5.5"
+    "@changesets/read": "^0.5.5",
+    "@manypkg/get-packages": "^1.1.3"
   },
   "devDependencies": {
     "tsx": "^3.7.1",


### PR DESCRIPTION
## Description

Check changeset CI add strict validate to guarantee version consistency when publishing:

- changeset not allow has major version
- changeset not allow exist not found package
- package's peerDependencies should use `workspace:^xx` to define
<!--- Describe your changes -->

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
