### PR TITLE
docs(builder): correct rspack case

### DIFF
--- a/packages/builder/builder-doc/docs/en/api/builder-core.mdx
+++ b/packages/builder/builder-doc/docs/en/api/builder-core.mdx
@@ -12,7 +12,7 @@ Create a Builder instance object.
 
 When using this method, it needs to be used with the `@modern-js/builder-webpack-provider` or `@modern-js/builder-rspack-provider`. Providers implements corresponding build feature based on specific bundlers.
 
-### Webpack Provider
+### builderWebpackProvider
 
 When `builderWebpackProvider` is passed, the Builder will use webpack as the bundler for building.
 
@@ -31,9 +31,9 @@ const builder = await createBuilder(provider, {
 });
 ```
 
-### Rspack Provider
+### builderRspackProvider
 
-When `builderRspackProvider` is passed, the Builder will use Rspack as the bundler for building.
+When `builderRspackProvider` is passed, the Builder will use rspack as the bundler for building.
 
 ```ts
 import { createBuilder } from '@modern-js/builder';

--- a/packages/builder/builder-doc/docs/en/api/plugin-core.mdx
+++ b/packages/builder/builder-doc/docs/en/api/plugin-core.mdx
@@ -42,11 +42,11 @@ The type of plugin API. The plugin API provides the context info, utility functi
 
 For a complete introduction to lifecycle hooks, please read the [Plugin Hooks](/api/plugin-hooks.html) chapter.
 
-When using webpack provider or rspack provider, the type definition of `BuilderPluginAPI` is somewhat different, and you can introduce the corresponding type according to the usage scenario of the plugin.
+When using webpack-provider or rspack-provider, the type definition of `BuilderPluginAPI` is somewhat different, and you can introduce the corresponding type according to the usage scenario of the plugin.
 
-### Plugin for webpack provider
+### Plugin for webpack-provider
 
-When developing plugins for webpack provider, please import `BuilderPluginAPI` from `@modern-js/builder-webpack-provider`.
+When developing plugins for webpack-provider, please import `BuilderPluginAPI` from `@modern-js/builder-webpack-provider`.
 
 ```ts
 import type { BuilderPlugin } from '@modern-js/builder';
@@ -63,9 +63,9 @@ export default (): BuilderPlugin<BuilderPluginAPI> => ({
 });
 ```
 
-### Plugins for rspack provider
+### Plugins for rspack-provider
 
-When developing plugins for rspack provider, please import `BuilderPluginAPI` from `@modern-js/builder-rspack-provider`.
+When developing plugins for rspack-provider, please import `BuilderPluginAPI` from `@modern-js/builder-rspack-provider`.
 
 ```ts
 import type { BuilderPlugin } from '@modern-js/builder';

--- a/packages/builder/builder-doc/docs/en/api/plugin-hooks.mdx
+++ b/packages/builder/builder-doc/docs/en/api/plugin-hooks.mdx
@@ -71,7 +71,7 @@ export default () => ({
 
 ### modifyWebpackChain
 
-Modify the webpack config through the webpack chain. This method is only called when using webpack provider.
+Modify the webpack config through the webpack chain. This method is only called when using webpack-provider.
 
 - **Type**
 
@@ -112,7 +112,7 @@ export default () => ({
 
 ### modifyWebpackConfig
 
-To modify the final webpack config object, you can directly modify the config object, or return a new object to replace the previous object. This method is only called when using webpack provider.
+To modify the final webpack config object, you can directly modify the config object, or return a new object to replace the previous object. This method is only called when using webpack-provider.
 
 This method is called later than the `modifyWebpackChain` hook.
 
@@ -163,7 +163,7 @@ export default () => ({
 
 ### modifyRspackConfig
 
-To modify the final Rspack config object, you can directly modify the config object, or return a new object to replace the previous object. This method is only called when using rspack provider.
+To modify the final rspack config object, you can directly modify the config object, or return a new object to replace the previous object. This method is only called when using rspack-provider.
 
 - **Type**
 

--- a/packages/builder/builder-doc/docs/en/config/output/externals.md
+++ b/packages/builder/builder-doc/docs/en/config/output/externals.md
@@ -7,7 +7,7 @@ At build time, prevent some `import` dependencies from being packed into bundles
 For more information, please see: [webpack Externals](https://webpack.js.org/configuration/externals/)
 
 :::tip
-When using Rspack as Bundler, only the `Record<string, string>` type is supported.
+When using rspack as Bundler, only the `Record<string, string>` type is supported.
 :::
 
 ### Example

--- a/packages/builder/builder-doc/docs/en/config/output/externals.md
+++ b/packages/builder/builder-doc/docs/en/config/output/externals.md
@@ -7,7 +7,7 @@ At build time, prevent some `import` dependencies from being packed into bundles
 For more information, please see: [webpack Externals](https://webpack.js.org/configuration/externals/)
 
 :::tip
-When using rspack as Bundler, only the `Record<string, string>` type is supported.
+When using rspack as the bundler, only the `Record<string, string>` type is supported.
 :::
 
 ### Example

--- a/packages/builder/builder-doc/docs/en/config/performance/chunkSplit.md
+++ b/packages/builder/builder-doc/docs/en/config/performance/chunkSplit.md
@@ -56,7 +56,7 @@ Builder use `split-by-experience` strategy by default, in which the following np
 If you want to use other splitting strategies, you can specify it via `performance.chunkSplit.strategy`.
 
 :::tip
-The `split-by-module` policy is not supported when using Rspack as Bundler.
+The `split-by-module` policy is not supported when using rspack as Bundler.
 :::
 
 ### chunkSplit.minSize

--- a/packages/builder/builder-doc/docs/en/config/performance/chunkSplit.md
+++ b/packages/builder/builder-doc/docs/en/config/performance/chunkSplit.md
@@ -56,7 +56,7 @@ Builder use `split-by-experience` strategy by default, in which the following np
 If you want to use other splitting strategies, you can specify it via `performance.chunkSplit.strategy`.
 
 :::tip
-The `split-by-module` policy is not supported when using rspack as Bundler.
+The `split-by-module` policy is not supported when using rspack as the bundler.
 :::
 
 ### chunkSplit.minSize

--- a/packages/builder/builder-doc/docs/en/config/source/alias.md
+++ b/packages/builder/builder-doc/docs/en/config/source/alias.md
@@ -8,7 +8,7 @@ For TypeScript projects, you only need to configure [compilerOptions.paths](http
 :::
 
 :::tip
-When using Rspack as Bundler, only the `Record<string, string> | Function` type is supported.
+When using rspack as Bundler, only the `Record<string, string> | Function` type is supported.
 :::
 
 #### Object Type

--- a/packages/builder/builder-doc/docs/en/config/source/alias.md
+++ b/packages/builder/builder-doc/docs/en/config/source/alias.md
@@ -8,7 +8,7 @@ For TypeScript projects, you only need to configure [compilerOptions.paths](http
 :::
 
 :::tip
-When using rspack as Bundler, only the `Record<string, string> | Function` type is supported.
+When using rspack as the bundler, only the `Record<string, string> | Function` type is supported.
 :::
 
 #### Object Type

--- a/packages/builder/builder-doc/docs/en/config/source/define.md
+++ b/packages/builder/builder-doc/docs/en/config/source/define.md
@@ -13,7 +13,7 @@ Each key passed into options is an identifier or multiple identifiers joined wit
 For more information please visit [https://webpack.js.org/plugins/define-plugin/](https://webpack.js.org/plugins/define-plugin/).
 
 :::tip
-When using rspack as Bundler, only the `Record<string, string>` type is supported.
+When using rspack as the bundler, only the `Record<string, string>` type is supported.
 :::
 
 ### Example

--- a/packages/builder/builder-doc/docs/en/config/source/define.md
+++ b/packages/builder/builder-doc/docs/en/config/source/define.md
@@ -13,7 +13,7 @@ Each key passed into options is an identifier or multiple identifiers joined wit
 For more information please visit [https://webpack.js.org/plugins/define-plugin/](https://webpack.js.org/plugins/define-plugin/).
 
 :::tip
-When using Rspack as Bundler, only the `Record<string, string>` type is supported.
+When using rspack as Bundler, only the `Record<string, string>` type is supported.
 :::
 
 ### Example

--- a/packages/builder/builder-doc/docs/en/config/tools/rspack.md
+++ b/packages/builder/builder-doc/docs/en/config/tools/rspack.md
@@ -6,7 +6,7 @@
 
 ### Object Type
 
-You can configure it as an object, which will be merged with the original Rspack configuration through [webpack-merge](https://github.com/survivejs/webpack-merge). For example:
+You can configure it as an object, which will be merged with the original rspack configuration through [webpack-merge](https://github.com/survivejs/webpack-merge). For example:
 
 ```js
 export default {
@@ -24,7 +24,7 @@ export default {
 
 ### Function Type
 
-You can also configure it as a function, which accepts one parameter, the original Rspack configuration, you can modify this configuration, and then return a new configuration. For example:
+You can also configure it as a function, which accepts one parameter, the original rspack configuration, you can modify this configuration, and then return a new configuration. For example:
 
 ```js
 export default {
@@ -174,7 +174,7 @@ export default {
 
 - **Type:** `(plugins: RspackPluginInstance | RspackPluginInstance[]) => void`
 
-Add additional plugins to the head of the internal Rspack plugins array, and the plugin will be executed first.
+Add additional plugins to the head of the internal rspack plugins array, and the plugin will be executed first.
 
 ```ts
 export default {
@@ -196,7 +196,7 @@ export default {
 
 - **Type:** `(plugins: RspackPluginInstance | RspackPluginInstance[]) => void`
 
-Add additional plugins at the end of the internal Rspack plugins array, the plugin will be executed last.
+Add additional plugins at the end of the internal rspack plugins array, the plugin will be executed last.
 
 ```ts
 export default {
@@ -218,7 +218,7 @@ export default {
 
 - **Type:** `(name: string) => void`
 
-Remove the internal Rspack plugin, the parameter is the `constructor.name` of the plugin.
+Remove the internal rspack plugin, the parameter is the `constructor.name` of the plugin.
 
 For example, remove the internal [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer):
 
@@ -236,7 +236,7 @@ export default {
 
 - **Type:** `(...configs: RspackConfig[]) => RspackConfig`
 
-Used to merge multiple Rspack configs, same as [webpack-merge](https://github.com/survivejs/webpack-merge)。
+Used to merge multiple rspack configs, same as [webpack-merge](https://github.com/survivejs/webpack-merge)。
 
 ```ts
 export default {

--- a/packages/builder/builder-doc/docs/en/guide/advanced/rspack-start.mdx
+++ b/packages/builder/builder-doc/docs/en/guide/advanced/rspack-start.mdx
@@ -1,18 +1,18 @@
 # Rspack Start
 
-[Rspack](https://www.rspack.org/) is a Rust bundler developed by ByteDance Web Infra team, with core architecture aligned with webpack's implementation. Currently, Rspack Provider has adapted and validated most of the configuration capabilities in Builder.
+[Rspack](https://www.rspack.org/) is a Rust bundler developed by ByteDance Web Infra team, with core architecture aligned with webpack's implementation. Currently, rspack-provider has adapted and validated most of the configuration capabilities in Builder.
 
-Switching to Rspack as the bundler can provide a faster compilation speed.
+Switching to rspack as the bundler can provide a faster compilation speed.
 
 ## Enable Rspack
 
 ### Enable in Modern.js framework
 
-We recommend enabling Rspack as the bundler for Modern.js framework through the [Modern.js generator](https://modernjs.dev/en/apis/app/commands/new.html#enable-features) if you prefer it over the default Webpack bundler.
+We recommend enabling rspack as the bundler for Modern.js framework through the [Modern.js generator](https://modernjs.dev/en/apis/app/commands/new.html#enable-features) if you prefer it over the default Webpack bundler.
 
 Of course, you can also access it manually by following the steps below:
 
-1. Install Rspack Provider（The version needs to be the same as the modern.js version).
+1. Install rspack-provider（The version needs to be the same as the modern.js version).
 
 ```
 pnpm add @modern-js/builder-rspack-provider@2.4.0 -D
@@ -42,7 +42,7 @@ export default defineConfig<'rspack'>({
 
 ### Use Builder in a front-end framework
 
-Integrating Rspack Provider into a frontend framework is similar to integrating Webpack Provider. You only need to change the dependency from `@modern-js/builder-webpack-provider` to `@modern-js/builder-rspack-provider`.
+Integrating rspack-provider into a frontend framework is similar to integrating webpack-provider. You only need to change the dependency from `@modern-js/builder-webpack-provider` to `@modern-js/builder-rspack-provider`.
 
 ```ts title=modern.config.ts
 import { createBuilder } from '@modern-js/builder';
@@ -64,7 +64,7 @@ Builder aims to eliminate the main differences between different bundlers and he
 Currently, most of configuration options in Builder have been adapted for Rspack.
 Throughout this process, Builder's work includes but is not limited to:
 - Validating and encapsulating webpack plugins such as `@svgr/webpack` and `webpack-bundle-analyzer`;
-- Encapsulating Rspack built-in features such as `css` and `minify`.
+- Encapsulating rspack built-in features such as `css` and `minify`.
 
 #### Source Config
 
@@ -151,9 +151,9 @@ Unsupported configurations and capabilities include:
 In addition to the above configurations, some of the supported configurations may have differences in their capabilities. For specific differences in configurations, please refer to the corresponding API for each configuration.
 :::
 
-### Modify the Rspack configuration object
+### Modify the Rspack Configuration Object
 
-You can use [tools.rspack](/api/config-tools.html#toolsrspack) to modify the Rspack configuration object.
+You can use [tools.rspack](/api/config-tools.html#toolsrspack) to modify the rspack configuration object.
 
 ```ts
 export default {

--- a/packages/builder/builder-doc/docs/en/guide/basic/wasm-assets.md
+++ b/packages/builder/builder-doc/docs/en/guide/basic/wasm-assets.md
@@ -3,7 +3,7 @@
 Builder supports import WebAssembly assets in code.
 
 :::tip
-If you are using Rspack as the bundler, import Wasm assets is not supported yet.
+If you are using rspack as the bundler, import Wasm assets is not supported yet.
 :::
 
 ## Import

--- a/packages/builder/builder-doc/docs/en/guide/glossary.mdx
+++ b/packages/builder/builder-doc/docs/en/guide/glossary.mdx
@@ -8,7 +8,7 @@ The main goal of bundlers is to bundle JavaScript, CSS and other files together,
 
 ## Rspack
 
-A Rust Bundler developed by the ByteDance Web Infra team. The core architecture of Rspack is aligned with the implementation of webpack, and provides out-of-the-box support for commonly used build features. In the long run, Rspack will align the main APIs of webpack and be compatible with the mainstream webpack loaders and plugins to ensure that developers can smoothly migrate from webpack to Rspack.
+A Rust Bundler developed by the ByteDance Web Infra team. The core architecture of rspack is aligned with the implementation of webpack, and provides out-of-the-box support for commonly used build features. In the long run, rspack will align the main APIs of webpack and be compatible with the mainstream webpack loaders and plugins to ensure that developers can smoothly migrate from webpack to Rspack.
 
 Rspack optimizes compilation performance by:
 

--- a/packages/builder/builder-doc/docs/en/guide/introduction.mdx
+++ b/packages/builder/builder-doc/docs/en/guide/introduction.mdx
@@ -38,9 +38,9 @@ Currently, the following front-end frameworks are already using Builder:
 
 By default, Builder uses webpack 5 as the bundler. Although the compilation speed of webpack is not ideal, it is still the most mature and ecological bundler in the community. Based on webpack, Builder integrates [babel](https://github.com/babel/babel), [postcss](https://github.com/postcss/postcss), [terser](https://github.com/terser/terser) and other tools to transform or minify codes. Builder also supports replacing some compile tools with native tools to improve compilation speed, such as replacing babel/terser with [swc](https://github.com/swc-project/swc) or [esbuild](https://github.com/evanw/esbuild).
 
-At the same time, We are integrating Rspack to improve compilation speed, Rspack is a Rust Bundler developed by ByteDance.
+At the same time, We are integrating rspack to improve compilation speed, rspack is a Rust Bundler developed by ByteDance.
 
-At present, the webpack provider is stable for production, and the Rspack provider is still under development.
+Builder also supports switching to **the fast Rust-based web bundler —— rspack**. Rspack is implemented based on Rust, and the build speed is extremely fast. The configuration and plugin contracts of rspack are designed to interoperate with the webpack ecosystem. For details, see [Rspack Start](builder/guide/advanced/rspack-start).
 
 ### Deep optimization
 
@@ -67,7 +67,7 @@ Below is the npm package published by Builder.
 | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- | --------------------------------- |
 | [@modern-js/builder](https://www.npmjs.com/package/@modern-js/builder)                                             | ![](https://img.shields.io/npm/v/@modern-js/builder?style=flat-square)                       | Core package of Builder           |
 | [@modern-js/builder-webpack-provider](https://www.npmjs.com/package/@modern-js/builder-webpack-provider)           | ![](https://img.shields.io/npm/v/@modern-js/builder-webpack-provider?style=flat-square)      | Provides webpack build ability    |
-| [@modern-js/builder-rspack-provider](https://www.npmjs.com/package/@modern-js/builder-rspack-provider)             | ![](https://img.shields.io/npm/v/@modern-js/builder-rspack-provider?style=flat-square)       | Provides Rspack build ability     |
+| [@modern-js/builder-rspack-provider](https://www.npmjs.com/package/@modern-js/builder-rspack-provider)             | ![](https://img.shields.io/npm/v/@modern-js/builder-rspack-provider?style=flat-square)       | Provides rspack build ability     |
 | [@modern-js/builder-plugin-swc](https://www.npmjs.com/package/@modern-js/builder-plugin-swc)                       | ![](https://img.shields.io/npm/v/@modern-js/builder-plugin-swc?style=flat-square)            | SWC Plugin                        |
 | [@modern-js/builder-plugin-stylus](https://www.npmjs.com/package/@modern-js/builder-plugin-stylus)                 | ![](https://img.shields.io/npm/v/@modern-js/builder-plugin-stylus?style=flat-square)         | Stylus Plugin                     |
 | [@modern-js/builder-plugin-esbuild](https://www.npmjs.com/package/@modern-js/builder-plugin-esbuild)               | ![](https://img.shields.io/npm/v/@modern-js/builder-plugin-esbuild?style=flat-square)        | Esbuild Plugin                    |

--- a/packages/builder/builder-doc/docs/en/plugins/introduction.md
+++ b/packages/builder/builder-doc/docs/en/plugins/introduction.md
@@ -8,7 +8,7 @@ Developing plugins to change the Builder's behavior and introduce extra features
 - Modify and compile file modules.
 - Deploy your application.
 
-Builder can use webpack or rspack as bundler, expose unified Node.js API, and integrate into different frameworks. Users can painlessly switch between bundlers.
+Builder can use webpack or rspack as the bundler, expose unified Node.js API, and integrate into different frameworks. Users can painlessly switch between bundlers.
 
 ## Write a plugin
 

--- a/packages/builder/builder-doc/docs/en/plugins/introduction.md
+++ b/packages/builder/builder-doc/docs/en/plugins/introduction.md
@@ -8,7 +8,7 @@ Developing plugins to change the Builder's behavior and introduce extra features
 - Modify and compile file modules.
 - Deploy your application.
 
-Builder can use webpack or Rspack as bundler, expose unified Node.js API, and integrate into different frameworks. Users can painlessly switch between bundlers.
+Builder can use webpack or rspack as bundler, expose unified Node.js API, and integrate into different frameworks. Users can painlessly switch between bundlers.
 
 ## Write a plugin
 

--- a/packages/builder/builder-doc/docs/zh/api/builder-core.mdx
+++ b/packages/builder/builder-doc/docs/zh/api/builder-core.mdx
@@ -12,7 +12,7 @@ extractApiHeaders: [2]
 
 使用该方法时，需要搭配 `@modern-js/builder-webpack-provider` 或 `@modern-js/builder-rspack-provider` 使用，Provider 基于特定 bundler 实现了对应的构建能力。
 
-### Webpack Provider
+### builderWebpackProvider
 
 当传入 `builderWebpackProvider` 时，Builder 会使用 webpack 作为 bundler 进行构建。
 
@@ -31,9 +31,9 @@ const builder = await createBuilder(provider, {
 });
 ```
 
-### Rspack Provider
+### builderWebpackProvider
 
-当传入 `builderRspackProvider` 时，Builder 会使用 Rspack 作为 bundler 进行构建。
+当传入 `builderRspackProvider` 时，Builder 会使用 rspack 作为 bundler 进行构建。
 
 ```ts
 import { createBuilder } from '@modern-js/builder';

--- a/packages/builder/builder-doc/docs/zh/api/plugin-core.mdx
+++ b/packages/builder/builder-doc/docs/zh/api/plugin-core.mdx
@@ -42,11 +42,11 @@ export default (): BuilderPlugin => ({
 
 关于生命周期钩子的完整介绍，请阅读 [Plugin Hooks](/api/plugin-hooks.html) 章节。
 
-在使用 webpack provider 或 rspack provider 时，`BuilderPluginAPI` 的类型定义有一定不同，你可以根据插件的使用场景来引入对应的类型。
+在使用 webpack-provider 或 rspack-provider 时，`BuilderPluginAPI` 的类型定义有一定不同，你可以根据插件的使用场景来引入对应的类型。
 
-### 适用于 webpack provider 的插件
+### 适用于 webpack-provider 的插件
 
-开发适用于 webpack provider 的插件时，请从 `@modern-js/builder-webpack-provider` 中引入 `BuilderPluginAPI`。
+开发适用于 webpack-provider 的插件时，请从 `@modern-js/builder-webpack-provider` 中引入 `BuilderPluginAPI`。
 
 ```ts
 import type { BuilderPlugin } from '@modern-js/builder';
@@ -63,9 +63,9 @@ export default (): BuilderPlugin<BuilderPluginAPI> => ({
 });
 ```
 
-### 适用于 rspack provider 的插件
+### 适用于 rspack-provider 的插件
 
-开发适用于 rspack provider 的插件时，请从 `@modern-js/builder-rspack-provider` 中引入 `BuilderPluginAPI`。
+开发适用于 rspack-provider 的插件时，请从 `@modern-js/builder-rspack-provider` 中引入 `BuilderPluginAPI`。
 
 ```ts
 import type { BuilderPlugin } from '@modern-js/builder';

--- a/packages/builder/builder-doc/docs/zh/api/plugin-hooks.mdx
+++ b/packages/builder/builder-doc/docs/zh/api/plugin-hooks.mdx
@@ -13,7 +13,7 @@ extractApiHeaders: [2]
 - `modifyBuilderConfig`：修改传递给 Builder 的配置项。
 - `modifyWebpackChain`：修改 webpack chain 配置。
 - `modifyWebpackConfig`：修改最终的 webpack 配置对象。
-- `modifyRspackConfig`：修改最终的 Rspack 配置对象。
+- `modifyRspackConfig`：修改最终的 rspack 配置对象。
 - `onBeforeCreateCompiler`：在创建 compiler 实例前调用。
 - `onAfterCreateCompiler`：在创建 compiler 实例后、执行构建前调用。
 
@@ -71,7 +71,7 @@ export default () => ({
 
 ### modifyWebpackChain
 
-通过 webpack chain 来修改 webpack 配置。该方法仅在使用 webpack provider 时调用。
+通过 webpack chain 来修改 webpack 配置。该方法仅在使用 webpack-provider 时调用。
 
 - **类型**
 
@@ -112,7 +112,7 @@ export default () => ({
 
 ### modifyWebpackConfig
 
-修改最终的 webpack 配置对象，你可以直接修改传入的 config 对象，也可以返回一个新的对象来替换传入的对象。该方法仅在使用 webpack provider 时调用。
+修改最终的 webpack 配置对象，你可以直接修改传入的 config 对象，也可以返回一个新的对象来替换传入的对象。该方法仅在使用 webpack-provider 时调用。
 
 该方法的调用时机晚于 `modifyWebpackChain` 钩子。
 
@@ -163,7 +163,7 @@ export default () => ({
 
 ### modifyRspackConfig
 
-修改最终的 Rspack 配置对象，你可以直接修改传入的 config 对象，也可以返回一个新的对象来替换传入的对象。该方法仅在使用 rspack provider 时调用。
+修改最终的 rspack 配置对象，你可以直接修改传入的 config 对象，也可以返回一个新的对象来替换传入的对象。该方法仅在使用 rspack-provider 时调用。
 
 - **类型**
 

--- a/packages/builder/builder-doc/docs/zh/config/output/externals.md
+++ b/packages/builder/builder-doc/docs/zh/config/output/externals.md
@@ -6,7 +6,7 @@
 详情请见: [webpack 外部扩展 (Externals)](https://webpack.docschina.org/configuration/externals/)
 
 :::tip
-在使用 Rspack 作为打包工具时，只支持 `Record<string, string>` 类型。
+在使用 rspack 作为打包工具时，只支持 `Record<string, string>` 类型。
 :::
 
 ### 示例

--- a/packages/builder/builder-doc/docs/zh/config/performance/chunkSplit.md
+++ b/packages/builder/builder-doc/docs/zh/config/performance/chunkSplit.md
@@ -56,7 +56,7 @@ Builder 默认采用 `split-by-experience` 策略，具体来说，以下的 NPM
 如果你想使用其他拆包策略，可以通过 `performance.chunkSplit.strategy` 配置项来指定。
 
 :::tip
-在使用 Rspack 作为打包工具时，不支持采用 `split-by-module` 策略。
+在使用 rspack 作为打包工具时，不支持采用 `split-by-module` 策略。
 :::
 
 ### chunkSplit.minSize

--- a/packages/builder/builder-doc/docs/zh/config/source/alias.md
+++ b/packages/builder/builder-doc/docs/zh/config/source/alias.md
@@ -8,7 +8,7 @@
 :::
 
 :::tip
-在使用 Rspack 作为打包工具时，只支持 `Record<string, string> | Function` 类型。
+在使用 rspack 作为打包工具时，只支持 `Record<string, string> | Function` 类型。
 :::
 
 #### Object 类型

--- a/packages/builder/builder-doc/docs/zh/config/source/define.md
+++ b/packages/builder/builder-doc/docs/zh/config/source/define.md
@@ -13,7 +13,7 @@
 更多细节参考 [https://webpack.js.org/plugins/define-plugin/](https://webpack.js.org/plugins/define-plugin/)。
 
 :::tip
-在使用 Rspack 作为打包工具时，只支持 `Record<string, string>` 类型。
+在使用 rspack 作为打包工具时，只支持 `Record<string, string>` 类型。
 :::
 
 ### 示例

--- a/packages/builder/builder-doc/docs/zh/config/tools/rspack.md
+++ b/packages/builder/builder-doc/docs/zh/config/tools/rspack.md
@@ -6,7 +6,7 @@
 
 ### Object 类型
 
-你可以配置为一个对象，这个对象将会和原始的 Rspack 配置通过 [webpack-merge](https://github.com/survivejs/webpack-merge) 进行合并。比如：
+你可以配置为一个对象，这个对象将会和原始的 rspack 配置通过 [webpack-merge](https://github.com/survivejs/webpack-merge) 进行合并。比如：
 
 ```js
 export default {
@@ -24,7 +24,7 @@ export default {
 
 ### Function 类型
 
-你也可以配置为一个函数，这个函数接收一个参数，即原始的 Rspack 配置，你可以对这个配置进行修改，然后返回一个新的配置。比如：
+你也可以配置为一个函数，这个函数接收一个参数，即原始的 rspack 配置，你可以对这个配置进行修改，然后返回一个新的配置。比如：
 
 ```js
 export default {
@@ -174,7 +174,7 @@ export default {
 
 - **类型：** `(plugins: RspackPluginInstance | RspackPluginInstance[]) => void`
 
-在内部 Rspack 插件数组头部添加额外的插件，数组头部的插件会优先执行。
+在内部 rspack 插件数组头部添加额外的插件，数组头部的插件会优先执行。
 
 ```ts
 export default {
@@ -196,7 +196,7 @@ export default {
 
 - **类型：** `(plugins: RspackPluginInstance | RspackPluginInstance[]) => void`
 
-在内部 Rspack 插件数组尾部添加额外的插件，数组尾部的插件会在最后执行。
+在内部 rspack 插件数组尾部添加额外的插件，数组尾部的插件会在最后执行。
 
 ```ts
 export default {
@@ -218,7 +218,7 @@ export default {
 
 - **类型：** `(name: string) => void`
 
-删除内部的 Rspack 插件，参数为该插件的 `constructor.name`。
+删除内部的 rspack 插件，参数为该插件的 `constructor.name`。
 
 例如，删除内部的 [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer)：
 
@@ -236,7 +236,7 @@ export default {
 
 - **类型：** `(...configs: RspackConfig[]) => RspackConfig`
 
-用于合并多份 Rspack 配置，等价于 [webpack-merge](https://github.com/survivejs/webpack-merge)。
+用于合并多份 rspack 配置，等价于 [webpack-merge](https://github.com/survivejs/webpack-merge)。
 
 ```ts
 export default {

--- a/packages/builder/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
+++ b/packages/builder/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
@@ -1,6 +1,6 @@
 # 使用 Rspack
 
-[Rspack](https://www.rspack.org/) 是字节跳动 Web Infra 团队自研的 Rust Bundler，核心架构对齐 webpack 实现。目前 Rspack Provider 已适配并验证了 Builder 内大部分配置能力。
+[Rspack](https://www.rspack.org/) 是字节跳动 Web Infra 团队自研的 Rust Bundler，核心架构对齐 webpack 实现。目前 rspack-provider 已适配并验证了 Builder 内大部分配置能力。
 
 通过将打包工具切换成 Rspack，可体验更快的编译速度。
 
@@ -8,11 +8,11 @@
 
 ### 在 Modern.js 框架中启用
 
-Modern.js 框架默认使用 Webpack 作为打包工具。如果希望启用 Rspack 作为打包工具，我们推荐通过 [Modern.js 生成器](https://modernjs.dev/apis/app/commands/new.html#启用可选功能) 方式启用。
+Modern.js 框架默认使用 Webpack 作为打包工具。如果希望启用 rspack 作为打包工具，我们推荐通过 [Modern.js 生成器](https://modernjs.dev/apis/app/commands/new.html#启用可选功能) 方式启用。
 
 当然，你也可以通过下面的步骤来手动接入:
 
-1. 安装 Rspack Provider（版本号需要与 modern.js 版本号保持一致）。
+1. 安装 rspack-provider（版本号需要与 modern.js 版本号保持一致）。
 
 ```
 pnpm add @modern-js/builder-rspack-provider@2.4.0 -D
@@ -42,7 +42,7 @@ export default defineConfig<'rspack'>({
 
 ### 在前端框架中接入
 
-在前端框架中接入 Rspack Provider 和 [接入 Webpack Provider](/guide/quick-start.html#在前端框架中接入) 方式类似，只需要把依赖从 `@modern-js/builder-webpack-provider` 改为 `@modern-js/builder-rspack-provider` 即可。
+在前端框架中接入 rspack-provider 和 [接入 webpack-provider](/guide/quick-start.html#在前端框架中接入) 方式类似，只需要把依赖从 `@modern-js/builder-webpack-provider` 改为 `@modern-js/builder-rspack-provider` 即可。
 
 ```ts title=modern.config.ts
 import { createBuilder } from '@modern-js/builder';
@@ -64,7 +64,7 @@ Builder 旨在消除不同打包工具之间的主要差异，帮助用户以较
 目前，Builder 内大部分的配置项已经适配了 Rspack。Builder 所做的工作包括不限于：
 
 - 对 webpack 插件进行验证及封装。如 @svgr/webpack、webpack-bundle-analyzer 等;
-- 对 Rspack 内置能力进行封装，如 css、minify 等;
+- 对 rspack 内置能力进行封装，如 css、minify 等;
 
 #### Source Config
 
@@ -78,19 +78,19 @@ Builder 旨在消除不同打包工具之间的主要差异，帮助用户以较
 
 > Builder 中与 HTML 有关的配置。
 
-所有 html 下的配置项及能力在 Rspack 内均可使用。
+所有 html 下的配置项及能力在 rspack 内均可使用。
 
 #### Security Config
 
 > Builder 中与安全有关的配置。
 
-所有 security 下的配置项及能力均不支持在 Rspack 内使用。
+所有 security 下的配置项及能力均不支持在 rspack 内使用。
 
 #### Dev Config
 
 > Builder 中与本地开发有关的配置。
 
-所有 dev 下的配置项及能力在 Rspack 内均可使用。
+所有 dev 下的配置项及能力在 rspack 内均可使用。
 
 #### Output Config
 
@@ -115,7 +115,7 @@ Builder 旨在消除不同打包工具之间的主要差异，帮助用户以较
 
 > Builder 中的一些实验性配置。
 
-所有 experiments 下的配置项及能力均不支持在 Rspack 内使用。
+所有 experiments 下的配置项及能力均不支持在 rspack 内使用。
 
 #### Performance Config
 
@@ -151,9 +151,9 @@ Builder 旨在消除不同打包工具之间的主要差异，帮助用户以较
 除上述配置外，一些已支持的配置可能存在能力差异，请参考各配置 API 获取具体差异信息。
 :::
 
-### 修改 Rspack 配置
+### 修改 rspack 配置
 
-你可以使用 [tools.rspack](/api/config-tools.html#toolsrspack) 来修改 Rspack 配置对象，对 Rspack 配置进行更灵活的操作。
+你可以使用 [tools.rspack](/api/config-tools.html#toolsrspack) 来修改 rspack 配置对象，对 rspack 配置进行更灵活的操作。
 
 ```ts
 export default {
@@ -168,4 +168,4 @@ export default {
 };
 ```
 
-关于 Rspack 的详细配置信息，请参考 [Rspack 官网](https://www.rspack.org/)。
+关于 rspack 的详细配置信息，请参考 [rspack 官网](https://rspack.org/)。

--- a/packages/builder/builder-doc/docs/zh/guide/basic/wasm-assets.md
+++ b/packages/builder/builder-doc/docs/zh/guide/basic/wasm-assets.md
@@ -3,7 +3,7 @@
 Builder 支持在代码引用 WebAssembly 资源。
 
 :::tip
-在使用 Rspack 作为打包工具时，暂时不支持引用 Wasm 资源。
+在使用 rspack 作为打包工具时，暂时不支持引用 Wasm 资源。
 :::
 
 ## 引用方式

--- a/packages/builder/builder-doc/docs/zh/guide/glossary.mdx
+++ b/packages/builder/builder-doc/docs/zh/guide/glossary.mdx
@@ -39,7 +39,7 @@ Builder Provider 是 Builder 的组成部分之一，Provider 基于特定 bundl
 目前 Builder 提供了两个 Provider：
 
 - `@modern-js/builder-webpack-provider`：底层基于 webpack 来实现。
-- `@modern-js/builder-rspack-provider`：底层基于 Rspack 来实现。
+- `@modern-js/builder-rspack-provider`：底层基于 rspack 来实现。
 
 ## {MODERN_JS}
 

--- a/packages/builder/builder-doc/docs/zh/guide/introduction.mdx
+++ b/packages/builder/builder-doc/docs/zh/guide/introduction.mdx
@@ -38,9 +38,7 @@ Modern.js Builder (简称 Builder) 的定位是**服务于上层框架的构建�
 
 默认情况下，Builder 使用 webpack 5 作为打包工具，尽管 webpack 的编译速度不是很理想，但它依然是社区中功能最完整、生态最丰富的打包工具。Builder 在 webpack 的基础上，集成了 [babel](https://github.com/babel/babel)、[postcss](https://github.com/postcss/postcss)、[terser](https://github.com/terser/terser) 等工具进行代码转义和压缩。Builder 也支持替换部分编译能力为原生工具来提升编译速度，比如将 babel/terser 替换为 [swc](https://github.com/swc-project/swc) 或 [esbuild](https://github.com/evanw/esbuild)。
 
-除了 webpack 打包，Builder 也正在对接**字节跳动 Web Infra 团队自研的 Rust Bundler —— Rspack**，以提供更快的编译速度。
-
-目前，Builder 基于 webpack 的构建已经成熟可用，基于 Rspack 的构建仍在开发过程中，敬请期待。
+除了 webpack 打包，Builder 也支持一键切换到**基于 Rust 的高性能打包工具 —— rspack**。Rspack 基于 Rust 实现，构建速度极快，同时对 webpack 生态有很好的兼容性，详见 [使用 Rspack](builder/guide/advanced/rspack-start)。
 
 ### 深度优化构建产物
 
@@ -67,7 +65,7 @@ Builder 已发布的 npm 包有：
 | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- | ---------------------- |
 | [@modern-js/builder](https://www.npmjs.com/package/@modern-js/builder)                                             | ![](https://img.shields.io/npm/v/@modern-js/builder?style=flat-square)                       | Builder 核心包         |
 | [@modern-js/builder-webpack-provider](https://www.npmjs.com/package/@modern-js/builder-webpack-provider)           | ![](https://img.shields.io/npm/v/@modern-js/builder-webpack-provider?style=flat-square)      | 提供 webpack 构建能力  |
-| [@modern-js/builder-rspack-provider](https://www.npmjs.com/package/@modern-js/builder-rspack-provider)             | ![](https://img.shields.io/npm/v/@modern-js/builder-rspack-provider?style=flat-square)       | 提供 Rspack 构建能力   |
+| [@modern-js/builder-rspack-provider](https://www.npmjs.com/package/@modern-js/builder-rspack-provider)             | ![](https://img.shields.io/npm/v/@modern-js/builder-rspack-provider?style=flat-square)       | 提供 rspack 构建能力   |
 | [@modern-js/builder-plugin-swc](https://www.npmjs.com/package/@modern-js/builder-plugin-swc)                       | ![](https://img.shields.io/npm/v/@modern-js/builder-plugin-swc?style=flat-square)            | SWC 插件               |
 | [@modern-js/builder-plugin-stylus](https://www.npmjs.com/package/@modern-js/builder-plugin-stylus)                 | ![](https://img.shields.io/npm/v/@modern-js/builder-plugin-stylus?style=flat-square)         | Stylus 插件            |
 | [@modern-js/builder-plugin-esbuild](https://www.npmjs.com/package/@modern-js/builder-plugin-esbuild)               | ![](https://img.shields.io/npm/v/@modern-js/builder-plugin-esbuild?style=flat-square)        | Esbuild 插件           |
@@ -96,5 +94,9 @@ import Step from '@components/Step';
     title="功能导航"
     description="了解 Builder 提供的所有功能"
   />
-  <Step href="/api/index.html" title="查阅 API" description="查看详细的 API 文档" />
+  <Step
+    href="/api/index.html"
+    title="查阅 API"
+    description="查看详细的 API 文档"
+  />
 </NextSteps>

--- a/packages/builder/builder-doc/docs/zh/plugins/introduction.md
+++ b/packages/builder/builder-doc/docs/zh/plugins/introduction.md
@@ -8,7 +8,7 @@ Builder 提供了一套轻量强大的插件系统，用以实现自身的大多
 - 修改或编译文件
 - 部署产物
 
-Builder 底层支持 webpack 和 Rspack 等 bundler，并提供统一的 Node.js API 来抹平插件开发的差异，进而接入不同的上层框架、降低用户对底层 bundler 切换的感知。
+Builder 底层支持 webpack 和 rspack 等 bundler，并提供统一的 Node.js API 来抹平插件开发的差异，进而接入不同的上层框架、降低用户对底层 bundler 切换的感知。
 
 ## 开发插件
 

--- a/packages/builder/builder-rspack-provider/src/types/config/index.ts
+++ b/packages/builder/builder-rspack-provider/src/types/config/index.ts
@@ -10,7 +10,7 @@ import type { NormalizedSecurityConfig, SecurityConfig } from './security';
 import type { NormalizedSourceConfig, SourceConfig } from './source';
 import type { NormalizedToolsConfig, ToolsConfig } from './tools';
 
-/** The Builder Config when using rspack provider */
+/** The Builder Config when using rspack-provider */
 export interface BuilderConfig {
   dev?: DevConfig;
   html?: HtmlConfig;

--- a/packages/builder/builder-webpack-provider/src/types/config/index.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/index.ts
@@ -14,7 +14,7 @@ import type { NormalizedSecurityConfig, SecurityConfig } from './security';
 import type { NormalizedSourceConfig, SourceConfig } from './source';
 import type { NormalizedToolsConfig, ToolsConfig } from './tools';
 
-/** The Builder Config when using webpack provider */
+/** The Builder Config when using webpack-provider */
 export interface BuilderConfig {
   dev?: DevConfig;
   html?: HtmlConfig;

--- a/packages/toolkit/main-doc/zh/guides/concept/builder.mdx
+++ b/packages/toolkit/main-doc/zh/guides/concept/builder.mdx
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 **Modern.js 的构建能力由 [Modern.js Builder](https://modernjs.dev/builder) 提供。**
 
-Modern.js Builder 是 Modern.js 体系的核心组件之一，它是一个面向 Web 开发场景的构建引擎，可以脱离 Modern.js 被独立使用。Modern.js Builder 同时支持 webpack 和 Rspack 等多种打包工具，默认情况下使用最成熟的 webpack 进行打包。
+Modern.js Builder 是 Modern.js 体系的核心组件之一，它是一个面向 Web 开发场景的构建引擎，可以脱离 Modern.js 被独立使用。Modern.js Builder 同时支持 webpack 和 rspack 等多种打包工具，默认情况下使用最成熟的 webpack 进行打包。
 
 ## 构建架构
 
@@ -14,7 +14,7 @@ Modern.js Builder 是 Modern.js 体系的核心组件之一，它是一个面向
 
 - 上层研发框架：Modern.js。
 - 通用构建引擎：Modern.js Builder。
-- 底层打包工具：webpack 和 Rspack。
+- 底层打包工具：webpack 和 rspack。
 
 <img src="https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/builder-layers-1117.png" style={{ maxWidth: '540px' }} />
 

--- a/website/main/src/i18n/en-US.ts
+++ b/website/main/src/i18n/en-US.ts
@@ -10,7 +10,7 @@ export const EN_US = {
   // Features
   features: 'Features',
   feature1: 'Rust Bundler',
-  featureDesc1: 'Easily switch to Rspack bundler with faster build speed.',
+  featureDesc1: 'Easily switch to rspack bundler with faster build speed.',
   feature2: 'Integrated BFF',
   featureDesc2:
     'Develop BFF code in the same project, enjoy simple function calls.',

--- a/website/main/src/i18n/zh-CN.ts
+++ b/website/main/src/i18n/zh-CN.ts
@@ -12,7 +12,7 @@ export const ZH_CN: Record<keyof typeof EN_US, string> = {
 
   // Features
   feature1: 'Rust 构建',
-  featureDesc1: '轻松切换到 Rspack 构建工具，编译飞快。',
+  featureDesc1: '轻松切换到 rspack 构建工具，编译飞快。',
   feature2: '一体化开发',
   featureDesc2: '在同一项目中完成 BFF 开发，享受简洁的函数调用。',
   feature3: '嵌套路由',


### PR DESCRIPTION
## Description

Correct rspack case, making it consistent with `webpack`.

- Rspack -> rspack (if not at the start of a sentence)
- Rspack Provider -> rspack-provider
- Webpack Provider -> webpack-provider

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [x] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
