### PR TITLE
fix(storybook): remove builtin babel-plugin-import when use module-tools

### DIFF
--- a/.changeset/silver-bears-accept.md
+++ b/.changeset/silver-bears-accept.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-storybook': patch
+---
+
+fix(plugin-storybook): remove builtin babel-plugin-import when use module-tools
+
+fix(plugin-storybook): 在 module-tools 内使用时不默认添加 babel-plugin-import


### PR DESCRIPTION
## Description

Remove builtin babel-plugin-import when use module-tools, so we can keep the behavior consistent between storybook and module build.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
