### PR TITLE
fix(module-tools): ignore some tsconfig compileOptions

### DIFF
--- a/.changeset/chilly-rice-knock.md
+++ b/.changeset/chilly-rice-knock.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix: ignore some tsconfig compileOptions
+fix: 忽略一些 tsconfig 的 compileOptions 配置

--- a/packages/solutions/module-tools/src/builder/dts/rollup.ts
+++ b/packages/solutions/module-tools/src/builder/dts/rollup.ts
@@ -49,9 +49,18 @@ export const runRollup = async (
   const { default: dtsPlugin } = await import(
     '../../../compiled/rollup-plugin-dts'
   );
+  const { transformUndefineObject } = await import('../../utils/common');
+
   const baseUrl = path.isAbsolute(options.baseUrl || '.')
     ? options.baseUrl
     : path.join(path.dirname(tsconfigPath), options.baseUrl || '.');
+  const ignoreCompileOptions = [
+    'incremental',
+    'tsBuildInfoFile',
+    'sourceMap',
+    'inlineSources',
+  ];
+
   const inputConfig: InputOptions = {
     input,
     external: externals,
@@ -83,6 +92,7 @@ export const runRollup = async (
           checkJs: false,
           // Ensure we can parse the latest code
           target: ts.ScriptTarget.ESNext,
+          ...transformUndefineObject(ignoreCompileOptions),
         },
         tsconfig: tsconfigPath,
       }),

--- a/packages/solutions/module-tools/src/utils/common.ts
+++ b/packages/solutions/module-tools/src/utils/common.ts
@@ -1,0 +1,13 @@
+/**
+ * transform ['a', 'b'] to {a: undefined, b: undefined}
+ */
+export const transformUndefineObject = (
+  arr: string[],
+): Record<string, undefined> => {
+  return arr.reduce((o, key) => {
+    return {
+      ...o,
+      [key]: undefined,
+    };
+  }, {});
+};


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

ignore some tsconfig compileOptions, Because their presence can cause errors in the bundling type

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
