### PR TITLE
fix(builder): tools.sass type should use legacy sass options by default

### DIFF
--- a/.changeset/big-melons-wave.md
+++ b/.changeset/big-melons-wave.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): tools.sass type should use legacy sass options by default
+
+fix(builder): tools.sass 默认使用 legacy sass 选项类型

--- a/packages/builder/builder-webpack-provider/src/plugins/sass.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/sass.ts
@@ -44,10 +44,7 @@ export function builderPluginSass(): BuilderPlugin {
             },
             config.tools.sass,
             { addExcludes },
-            (
-              defaults: SassLoaderOptions,
-              userOptions: SassLoaderOptions,
-            ): SassLoaderOptions => {
+            (defaults: SassLoaderOptions, userOptions: SassLoaderOptions) => {
               return {
                 ...defaults,
                 ...userOptions,

--- a/packages/builder/builder-webpack-provider/src/types/thirdParty/index.ts
+++ b/packages/builder/builder-webpack-provider/src/types/thirdParty/index.ts
@@ -5,7 +5,10 @@ import type TerserPlugin from 'terser-webpack-plugin';
 import type CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import type ForkTSCheckerPlugin from 'fork-ts-checker-webpack-plugin';
 import type { Options as RawTSLoaderOptions } from 'ts-loader';
-import type { Options as SassOptions } from '../../../compiled/sass';
+import type {
+  Options as SassOptions,
+  LegacyOptions as LegacySassOptions,
+} from '../../../compiled/sass';
 import type * as SassLoader from '../../../compiled/sass-loader';
 import type Less from '../../../compiled/less';
 
@@ -44,9 +47,17 @@ export type {
   MiniCSSExtractLoaderOptions,
 } from './css';
 
-export type SassLoaderOptions = Omit<SassLoader.Options, 'sassOptions'> & {
-  sassOptions?: SassOptions<'sync'>;
-};
+export type SassLoaderOptions = Omit<SassLoader.Options, 'sassOptions'> &
+  (
+    | {
+        api?: 'legacy';
+        sassOptions?: Partial<LegacySassOptions<'async'>>;
+      }
+    | {
+        api: 'modern';
+        sassOptions?: SassOptions<'async'>;
+      }
+  );
 
 export type LessLoaderOptions = {
   lessOptions?: Less.Options;


### PR DESCRIPTION
## Description

Sass supports two type of options: `Options` and `LegacyOptions`.

In sass-loader, the `sassOptions` should use legacy sass options by default, and users can switch the option type via the `api` config.

### Ref

https://github.com/webpack-contrib/sass-loader#api

![image](https://user-images.githubusercontent.com/7237365/222099149-18d4f047-a049-4494-8c9f-526788fd7e5d.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
