### PR TITLE
feat: remove command modify config

### DIFF
--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -69,10 +69,6 @@ export const build = async (
     return;
   }
 
-  api.modifyResolvedConfig(config => {
-    return { ...config, cliOptions: options };
-  });
-
   const { distDirectory, appDirectory, serverConfigFile } = appContext;
 
   await buildServerConfig({

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -49,10 +49,6 @@ export const dev = async (
     normalizedConfig?.source?.alias,
   );
 
-  api.modifyResolvedConfig(config => {
-    return { ...config, cliOptions: options };
-  });
-
   const {
     appDirectory,
     distDirectory,


### PR DESCRIPTION
## Summary

In addCommand Hook, modifyResolvedConfig has already been executed, so `api.modifyResolvedConfig` will not be executed.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
