### PR TITLE
fix: windows path compat in modifyPresetOptions

### DIFF
--- a/.changeset/dirty-rats-own.md
+++ b/.changeset/dirty-rats-own.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/babel-preset-base': patch
+---
+
+fix: windows path compat in modifyPresetOptions
+
+fix: 在 modifyPresetOptions 方法中兼容 windows 路径

--- a/packages/cli/babel-preset-base/src/babel-utils.ts
+++ b/packages/cli/babel-preset-base/src/babel-utils.ts
@@ -1,5 +1,5 @@
 import { sep, isAbsolute } from 'path';
-import { ensureArray } from '@modern-js/utils';
+import { ensureArray, normalizeToPosixPath } from '@modern-js/utils';
 import type { TransformOptions, PluginItem, PluginOptions } from '@babel/core';
 import { BabelConfigUtils, PresetEnvOptions, PresetReactOptions } from './type';
 
@@ -83,14 +83,20 @@ const modifyPresetOptions = <T>(
   presets.forEach((preset: PluginItem, index) => {
     // 1. ['@babel/preset-env', ...]
     if (Array.isArray(preset)) {
-      if (typeof preset[0] === 'string' && preset[0].includes(presetName)) {
+      if (
+        typeof preset[0] === 'string' &&
+        normalizeToPosixPath(preset[0]).includes(presetName)
+      ) {
         preset[1] = {
           ...(preset[1] || {}),
           ...options,
           // `options` is specific to different presets
         } as unknown as PluginOptions;
       }
-    } else if (typeof preset === 'string' && preset.includes(presetName)) {
+    } else if (
+      typeof preset === 'string' &&
+      normalizeToPosixPath(preset).includes(presetName)
+    ) {
       // 2. '@babel/preset-env'
       presets[index] = [preset, options];
     }


### PR DESCRIPTION
## Description

避免 modifyPresetReactOptions  及 modifyPresetEnvOptions 配置在 windows 系统不生效的问题
## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
