### PR TITLE
feat: support optional params in file-based route

### DIFF
--- a/.changeset/moody-pots-laugh.md
+++ b/.changeset/moody-pots-laugh.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+feat: support optional params in file-based route
+feat: 约定式路由支持可选参数

--- a/packages/solutions/app-tools/src/analyze/getClientRoutes/getRoutes.ts
+++ b/packages/solutions/app-tools/src/analyze/getClientRoutes/getRoutes.ts
@@ -91,7 +91,9 @@ const recursiveReadDir = ({
       const route: PageRoute = {
         path: `${basePath}${
           dynamicRouteMatched
-            ? `:${dynamicRouteMatched[1]}${dynamicRouteMatched[2]}`
+            ? `:${dynamicRouteMatched[1].replace(/\$$/, '?')}${
+                dynamicRouteMatched[2]
+              }`
             : filename
         }`,
         _component: alias,

--- a/packages/solutions/app-tools/src/analyze/getClientRoutes/getRoutesLegacy.ts
+++ b/packages/solutions/app-tools/src/analyze/getClientRoutes/getRoutesLegacy.ts
@@ -93,7 +93,9 @@ const recursiveReadDirLegacy = ({
       const route: RouteLegacy = {
         path: `${basePath}${
           dynamicRouteMatched
-            ? `:${dynamicRouteMatched[1]}${dynamicRouteMatched[2]}`
+            ? `:${dynamicRouteMatched[1].replace(/\$$/, '?')}${
+                dynamicRouteMatched[2]
+              }`
             : filename
         }`,
         _component: alias,

--- a/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
+++ b/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
@@ -42,6 +42,7 @@ const createRoute = (
   };
 };
 
+// eslint-disable-next-line complexity
 export const walk = async (
   dirname: string,
   rootDir: string,

--- a/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
+++ b/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
@@ -72,7 +72,7 @@ export const walk = async (
   routePath = replaceDynamicPath(routePath);
 
   const route: Partial<NestedRoute> = {
-    path: routePath,
+    path: routePath?.replace(/\$$/, '?'),
     children: [],
     isRoot,
   };

--- a/tests/integration/routes/src/four/routes/act/[bid$]/page.tsx
+++ b/tests/integration/routes/src/four/routes/act/[bid$]/page.tsx
@@ -1,0 +1,10 @@
+import { useParams } from '@modern-js/runtime/router';
+
+const Page = () => {
+  const params = useParams<{
+    bid: string;
+  }>();
+  return <div className="act">act page, param is {params.bid}</div>;
+};
+
+export default Page;

--- a/tests/integration/routes/src/two/pages/act/bar/[bid$]/detail.tsx
+++ b/tests/integration/routes/src/two/pages/act/bar/[bid$]/detail.tsx
@@ -1,0 +1,8 @@
+import { useParams } from '@modern-js/runtime/router';
+
+const Item = () => {
+  const params = useParams();
+  return <div className="item">bid detail {params.bid}</div>;
+};
+
+export default Item;

--- a/tests/integration/routes/src/two/pages/act/bar/[bid$]/index.tsx
+++ b/tests/integration/routes/src/two/pages/act/bar/[bid$]/index.tsx
@@ -1,0 +1,8 @@
+import { useParams } from '@modern-js/runtime/router';
+
+const Item = () => {
+  const params = useParams();
+  return <div className="item">{params.bid} bid exist</div>;
+};
+
+export default Item;

--- a/tests/integration/routes/src/two/pages/act/foo/[uid$].tsx
+++ b/tests/integration/routes/src/two/pages/act/foo/[uid$].tsx
@@ -1,0 +1,8 @@
+import { useParams } from '@modern-js/runtime/router';
+
+const Item = () => {
+  const params = useParams();
+  return <div className="item">{params.uid} uid exist</div>;
+};
+
+export default Item;

--- a/tests/integration/routes/tests/index.test.ts
+++ b/tests/integration/routes/tests/index.test.ts
@@ -48,6 +48,56 @@ const renderDynamaticRoute = async (errors: string[], appPort: number) => {
   expect(errors.length).toEqual(0);
 };
 
+const renderOptionalParamsRoute = async (errors: string[], appPort: number) => {
+  await page.goto(`http://localhost:${appPort}/two/act/bar`, {
+    waitUntil: ['networkidle0'],
+  });
+  const element = await page.$('.item');
+  const targetText = await page.evaluate(el => el.textContent, element);
+  expect(targetText.trim()).toEqual('bid exist');
+  expect(errors.length).toEqual(0);
+
+  await page.goto(`http://localhost:${appPort}/two/act/bar/1234`, {
+    waitUntil: ['networkidle0'],
+  });
+  const element1 = await page.$('.item');
+  const targetText1 = await page.evaluate(el => el.textContent, element1);
+  expect(targetText1.trim()).toEqual('1234 bid exist');
+  expect(errors.length).toEqual(0);
+
+  await page.goto(`http://localhost:${appPort}/two/act/foo`, {
+    waitUntil: ['networkidle0'],
+  });
+  const element3 = await page.$('.item');
+  const targetText3 = await page.evaluate(el => el.textContent, element3);
+  expect(targetText3.trim()).toEqual('uid exist');
+  expect(errors.length).toEqual(0);
+
+  await page.goto(`http://localhost:${appPort}/two/act/foo/1234`, {
+    waitUntil: ['networkidle0'],
+  });
+  const element4 = await page.$('.item');
+  const targetText4 = await page.evaluate(el => el.textContent, element4);
+  expect(targetText4.trim()).toEqual('1234 uid exist');
+  expect(errors.length).toEqual(0);
+
+  await page.goto(`http://localhost:${appPort}/two/act/bar/detail`, {
+    waitUntil: ['networkidle0'],
+  });
+  const element5 = await page.$('.item');
+  const targetText5 = await page.evaluate(el => el.textContent, element5);
+  expect(targetText5.trim()).toEqual('bid detail');
+  expect(errors.length).toEqual(0);
+
+  await page.goto(`http://localhost:${appPort}/two/act/bar/1234/detail`, {
+    waitUntil: ['networkidle0'],
+  });
+  const element6 = await page.$('.item');
+  const targetText6 = await page.evaluate(el => el.textContent, element6);
+  expect(targetText6.trim()).toEqual('bid detail 1234');
+  expect(errors.length).toEqual(0);
+};
+
 const supportGlobalLayout = async (errors: string[], appPort: number) => {
   await page.goto(`http://localhost:${appPort}/two/user`, {
     waitUntil: ['networkidle0'],
@@ -195,6 +245,21 @@ const supportNestedRouteAndPage = async (errors: string[], appPort: number) => {
   const text1 = await page.evaluate(el => el.textContent, rootElm1);
   expect(text1.includes('root layout')).toBeTruthy();
   expect(text1.includes('1234')).toBeTruthy();
+
+  await page.goto(`http://localhost:${appPort}/four/act`, {
+    waitUntil: ['networkidle0'],
+  });
+  const rootElm2 = await page.$('.act');
+  const text2 = await page.evaluate(el => el.textContent, rootElm2);
+  expect(text2.includes('act page, param is')).toBeTruthy();
+  expect(text2.includes('1234')).toBeFalsy();
+
+  await page.goto(`http://localhost:${appPort}/four/act/1234`, {
+    waitUntil: ['networkidle0'],
+  });
+  const rootElm3 = await page.$('.act');
+  const text3 = await page.evaluate(el => el.textContent, rootElm3);
+  expect(text3.includes('act page, param is 1234')).toBeTruthy();
 };
 
 const supportHandleLoaderError = async (errors: string[], appPort: number) => {
@@ -350,7 +415,6 @@ describe('dev', () => {
 
     // FIXME: skip the test
     test.skip('support handle loader error', async () =>
-      // eslint-disable-next-line max-lines
       supportHandleLoaderError(errors, appPort));
   });
 
@@ -410,6 +474,9 @@ describe('build', () => {
 
     test('render dynamic pages route correctly', async () =>
       renderDynamaticRoute(errors, appPort));
+
+    test('render options params pages route correctly', async () =>
+      renderOptionalParamsRoute(errors, appPort));
 
     test('support global layout', async () =>
       supportGlobalLayout(errors, appPort));


### PR DESCRIPTION
## Description

Optional parameters can now be set via `[id?]/page.tsx` in file-based routes

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
