### PR TITLE
hotfix(builder): make devServer.proxy schema check loosely

### DIFF
--- a/.changeset/silly-rice-retire.md
+++ b/.changeset/silly-rice-retire.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+hotfix(builder): make devServer.proxy schema check loosely
+
+hotfix(builder): devServer.proxy 类型检验采用非严格模式

--- a/packages/builder/builder-shared/src/schema/tools.ts
+++ b/packages/builder/builder-shared/src/schema/tools.ts
@@ -28,7 +28,7 @@ const sharedDevServerConfigSchema = z.partialObj({
   liveReload: z.boolean(),
   setupMiddlewares: z.array(z.function()),
   headers: z.record(z.string()),
-  proxy: z.record(z.union([z.string(), z.record(z.unknown())])),
+  proxy: z.record(z.unknown()),
   watch: z.boolean(),
 });
 


### PR DESCRIPTION
## Description

fix schema check error:
![img_v2_f42a62be-cfde-4379-a20c-e8c4e873406g](https://user-images.githubusercontent.com/22373761/220861470-b89a5805-6fcf-4704-86d7-aa14a3676c7d.jpg)

devServer.proxy type is too complex

https://modernjs.dev/configure/app/tools/dev-server.html#proxy

<!--- Describe your changes -->

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
