### PR TITLE
Release v2.6.0

### DIFF
--- a/packages/builder/builder-doc/CHANGELOG.md
+++ b/packages/builder/builder-doc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/builder-doc
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- 107f674: feat(builder): add dev.beforeStartUrl config
+
+  feat(builder): 新增 dev.beforeStartUrl 配置项
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/builder/builder-doc/package.json
+++ b/packages/builder/builder-doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/builder-doc",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "description": "Shared documentation of modern.js builder",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/builder/builder-rspack-provider/CHANGELOG.md
+++ b/packages/builder/builder-rspack-provider/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @modern-js/builder-rspack-provider
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [b92d6db]
+- Updated dependencies [107f674]
+- Updated dependencies [7915ab3]
+  - @modern-js/builder-shared@3.0.0-next.0
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/server@3.0.0-next.0
+  - @modern-js/e2e@3.0.0-next.0
+  - @modern-js/types@3.0.0-next.0
+
 ## 2.5.0
 
 ### Minor Changes

--- a/packages/builder/builder-rspack-provider/package.json
+++ b/packages/builder/builder-rspack-provider/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
@@ -55,7 +55,7 @@
     "typescript": "^4"
   },
   "peerDependencies": {
-    "@modern-js/e2e": "workspace:^2.5.0"
+    "@modern-js/e2e": "workspace:^3.0.0-next.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/e2e": {

--- a/packages/builder/builder-shared/CHANGELOG.md
+++ b/packages/builder/builder-shared/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @modern-js/builder-shared
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- b92d6db: fix(builder): missing dev.beforeStartUrl schema validation
+
+  fix(builder): 修复 dev.beforeStartUrl 缺少 schema 校验的问题
+
+- 107f674: feat(builder): add dev.beforeStartUrl config
+
+  feat(builder): 新增 dev.beforeStartUrl 配置项
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/server@3.0.0-next.0
+  - @modern-js/types@3.0.0-next.0
+
 ## 2.5.0
 
 ### Minor Changes

--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/builder-webpack-provider/CHANGELOG.md
+++ b/packages/builder/builder-webpack-provider/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @modern-js/builder-webpack-provider
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- 671477d: chore(CI): make CI faster
+
+  chore(CI): 提升 CI 执行速度
+
+- 1c76d0e: fix: adjust @babel/core to dependencies instead of devDependencies.
+  fix: 调整 `@babel/core` 为 `dependencies` 而不是 `devDependencies`.
+- Updated dependencies [b92d6db]
+- Updated dependencies [107f674]
+- Updated dependencies [7915ab3]
+  - @modern-js/builder-shared@3.0.0-next.0
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/babel-preset-app@3.0.0-next.0
+  - @modern-js/server@3.0.0-next.0
+  - @modern-js/e2e@3.0.0-next.0
+  - @modern-js/types@3.0.0-next.0
+
 ## 2.5.0
 
 ### Minor Changes

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
@@ -114,7 +114,7 @@
     "typescript": "^4"
   },
   "peerDependencies": {
-    "@modern-js/e2e": "workspace:^2.5.0"
+    "@modern-js/e2e": "workspace:^3.0.0-next.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/e2e": {

--- a/packages/builder/builder/CHANGELOG.md
+++ b/packages/builder/builder/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @modern-js/builder
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- 107f674: feat(builder): add dev.beforeStartUrl config
+
+  feat(builder): 新增 dev.beforeStartUrl 配置项
+
+- Updated dependencies [b92d6db]
+- Updated dependencies [107f674]
+- Updated dependencies [7915ab3]
+  - @modern-js/builder-shared@3.0.0-next.0
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/builder/builder/package.json
+++ b/packages/builder/builder/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-esbuild/CHANGELOG.md
+++ b/packages/builder/plugin-esbuild/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/builder-plugin-esbuild
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [b92d6db]
+- Updated dependencies [107f674]
+  - @modern-js/builder-shared@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/builder/plugin-esbuild/package.json
+++ b/packages/builder/plugin-esbuild/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-image-compress/CHANGELOG.md
+++ b/packages/builder/plugin-image-compress/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @modern-js/builder-plugin-image-compress
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- 671477d: chore(CI): make CI faster
+
+  chore(CI): 提升 CI 执行速度
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/builder/plugin-image-compress/package.json
+++ b/packages/builder/plugin-image-compress/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-node-polyfill/CHANGELOG.md
+++ b/packages/builder/plugin-node-polyfill/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/builder-plugin-node-polyfill
 
+## 3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/builder/plugin-node-polyfill/package.json
+++ b/packages/builder/plugin-node-polyfill/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-stylus/CHANGELOG.md
+++ b/packages/builder/plugin-stylus/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @modern-js/builder-plugin-stylus
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [671477d]
+- Updated dependencies [b92d6db]
+- Updated dependencies [107f674]
+- Updated dependencies [1c76d0e]
+  - @modern-js/builder-webpack-provider@3.0.0-next.0
+  - @modern-js/builder-shared@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/builder/plugin-stylus/package.json
+++ b/packages/builder/plugin-stylus/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/builder/plugin-swc/CHANGELOG.md
+++ b/packages/builder/plugin-swc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/builder-plugin-swc
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [b92d6db]
+- Updated dependencies [107f674]
+- Updated dependencies [7915ab3]
+  - @modern-js/builder-shared@3.0.0-next.0
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/builder/plugin-swc/package.json
+++ b/packages/builder/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/builder-plugin-swc",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "description": "SWC plugin for builder in Modern.js",
   "main": "./dist/index.js",
   "types": "./src/index.ts",

--- a/packages/cli/babel-preset-app/CHANGELOG.md
+++ b/packages/cli/babel-preset-app/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/babel-preset-app
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [44f1adc]
+- Updated dependencies [7915ab3]
+  - @modern-js/babel-preset-base@3.0.0-next.0
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/babel-preset-app/package.json
+++ b/packages/cli/babel-preset-app/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/babel-preset-base/CHANGELOG.md
+++ b/packages/cli/babel-preset-base/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @modern-js/babel-preset-base
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- 44f1adc: fix: windows path compat in modifyPresetOptions
+
+  fix: 在 modifyPresetOptions 方法中兼容 windows 路径
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/babel-preset-base/package.json
+++ b/packages/cli/babel-preset-base/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/cli/babel-preset-lib/CHANGELOG.md
+++ b/packages/cli/babel-preset-lib/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/babel-preset-lib
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [44f1adc]
+- Updated dependencies [7915ab3]
+  - @modern-js/babel-preset-base@3.0.0-next.0
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/babel-preset-lib/package.json
+++ b/packages/cli/babel-preset-lib/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/babel-preset-module/CHANGELOG.md
+++ b/packages/cli/babel-preset-module/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/babel-preset-module
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/babel-preset-lib@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/babel-preset-module/package.json
+++ b/packages/cli/babel-preset-module/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/core/CHANGELOG.md
+++ b/packages/cli/core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/core
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/node-bundle-require@3.0.0-next.0
+  - @modern-js/plugin@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/cli/doc-core/package.json
+++ b/packages/cli/doc-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/doc-core",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "description": "The Documentation Framework of Modern.js.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",
@@ -110,7 +110,7 @@
     "medium-zoom": "1.0.8"
   },
   "peerDependencies": {
-    "@modern-js/core": "workspace:^2.5.0",
+    "@modern-js/core": "workspace:^3.0.0-next.0",
     "react": ">=17"
   },
   "devDependencies": {

--- a/packages/cli/doc-plugin-auto-sidebar/package.json
+++ b/packages/cli/doc-plugin-auto-sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/doc-plugin-auto-sidebar",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "description": "The Documentation Framework of Modern.js.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",
@@ -33,7 +33,7 @@
     "dist/"
   ],
   "peerDependencies": {
-    "@modern-js/doc-tools": "workspace:^2.5.0",
+    "@modern-js/doc-tools": "workspace:^3.0.0-next.0",
     "react": ">=17"
   },
   "devDependencies": {

--- a/packages/cli/plugin-bff/CHANGELOG.md
+++ b/packages/cli/plugin-bff/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/plugin-bff
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/bff-core@3.0.0-next.0
+  - @modern-js/create-request@3.0.0-next.0
+  - @modern-js/server-utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/plugin-bff/package.json
+++ b/packages/cli/plugin-bff/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/cli.ts",
   "types": "./src/cli.ts",
   "main": "./dist/cjs/cli.js",

--- a/packages/cli/plugin-changeset/CHANGELOG.md
+++ b/packages/cli/plugin-changeset/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/plugin-changeset
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/plugin-i18n@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/plugin-changeset/package.json
+++ b/packages/cli/plugin-changeset/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/plugin-data-loader/package.json
+++ b/packages/cli/plugin-data-loader/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/plugin-i18n/CHANGELOG.md
+++ b/packages/cli/plugin-i18n/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/plugin-i18n
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/plugin-i18n/package.json
+++ b/packages/cli/plugin-i18n/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/plugin-lint/CHANGELOG.md
+++ b/packages/cli/plugin-lint/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/plugin-lint
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/tsconfig@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/plugin-lint/package.json
+++ b/packages/cli/plugin-lint/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/plugin-module-babel/package.json
+++ b/packages/cli/plugin-module-babel/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "@modern-js/module-tools": "workspace:*"
   },
   "peerDependencies": {
-    "@modern-js/module-tools": "workspace:^2.5.0"
+    "@modern-js/module-tools": "workspace:^3.0.0-next.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/cli/plugin-module-main-fields/package.json
+++ b/packages/cli/plugin-module-main-fields/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
     "@modern-js/module-tools": "workspace:*"
   },
   "peerDependencies": {
-    "@modern-js/module-tools": "workspace:^2.5.0"
+    "@modern-js/module-tools": "workspace:^3.0.0-next.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/cli/plugin-module-polyfill/package.json
+++ b/packages/cli/plugin-module-polyfill/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
     "@modern-js/module-tools": "workspace:*"
   },
   "peerDependencies": {
-    "@modern-js/module-tools": "workspace:^2.5.0",
+    "@modern-js/module-tools": "workspace:^3.0.0-next.0",
     "core-js-pure": "^3.25.0"
   },
   "dependencies": {

--- a/packages/cli/plugin-module-target/package.json
+++ b/packages/cli/plugin-module-target/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
     "@modern-js/module-tools": "workspace:*"
   },
   "peerDependencies": {
-    "@modern-js/module-tools": "workspace:^2.5.0"
+    "@modern-js/module-tools": "workspace:^3.0.0-next.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/cli/plugin-proxy/CHANGELOG.md
+++ b/packages/cli/plugin-proxy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/plugin-proxy
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/plugin-proxy/package.json
+++ b/packages/cli/plugin-proxy/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/plugin-ssg/CHANGELOG.md
+++ b/packages/cli/plugin-ssg/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/plugin-ssg
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/plugin-ssg/package.json
+++ b/packages/cli/plugin-ssg/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/plugin-storybook/CHANGELOG.md
+++ b/packages/cli/plugin-storybook/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @modern-js/plugin-storybook
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- 77887d8: fix(storybook): remove `require` and fix dist/template path
+  fix(storybook): 移除 require 代码以及修复 dist/template 的路径问题
+- Updated dependencies [671477d]
+- Updated dependencies [b92d6db]
+- Updated dependencies [107f674]
+- Updated dependencies [7915ab3]
+- Updated dependencies [1c76d0e]
+- Updated dependencies [1906d7b]
+  - @modern-js/builder-webpack-provider@3.0.0-next.0
+  - @modern-js/runtime@3.0.0-next.0
+  - @modern-js/builder-shared@3.0.0-next.0
+  - @modern-js/builder@3.0.0-next.0
+  - @modern-js/plugin-router-v5@3.0.0-next.0
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/builder-plugin-node-polyfill@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/plugin-storybook/package.json
+++ b/packages/cli/plugin-storybook/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
@@ -84,8 +84,8 @@
     "webpack-chain": "^6.5.1"
   },
   "peerDependencies": {
-    "@modern-js/runtime": "workspace:^2.5.0",
-    "@modern-js/plugin-router-v5": "workspace:^2.5.0",
+    "@modern-js/runtime": "workspace:^3.0.0-next.0",
+    "@modern-js/plugin-router-v5": "workspace:^3.0.0-next.0",
     "react": ">=17",
     "react-dom": ">=17"
   },

--- a/packages/cli/plugin-swc/CHANGELOG.md
+++ b/packages/cli/plugin-swc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/core
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/builder-plugin-swc@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/plugin-swc/package.json
+++ b/packages/cli/plugin-swc/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/cli/plugin-tailwind/CHANGELOG.md
+++ b/packages/cli/plugin-tailwind/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/plugin-tailwindcss
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [671477d]
+- Updated dependencies [7915ab3]
+- Updated dependencies [1906d7b]
+  - @modern-js/runtime@3.0.0-next.0
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/cli/plugin-tailwind/package.json
+++ b/packages/cli/plugin-tailwind/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "tailwindcss": ">= 2.0.0 || >= 3.0.0",
-    "@modern-js/runtime": "workspace:^2.5.0"
+    "@modern-js/runtime": "workspace:^3.0.0-next.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/runtime": {

--- a/packages/generator/generator-cases/CHANGELOG.md
+++ b/packages/generator/generator-cases/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/generator-cases
 
+## 3.0.8-next.0
+
+### Patch Changes
+
+- Updated dependencies [b2ea17b]
+  - @modern-js/generator-common@3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generator-cases/package.json
+++ b/packages/generator/generator-cases/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/generator/generator-common/CHANGELOG.md
+++ b/packages/generator/generator-common/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/generator-common
 
+## 3.0.8-next.0
+
+### Patch Changes
+
+- b2ea17b: feat: create web app support select build tools
+
+  feat: 创建 Web App 支持选择构建工具
+
+  - @modern-js/plugin-i18n@3.0.0-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generator-common/package.json
+++ b/packages/generator/generator-common/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/generator/generator-plugin/CHANGELOG.md
+++ b/packages/generator/generator-plugin/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/generator-plugin
 
+## 3.0.8-next.0
+
+### Patch Changes
+
+- Updated dependencies [b2ea17b]
+- Updated dependencies [7915ab3]
+  - @modern-js/generator-common@3.0.8-next.0
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/generator-utils@3.0.8-next.0
+  - @modern-js/new-action@3.0.0-next.0
+  - @modern-js/plugin-i18n@3.0.0-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generator-plugin/package.json
+++ b/packages/generator/generator-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/generator-plugin",
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/generator/generator-utils/CHANGELOG.md
+++ b/packages/generator/generator-utils/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/generator-utils
 
+## 3.0.8-next.0
+
+### Patch Changes
+
+- Updated dependencies [b2ea17b]
+- Updated dependencies [7915ab3]
+  - @modern-js/generator-common@3.0.8-next.0
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/plugin-i18n@3.0.0-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generator-utils/package.json
+++ b/packages/generator/generator-utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/generator/generators/base-generator/CHANGELOG.md
+++ b/packages/generator/generators/base-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/base-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/base-generator/package.json
+++ b/packages/generator/generators/base-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./src/index.ts",

--- a/packages/generator/generators/bff-generator/CHANGELOG.md
+++ b/packages/generator/generators/bff-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/bff-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/bff-generator/package.json
+++ b/packages/generator/generators/bff-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./src/index.ts",

--- a/packages/generator/generators/changeset-generator/CHANGELOG.md
+++ b/packages/generator/generators/changeset-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/changeset-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/changeset-generator/package.json
+++ b/packages/generator/generators/changeset-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/dependence-generator/CHANGELOG.md
+++ b/packages/generator/generators/dependence-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/dependence-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/dependence-generator/package.json
+++ b/packages/generator/generators/dependence-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/entry-generator/CHANGELOG.md
+++ b/packages/generator/generators/entry-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/entry-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/entry-generator/package.json
+++ b/packages/generator/generators/entry-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/generator-generator/CHANGELOG.md
+++ b/packages/generator/generators/generator-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/generator-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/generator-generator/package.json
+++ b/packages/generator/generators/generator-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/module-generator/CHANGELOG.md
+++ b/packages/generator/generators/module-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/module-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/module-generator/package.json
+++ b/packages/generator/generators/module-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/module-test-generator/package.json
+++ b/packages/generator/generators/module-test-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/monorepo-generator/CHANGELOG.md
+++ b/packages/generator/generators/monorepo-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/monorepo-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/monorepo-generator/package.json
+++ b/packages/generator/generators/monorepo-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/mwa-generator/CHANGELOG.md
+++ b/packages/generator/generators/mwa-generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/mwa-generator
 
+## 3.0.8-next.0
+
+### Patch Changes
+
+- b2ea17b: feat: create web app support select build tools
+
+  feat: 创建 Web App 支持选择构建工具
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/mwa-generator/package.json
+++ b/packages/generator/generators/mwa-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/packages-generator/package.json
+++ b/packages/generator/generators/packages-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/repo-generator/CHANGELOG.md
+++ b/packages/generator/generators/repo-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/repo-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/repo-generator/package.json
+++ b/packages/generator/generators/repo-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/router-v5-generator/package.json
+++ b/packages/generator/generators/router-v5-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/rspack-generator/package.json
+++ b/packages/generator/generators/rspack-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/server-generator/CHANGELOG.md
+++ b/packages/generator/generators/server-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/server-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/server-generator/package.json
+++ b/packages/generator/generators/server-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./src/index.ts",

--- a/packages/generator/generators/ssg-generator/package.json
+++ b/packages/generator/generators/ssg-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/storybook-generator/CHANGELOG.md
+++ b/packages/generator/generators/storybook-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/storybook-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/storybook-generator/package.json
+++ b/packages/generator/generators/storybook-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/tailwindcss-generator/CHANGELOG.md
+++ b/packages/generator/generators/tailwindcss-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/tailwindcss-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/tailwindcss-generator/package.json
+++ b/packages/generator/generators/tailwindcss-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/test-generator/CHANGELOG.md
+++ b/packages/generator/generators/test-generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/test-generator
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/generator/generators/test-generator/package.json
+++ b/packages/generator/generators/test-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/generators/upgrade-generator/package.json
+++ b/packages/generator/generators/upgrade-generator/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/generator/new-action/CHANGELOG.md
+++ b/packages/generator/new-action/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/new-action
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [b2ea17b]
+- Updated dependencies [7915ab3]
+  - @modern-js/generator-common@3.0.8-next.0
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/generator-utils@3.0.8-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/generator/new-action/package.json
+++ b/packages/generator/new-action/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/generator/plugins/generator-plugin/CHANGELOG.md
+++ b/packages/generator/plugins/generator-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/generator-plugin-plugin
 
+## 3.0.8-next.0
+
 ## 3.0.7
 
 ## 3.0.6

--- a/packages/generator/plugins/generator-plugin/package.json
+++ b/packages/generator/plugins/generator-plugin/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8-next.0",
   "jsnext:source": "./src/index.ts",
   "main": "./src/index.ts",
   "files": [

--- a/packages/review/eslint-config-app/CHANGELOG.md
+++ b/packages/review/eslint-config-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js-app/eslint-config
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- @modern-js/babel-preset-app@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/review/eslint-config-app/package.json
+++ b/packages/review/eslint-config-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js-app/eslint-config",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "description": "A Progressive React Framework for modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/review/eslint-config/CHANGELOG.md
+++ b/packages/review/eslint-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/eslint-config
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- @modern-js-app/eslint-config@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/review/eslint-config/package.json
+++ b/packages/review/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/eslint-config",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "description": "A Progressive React Framework for modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/review/tsconfig/CHANGELOG.md
+++ b/packages/review/tsconfig/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/tsconfig
 
+## 3.0.0-next.0
+
 ## 2.5.0
 
 ## 2.4.0

--- a/packages/review/tsconfig/package.json
+++ b/packages/review/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/tsconfig",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "description": "A Progressive React Framework for modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/runtime/plugin-garfish/CHANGELOG.md
+++ b/packages/runtime/plugin-garfish/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/plugin-garfish
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [671477d]
+- Updated dependencies [7915ab3]
+- Updated dependencies [1906d7b]
+  - @modern-js/runtime@3.0.0-next.0
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/cli/index.ts",
   "types": "./src/cli/index.ts",
   "typesVersions": {
@@ -73,7 +73,7 @@
     "react-loadable": "^5.5.0"
   },
   "peerDependencies": {
-    "@modern-js/runtime": "workspace:^2.5.0"
+    "@modern-js/runtime": "workspace:^3.0.0-next.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/runtime": {

--- a/packages/runtime/plugin-router-v5/package.json
+++ b/packages/runtime/plugin-router-v5/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/cli/index.ts",
   "main": "./dist/cjs/cli/index.js",

--- a/packages/runtime/plugin-runtime/CHANGELOG.md
+++ b/packages/runtime/plugin-runtime/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @modern-js/runtime
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- 671477d: chore(CI): make CI faster
+
+  chore(CI): 提升 CI 执行速度
+
+- 7915ab3: fix: should not assign nestedRoutesEntry to entrypoint if use v5 router
+  fix: 使用 v5 路由的时候，不应该在 entrypoint 上挂载 nestedRoutesEntry 属性
+- 1906d7b: fix: document param output get undefined in default template
+  fix: 修复 Document param 中 output 参数取值问题
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/plugin@3.0.0-next.0
+  - @modern-js/types@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "engines": {
     "node": ">=14.17.6"
   },

--- a/packages/runtime/plugin-testing/CHANGELOG.md
+++ b/packages/runtime/plugin-testing/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @modern-js/plugin-testing
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [671477d]
+- Updated dependencies [7915ab3]
+- Updated dependencies [1906d7b]
+  - @modern-js/runtime@3.0.0-next.0
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/babel-preset-app@3.0.0-next.0
+  - @modern-js/prod-server@3.0.0-next.0
+  - @modern-js/babel-compiler@3.0.0-next.0
+  - @modern-js/plugin@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/cli/index.ts",
   "types": "./src/cli/index.ts",
   "main": "./dist/cjs/cli/index.js",
@@ -122,7 +122,7 @@
   "peerDependencies": {
     "react": ">=17",
     "react-dom": ">=17",
-    "@modern-js/runtime": "workspace:^2.5.0"
+    "@modern-js/runtime": "workspace:^3.0.0-next.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/runtime": {

--- a/packages/server/bff-core/CHANGELOG.md
+++ b/packages/server/bff-core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/bff-core
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/bff-runtime@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/bff-core/package.json
+++ b/packages/server/bff-core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/server/bff-runtime/CHANGELOG.md
+++ b/packages/server/bff-runtime/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/bff-runtime
 
+## 3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/bff-runtime/package.json
+++ b/packages/server/bff-runtime/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/server/core/CHANGELOG.md
+++ b/packages/server/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/server-plugin
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/plugin@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/server/create-request/CHANGELOG.md
+++ b/packages/server/create-request/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/create-request
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/create-request/package.json
+++ b/packages/server/create-request/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/server/plugin-egg/CHANGELOG.md
+++ b/packages/server/plugin-egg/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/plugin-egg
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/bff-core@3.0.0-next.0
+  - @modern-js/bff-runtime@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/plugin-egg/package.json
+++ b/packages/server/plugin-egg/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/server/plugin-express/CHANGELOG.md
+++ b/packages/server/plugin-express/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/plugin-express
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/bff-core@3.0.0-next.0
+  - @modern-js/bff-runtime@3.0.0-next.0
+  - @modern-js/types@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/plugin-express/package.json
+++ b/packages/server/plugin-express/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/cli",
   "main": "./dist/cjs/cli/index.js",

--- a/packages/server/plugin-koa/CHANGELOG.md
+++ b/packages/server/plugin-koa/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/plugin-koa
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/bff-core@3.0.0-next.0
+  - @modern-js/bff-runtime@3.0.0-next.0
+  - @modern-js/types@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/plugin-koa/package.json
+++ b/packages/server/plugin-koa/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/cli",
   "main": "./dist/cjs/cli/index.js",

--- a/packages/server/plugin-nest/CHANGELOG.md
+++ b/packages/server/plugin-nest/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/plugin-nest
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/bff-core@3.0.0-next.0
+  - @modern-js/bff-runtime@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/plugin-nest/package.json
+++ b/packages/server/plugin-nest/package.json
@@ -10,7 +10,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/server/plugin-polyfill/CHANGELOG.md
+++ b/packages/server/plugin-polyfill/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/plugin-polyfill
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/plugin-polyfill/package.json
+++ b/packages/server/plugin-polyfill/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/cli.ts",
   "types": "./src/cli.ts",
   "main": "./dist/cjs/cli.js",

--- a/packages/server/plugin-server/CHANGELOG.md
+++ b/packages/server/plugin-server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/plugin-server
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/server-utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/plugin-server/package.json
+++ b/packages/server/plugin-server/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "types": "./src/cli",
   "jsnext:source": "./src/cli",
   "main": "./dist/cjs/cli.js",

--- a/packages/server/plugin-worker/package.json
+++ b/packages/server/plugin-worker/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "types": "./src",
   "jsnext:source": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/server/prod-server/CHANGELOG.md
+++ b/packages/server/prod-server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/prod-server
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/server-core@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/prod-server/package.json
+++ b/packages/server/prod-server/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/server/server/CHANGELOG.md
+++ b/packages/server/server/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/server
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/prod-server@3.0.0-next.0
+  - @modern-js/server-utils@3.0.0-next.0
+  - @modern-js/types@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/server/utils/CHANGELOG.md
+++ b/packages/server/utils/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @modern-js/server-utils
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/babel-preset-lib@3.0.0-next.0
+  - @modern-js/babel-compiler@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/solutions/app-tools/CHANGELOG.md
+++ b/packages/solutions/app-tools/CHANGELOG.md
@@ -1,5 +1,36 @@
 # @modern-js/app-tools
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- 7915ab3: fix: should not assign nestedRoutesEntry to entrypoint if use v5 router
+  fix: 使用 v5 路由的时候，不应该在 entrypoint 上挂载 nestedRoutesEntry 属性
+- Updated dependencies [671477d]
+- Updated dependencies [b92d6db]
+- Updated dependencies [d638438]
+- Updated dependencies [107f674]
+- Updated dependencies [7915ab3]
+- Updated dependencies [1c76d0e]
+  - @modern-js/builder-webpack-provider@3.0.0-next.0
+  - @modern-js/builder-shared@3.0.0-next.0
+  - @modern-js/plugin-data-loader@3.0.0-next.0
+  - @modern-js/builder@3.0.0-next.0
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/builder-plugin-esbuild@3.0.0-next.0
+  - @modern-js/builder-plugin-node-polyfill@3.0.0-next.0
+  - @modern-js/builder-rspack-provider@3.0.0-next.0
+  - @modern-js/core@3.0.0-next.0
+  - @modern-js/new-action@3.0.0-next.0
+  - @modern-js/plugin-i18n@3.0.0-next.0
+  - @modern-js/plugin-lint@3.0.0-next.0
+  - @modern-js/prod-server@3.0.0-next.0
+  - @modern-js/server@3.0.0-next.0
+  - @modern-js/node-bundle-require@3.0.0-next.0
+  - @modern-js/upgrade@3.0.0-next.0
+  - @modern-js/plugin@3.0.0-next.0
+  - @modern-js/types@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
@@ -103,7 +103,7 @@
     "webpack": "^5.75.0"
   },
   "peerDependencies": {
-    "@modern-js/builder-rspack-provider": "workspace:^2.5.0"
+    "@modern-js/builder-rspack-provider": "workspace:^3.0.0-next.0"
   },
   "peerDependenciesMeta": {
     "@modern-js/builder-rspack-provider": {

--- a/packages/solutions/doc-tools/package.json
+++ b/packages/solutions/doc-tools/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",
   "repository": "modern-js-dev/modern.js",
   "license": "MIT",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/packages/solutions/module-tools/CHANGELOG.md
+++ b/packages/solutions/module-tools/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @modern-js/module-tools
 
+## 3.0.0-next.0
+
+### Minor Changes
+
+- c1918f5: feat(module-tools): add new Buildpreset and `extendPreset` function
+  feat(module-tools): 新增新的 buildPreset 以及 extendPreset 函数
+- 44e7b10: feat: add noDevTools hook. fix dev log content and add add chinese and english content
+  feat: 增加 noDevTools hook. 修复 dev 的日志内容, 增加中英内容
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/core@3.0.0-next.0
+  - @modern-js/new-action@3.0.0-next.0
+  - @modern-js/plugin-changeset@3.0.0-next.0
+  - @modern-js/plugin-i18n@3.0.0-next.0
+  - @modern-js/plugin-lint@3.0.0-next.0
+  - @modern-js/upgrade@3.0.0-next.0
+  - @modern-js/plugin@3.0.0-next.0
+
 ## 2.5.0
 
 ### Minor Changes

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -11,7 +11,7 @@
     "module-tools",
     "lib-tools"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "bin": {
     "modern": "./bin/modern.js",
     "modern-module": "./bin/modern.js"

--- a/packages/solutions/monorepo-tools/CHANGELOG.md
+++ b/packages/solutions/monorepo-tools/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @modern-js/monorepo-tools
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+  - @modern-js/core@3.0.0-next.0
+  - @modern-js/new-action@3.0.0-next.0
+  - @modern-js/plugin-changeset@3.0.0-next.0
+  - @modern-js/plugin-i18n@3.0.0-next.0
+  - @modern-js/plugin-lint@3.0.0-next.0
+  - @modern-js/upgrade@3.0.0-next.0
+  - @modern-js/plugin@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/solutions/monorepo-tools/package.json
+++ b/packages/solutions/monorepo-tools/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/toolkit/compiler/babel/CHANGELOG.md
+++ b/packages/toolkit/compiler/babel/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/babel-compiler
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/toolkit/compiler/babel/package.json
+++ b/packages/toolkit/compiler/babel/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/toolkit/create/CHANGELOG.md
+++ b/packages/toolkit/create/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/create
 
+## 3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/toolkit/create/package.json
+++ b/packages/toolkit/create/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/toolkit/doc-tools-doc/package.json
+++ b/packages/toolkit/doc-tools-doc/package.json
@@ -16,7 +16,7 @@
     "build:doc": "modern build",
     "preview": "cross-env NODE_ENV=production modern preview"
   },
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/toolkit/e2e/package.json
+++ b/packages/toolkit/e2e/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@modern-js/e2e",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "build": "tsc",

--- a/packages/toolkit/main-doc/package.json
+++ b/packages/toolkit/main-doc/package.json
@@ -14,13 +14,13 @@
   "scripts": {
     "build": "npx ts-node ./scripts/sync.ts"
   },
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
   "peerDependencies": {
-    "@modern-js/builder-doc": "workspace:^2.5.0"
+    "@modern-js/builder-doc": "workspace:^3.0.0-next.0"
   },
   "devDependencies": {
     "@modern-js/builder-doc": "workspace:*",

--- a/packages/toolkit/module-doc/package.json
+++ b/packages/toolkit/module-doc/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",
   "repository": "modern-js-dev/modern.js",
   "license": "MIT",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "main": "index.js",
   "scripts": {
     "dev": "modern dev",

--- a/packages/toolkit/node-bundle-require/CHANGELOG.md
+++ b/packages/toolkit/node-bundle-require/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/node-bundle-require
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- Updated dependencies [7915ab3]
+  - @modern-js/utils@3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/toolkit/node-bundle-require/package.json
+++ b/packages/toolkit/node-bundle-require/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/node-bundle-require",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "description": "A Progressive React Framework for modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/modern-js-dev/modern.js/issues",

--- a/packages/toolkit/plugin/CHANGELOG.md
+++ b/packages/toolkit/plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/plugin
 
+## 3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/toolkit/plugin/package.json
+++ b/packages/toolkit/plugin/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/toolkit/remark-container/package.json
+++ b/packages/toolkit/remark-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/remark-container",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/packages/toolkit/types/CHANGELOG.md
+++ b/packages/toolkit/types/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/types
 
+## 3.0.0-next.0
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/toolkit/types/package.json
+++ b/packages/toolkit/types/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "types": "./index.d.ts",
   "exports": {
     ".": "./index.d.ts",

--- a/packages/toolkit/upgrade/package.json
+++ b/packages/toolkit/upgrade/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/toolkit/utils/CHANGELOG.md
+++ b/packages/toolkit/utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/utils
 
+## 3.0.0-next.0
+
+### Patch Changes
+
+- 7915ab3: fix: should not assign nestedRoutesEntry to entrypoint if use v5 router
+  fix: 使用 v5 路由的时候，不应该在 entrypoint 上挂载 nestedRoutesEntry 属性
+
 ## 2.5.0
 
 ### Patch Changes

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",

--- a/scripts/build/package.json
+++ b/scripts/build/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/build",
   "private": true,
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "main": "./src/index.js",
   "bin": {
     "modern-lib": "./bin/modern.js",

--- a/scripts/check-changeset/package.json
+++ b/scripts/check-changeset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scripts/check-changeset",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "private": true,
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/codemod/package.json
+++ b/scripts/codemod/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/codemod",
   "private": true,
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "scripts": {
     "build": "modern-lib build"
   },

--- a/scripts/jest-config/package.json
+++ b/scripts/jest-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/jest-config",
   "private": true,
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "main": "jest.config.js",
   "devDependencies": {
     "@swc/core": "1.3.18",

--- a/scripts/lint-package-json/package.json
+++ b/scripts/lint-package-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scripts/lint-package-json",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "private": true,
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/prebundle/package.json
+++ b/scripts/prebundle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/prebundle",
   "private": true,
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "main": "./dist/index.js",
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/vitest-config/package.json
+++ b/scripts/vitest-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/vitest-config",
   "private": true,
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {

--- a/website/main/package.json
+++ b/website/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/main-doc-website",
-  "version": "2.5.0",
+  "version": "3.0.0-next.0",
   "private": true,
   "scripts": {
     "dev": "modern dev",


### PR DESCRIPTION

# Release v2.6.0



## Features:

- [#2919](https://github.com/modern-js-dev/modern.js/pull/2919) 

  chore(CI): make CI faster

  chore(CI): 提升 CI 执行速度

- [#2927](https://github.com/modern-js-dev/modern.js/pull/2927) 

  feat(module-tools): add new Buildpreset and `extendPreset` function

  feat(module-tools): 新增新的 buildPreset 以及 extendPreset 函数

- [#2927](https://github.com/modern-js-dev/modern.js/pull/2927) 

  docs(module-tools): update `buildPreset` api content

  docs(module-tools): 更新 `buildPreset` API 内容

- [#2932](https://github.com/modern-js-dev/modern.js/pull/2932) 

  feat: create web app support select build tools

  feat: 创建 Web App 支持选择构建工具

- [#2928](https://github.com/modern-js-dev/modern.js/pull/2928) 

  feat(builder): add dev.beforeStartUrl config

  feat(builder): 新增 dev.beforeStartUrl 配置项

- [#2935](https://github.com/modern-js-dev/modern.js/pull/2935) 

  feat: add noDevTools hook. fix dev log content and add add chinese and english content

  feat: 增加 noDevTools hook. 修复 dev 的日志内容, 增加中英内容

- [#2931](https://github.com/modern-js-dev/modern.js/pull/2931) 

  feat: doc tools doc

  feat: 文档框架文档开发

## Bug Fix:

- [#2939](https://github.com/modern-js-dev/modern.js/pull/2939) 

  fix(builder): missing dev.beforeStartUrl schema validation

  fix(builder): 修复 dev.beforeStartUrl 缺少 schema 校验的问题

- [#2943](https://github.com/modern-js-dev/modern.js/pull/2943) 

  fix: windows path compat in modifyPresetOptions

  fix: 在 modifyPresetOptions 方法中兼容 windows 路径

- [#2934](https://github.com/modern-js-dev/modern.js/pull/2934) 

  fix: worker use loader error

  fix: 修复 worker 中使用 loader 报错问题

- [#2922](https://github.com/modern-js-dev/modern.js/pull/2922) 

  fix: search index file enter userRoot

  fix: 防止搜索索引文件路径进入项目目录

- [#2948](https://github.com/modern-js-dev/modern.js/pull/2948) 

  fix: doc-tools doc base

  fix: 文档框架文档 base 配置

- [#2926](https://github.com/modern-js-dev/modern.js/pull/2926) 

  fix: should not assign nestedRoutesEntry to entrypoint if use v5 router

  fix: 使用 v5 路由的时候，不应该在 entrypoint 上挂载 nestedRoutesEntry 属性

- [#2936](https://github.com/modern-js-dev/modern.js/pull/2936) 

  fix: adjust @babel/core to dependencies instead of devDependencies.

  fix: 调整 `@babel/core` 为 `dependencies` 而不是 `devDependencies`.

- [#2946](https://github.com/modern-js-dev/modern.js/pull/2946) 

  fix: micro frontend docs

  fix: 微前端文档

- [#2929](https://github.com/modern-js-dev/modern.js/pull/2929) 

  fix(storybook): remove `require` and fix dist/template path

  fix(storybook): 移除 require 代码以及修复 dist/template 的路径问题

- [#2924](https://github.com/modern-js-dev/modern.js/pull/2924) 

  fix: document param output get undefined in default template

  fix: 修复 Document param 中 output 参数取值问题

