### PR TITLE
fix(plugin-swc): runtime error when set dev.hmr to false

### DIFF
--- a/.changeset/twenty-monkeys-flow.md
+++ b/.changeset/twenty-monkeys-flow.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-swc': patch
+---
+
+fix(plugin-swc): runtime error when set dev.hmr to false
+
+fix(plugin-swc): 修复 dev.hmr 设置为 false 时出现运行时错误的问题

--- a/packages/builder/plugin-swc/src/loader.ts
+++ b/packages/builder/plugin-swc/src/loader.ts
@@ -46,8 +46,9 @@ function setReactDevMode(
     swc.jsc.transform.react = {};
   }
 
-  swc.jsc.transform.react.development = mode === 'development';
-  swc.jsc.transform.react.refresh = mode === 'development';
+  const { react } = swc.jsc.transform;
+  react.development = react.development ?? mode === 'development';
+  react.refresh = react.refresh ?? mode === 'development';
 }
 
 export function normalizeLoaderOption(

--- a/packages/builder/plugin-swc/src/plugin.ts
+++ b/packages/builder/plugin-swc/src/plugin.ts
@@ -39,7 +39,7 @@ export const builderPluginSwc = (
     const SWC_HELPERS_PATH = require.resolve('@swc/helpers/package.json');
 
     // Find if babel & ts loader exists
-    api.modifyWebpackChain(async (chain, { target, CHAIN_ID }) => {
+    api.modifyWebpackChain(async (chain, { env, target, CHAIN_ID }) => {
       const { isProd } = await import('@modern-js/utils');
       const { rootPath } = api.context;
 
@@ -50,14 +50,23 @@ export const builderPluginSwc = (
       determinePresetReact(rootPath, pluginConfig);
 
       const swc: TransformConfig = {
-        jsc: { transform: {} },
+        jsc: {
+          transform: {
+            react: {
+              refresh: env === 'development' && builderConfig.dev.hmr,
+            },
+          },
+        },
         env: pluginConfig.presetEnv || {},
         extensions: {},
         cwd: rootPath,
       };
 
       if (pluginConfig.presetReact) {
-        swc.jsc!.transform!.react = pluginConfig.presetReact;
+        swc.jsc!.transform!.react = {
+          ...swc.jsc!.transform!.react,
+          ...pluginConfig.presetReact,
+        };
       }
 
       const { polyfill } = builderConfig.output;

--- a/packages/builder/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/builder/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -43,6 +43,7 @@ exports[`plugins/swc > should apply source.include and source.exclude correctly 
               "jsc": {
                 "transform": {
                   "react": {
+                    "refresh": false,
                     "runtime": "classic",
                   },
                 },
@@ -81,6 +82,7 @@ exports[`plugins/swc > should apply source.include and source.exclude correctly 
               "jsc": {
                 "transform": {
                   "react": {
+                    "refresh": false,
                     "runtime": "classic",
                   },
                 },
@@ -91,6 +93,47 @@ exports[`plugins/swc > should apply source.include and source.exclude correctly 
       },
     ],
   },
+}
+`;
+
+exports[`plugins/swc > should disable react refresh when dev.hmr is false 1`] = `
+{
+  "rules": [
+    {
+      "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$\\|\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+      "use": [
+        {
+          "loader": "<ROOT>/src/loader",
+          "options": {
+            "cwd": "<ROOT>",
+            "env": {
+              "coreJs": "3.26",
+              "mode": "entry",
+              "targets": [
+                "> 0.01%",
+                "not dead",
+                "not op_mini all",
+              ],
+            },
+            "extensions": {
+              "lockCorejsVersion": {
+                "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+                "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+              },
+            },
+            "jsc": {
+              "transform": {
+                "react": {
+                  "refresh": false,
+                  "runtime": "classic",
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  ],
 }
 `;
 
@@ -146,6 +189,7 @@ exports[`plugins/swc > should set swc-loader 1`] = `
               "jsc": {
                 "transform": {
                   "react": {
+                    "refresh": false,
                     "runtime": "classic",
                   },
                 },
@@ -184,6 +228,7 @@ exports[`plugins/swc > should set swc-loader 1`] = `
               "jsc": {
                 "transform": {
                   "react": {
+                    "refresh": false,
                     "runtime": "classic",
                   },
                 },

--- a/packages/builder/plugin-swc/tests/plugin.test.ts
+++ b/packages/builder/plugin-swc/tests/plugin.test.ts
@@ -63,4 +63,20 @@ describe('plugins/swc', () => {
 
     expect(config).toMatchSnapshot();
   });
+
+  it('should disable react refresh when dev.hmr is false', async () => {
+    process.env.NODE_ENV = 'development';
+    const builder = await createStubBuilder({
+      plugins: [builderPluginSwc()],
+      builderConfig: {
+        dev: {
+          hmr: false,
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+    expect(config.module).toMatchSnapshot();
+
+    process.env.NODE_ENV = 'test';
+  });
 });


### PR DESCRIPTION
## Description

Fix runtime error when set `dev.hmr` to false.

We should disable `swc.jsc.transform.react.refresh` when `dev.hmr` is false.

<img width="578" alt="Screen Shot 2023-02-24 at 14 28 56" src="https://user-images.githubusercontent.com/7237365/221111452-07b5d425-f374-45a4-a2e1-982d2660fa02.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
