### PR TITLE
fix(plugin-swc): webpack magic comment is removed after compilation

### DIFF
--- a/.changeset/fluffy-birds-type.md
+++ b/.changeset/fluffy-birds-type.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-swc': patch
+---
+
+fix(plugin-swc): webpack magic comment is removed after compilation
+
+fix(plugin-swc): 修复 webpack magic comment 被错误移除的问题

--- a/packages/builder/plugin-swc/src/config.ts
+++ b/packages/builder/plugin-swc/src/config.ts
@@ -41,6 +41,9 @@ function getDefaultSwcConfig(): TransformConfig {
           runtime: 'automatic',
         },
       },
+      // Avoid the webpack magic comment to be removed
+      // https://github.com/swc-project/swc/issues/6403
+      preserveAllComments: true,
     },
     minify: false, // for loader, we don't need to minify, we do minification using plugin
     sourceMaps: true,

--- a/packages/builder/plugin-swc/tests/fixtures/compat/cjs-no-preserve-dyn-import/expected.js
+++ b/packages/builder/plugin-swc/tests/fixtures/compat/cjs-no-preserve-dyn-import/expected.js
@@ -5,5 +5,5 @@ require("core-js/modules/es.object.to-string.js");
 var a = require("foo");
 console.log(a);
 Promise.resolve().then(function() {
-    return /*#__PURE__*/ _interopRequireWildcard(require("other"));
-});
+    return _interopRequireWildcard(require("other"));
+}) /*#__PURE__*/ ;


### PR DESCRIPTION
## Description

Fix webpack magic comment is removed after compilation.

It can be fixed by adding the `preserveAllComments: true` config.

![image](https://user-images.githubusercontent.com/7237365/220879915-38e58f87-3d18-41c6-b109-ee713a446213.png)

## Related Issue

https://github.com/swc-project/swc/issues/6403

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
