### PR TITLE
feat(app-tools): support router plugin in rspack

### DIFF
--- a/.changeset/tough-queens-repeat.md
+++ b/.changeset/tough-queens-repeat.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': minor
+---
+
+feat: support router-plugin in rspack bundler.
+feat: 在 rspack bundler 里支持 router-plugin

--- a/packages/solutions/app-tools/src/builder/builder-webpack/builderPlugins/compatModern.ts
+++ b/packages/solutions/app-tools/src/builder/builder-webpack/builderPlugins/compatModern.ts
@@ -3,7 +3,6 @@ import { BuilderPlugin } from '@modern-js/builder-shared';
 import type { BuilderPluginAPI } from '@modern-js/builder-webpack-provider';
 
 import { BuilderOptions, createCopyPattern } from '../../shared';
-import { RouterPlugin } from '../webpackPlugins';
 
 /**
  * Provides default configuration consistent with modern.js v1
@@ -36,18 +35,6 @@ export const builderPluginCompatModern = (
             patterns: [...(args[0]?.patterns || []), defaultCopyPattern],
           },
         ]);
-      }
-
-      const { entrypoints } = appContext;
-      const existNestedRoutes = entrypoints.some(
-        entrypoint => entrypoint.nestedRoutesEntry,
-      );
-
-      const routerConfig: any = modernConfig?.runtime?.router;
-      const routerManifest = Boolean(routerConfig?.manifest);
-      // for ssr mode
-      if (existNestedRoutes || routerManifest) {
-        chain.plugin('route-plugin').use(RouterPlugin);
       }
     });
   },

--- a/packages/solutions/app-tools/src/builder/builder-webpack/webpackPlugins/index.ts
+++ b/packages/solutions/app-tools/src/builder/builder-webpack/webpackPlugins/index.ts
@@ -1,1 +1,0 @@
-export * from './RouterPlugin';

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterModern.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterModern.ts
@@ -17,8 +17,11 @@ import { ChainIdentifier, getEntryOptions } from '@modern-js/utils';
 import HtmlWebpackPlugin from '@modern-js/builder-webpack-provider/html-webpack-plugin';
 import { template as lodashTemplate } from '@modern-js/utils/lodash';
 import type { BuilderOptions } from '../types';
-import { HtmlAsyncChunkPlugin } from '../bundlerPlugins/HtmlAsyncChunkPlugin';
-import { BottomTemplatePlugin } from '../bundlerPlugins/HtmlBottomTemplate';
+import {
+  HtmlAsyncChunkPlugin,
+  BottomTemplatePlugin,
+  RouterPlugin,
+} from '../bundlerPlugins';
 import type {
   AppNormalizedConfig,
   Bundler,
@@ -124,6 +127,19 @@ export const builderPluginAdapterModern = <B extends Bundler>(
           .test(bareServerModuleReg)
           .use('server-module-loader')
           .loader(require.resolve('../loaders/serverModuleLoader'));
+      }
+
+      const { entrypoints } = appContext;
+      const existNestedRoutes = entrypoints.some(
+        entrypoint => entrypoint.nestedRoutesEntry,
+      );
+
+      const routerConfig: any = normalizedConfig?.runtime?.router;
+      const routerManifest = Boolean(routerConfig?.manifest);
+
+      // for ssr mode
+      if (existNestedRoutes || routerManifest) {
+        chain.plugin('route-plugin').use(RouterPlugin);
       }
     });
 

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/index.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/index.ts
@@ -1,0 +1,3 @@
+export * from './HtmlAsyncChunkPlugin';
+export * from './HtmlBottomTemplate';
+export * from './RouterPlugin';

--- a/packages/solutions/app-tools/tests/routes/webpackRouterPlugin.test.ts
+++ b/packages/solutions/app-tools/tests/routes/webpackRouterPlugin.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fs, ROUTE_MINIFEST_FILE } from '@modern-js/utils';
-import { RouterPlugin } from '../../src/builder/builder-webpack/webpackPlugins/RouterPlugin';
+import { RouterPlugin } from '../../src/builder/shared/bundlerPlugins';
 import { compiler } from './compiler';
 
 describe('webpack-router-plugin', () => {


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Router Plugin would use in SSR mode.
We need support this plugin to Rspack. Otherwise the SSR mode can't run ,when we switch on Rspack bundler.

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
