### PR TITLE
docs(main): fix failed to resolve rspackTip.mdx

### DIFF
--- a/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Using Rspack
 
-import Rspack from '@modern-js/builder-doc/docs/en/shared/rspack-tip.mdx';
+import Rspack from '@modern-js/builder-doc/docs/en/shared/rspackTip.mdx';
 
 <Rspack />
 

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # 使用 Rspack
 
-import Rspack from '@modern-js/builder-doc/docs/zh/shared/rspack-tip.mdx';
+import Rspack from '@modern-js/builder-doc/docs/zh/shared/rspackTip.mdx';
 
 <Rspack />
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1de006f</samp>

Fixed import path of `Rspack` component in the documentation guides for advanced features. This ensures the correct rendering of the `rspackTip.mdx` file in both English and Chinese versions.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1de006f</samp>

* Fix import path of Rspack component in both English and Chinese documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4260/files?diff=unified&w=0#diff-eda7074c67ef707f70206cf9404950df1e4b9de3c8b7831a6c951b38af9403ceL7-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4260/files?diff=unified&w=0#diff-6b5d7dabc07cedb68247471404a2ee5ea2426fb560961f24781a4ab144909737L8-R8))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
