### PR TITLE
docs: should not clean doc-tools folder

### DIFF
--- a/.github/workflows/build-main-website.yml
+++ b/.github/workflows/build-main-website.yml
@@ -59,5 +59,7 @@ jobs:
             v1/**/*
             builder/*
             builder/**/*
+            doc-tools/*
+            doc-tools/**/*
             module-tools/*
             module-tools/**/*


### PR DESCRIPTION
## Description

Should not clean doc-tools folder when build main website.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [x] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
