### PR TITLE
fix(doc-core): failed to build when using logo.dark

### DIFF
--- a/.changeset/red-eyes-matter.md
+++ b/.changeset/red-eyes-matter.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): failed to build when using logo.dark
+
+fix(doc-core): 修复配置 logo.dark 时构建失败的问题

--- a/packages/cli/doc-core/src/theme-default/logic/useAppearance.ts
+++ b/packages/cli/doc-core/src/theme-default/logic/useAppearance.ts
@@ -1,12 +1,12 @@
 import { APPEARANCE_KEY } from '@/shared/utils';
 
-let classList: DOMTokenList;
+let classList: DOMTokenList | undefined;
 // Determine if the theme mode of the user's operating system is dark
 let userPreference: string;
 let query: MediaQueryList;
 
 const setClass = (dark: boolean): void => {
-  classList[dark ? 'add' : 'remove']('dark');
+  classList?.[dark ? 'add' : 'remove']('dark');
 };
 
 const updateAppearance = (): void => {
@@ -23,14 +23,14 @@ if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {
   classList = document.documentElement.classList;
 }
 
-export const isDarkMode = () => classList.contains('dark');
+export const isDarkMode = () => classList?.contains('dark');
 
 export const getToggle = () => {
   if (typeof window !== 'undefined') {
     window.addEventListener('storage', updateAppearance);
   }
   return () => {
-    const isDark = classList.contains('dark');
+    const isDark = isDarkMode();
     if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {
       setClass(!isDark);
       userPreference = isDark ? 'light' : 'dark';


### PR DESCRIPTION
## Description

Fix failed to build when using logo.dark.

<img width="1075" alt="Screen Shot 2023-03-01 at 11 03 51" src="https://user-images.githubusercontent.com/7237365/222035269-a4da45ba-8eeb-4d76-a9f3-72d1bcc1c2dc.png">


```ts
export default defineConfig({
  doc: {
    logo: {
      light: 'xxx',
      dark: 'xxx',
    },
  }
});
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
