### PR TITLE
chore(deps): update playwright to 1.54.2

### DIFF
--- a/packages/toolkit/e2e/package.json
+++ b/packages/toolkit/e2e/package.json
@@ -38,10 +38,10 @@
   },
   "dependencies": {
     "@modern-js/utils": "workspace:*",
-    "@playwright/test": "1.33.0",
+    "@playwright/test": "1.54.2",
     "@swc/helpers": "^0.5.17",
     "connect": "^3.7.0",
-    "playwright": "1.33.0",
+    "playwright": "1.54.2",
     "serve-static": "^1.16.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2286,8 +2286,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       '@playwright/test':
-        specifier: 1.33.0
-        version: 1.33.0
+        specifier: 1.54.2
+        version: 1.54.2
       '@swc/helpers':
         specifier: ^0.5.17
         version: 0.5.17
@@ -2295,8 +2295,8 @@ importers:
         specifier: ^3.7.0
         version: 3.7.0
       playwright:
-        specifier: 1.33.0
-        version: 1.33.0
+        specifier: 1.54.2
+        version: 1.54.2
       serve-static:
         specifier: ^1.16.2
         version: 1.16.2
@@ -3071,8 +3071,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/toolkit/utils
       '@playwright/test':
-        specifier: 1.33.0
-        version: 1.33.0
+        specifier: 1.54.2
+        version: 1.54.2
       '@rsbuild/core':
         specifier: 1.4.13
         version: 1.4.13
@@ -8012,10 +8012,9 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.33.0':
-    resolution: {integrity: sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==}
-    engines: {node: '>=14'}
-    deprecated: Please update to the latest version of Playwright to test up-to-date browsers.
+  '@playwright/test@1.54.2':
+    resolution: {integrity: sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   '@polka/url@1.0.0-next.28':
@@ -13858,14 +13857,14 @@ packages:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
 
-  playwright-core@1.33.0:
-    resolution: {integrity: sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==}
-    engines: {node: '>=14'}
+  playwright-core@1.54.2:
+    resolution: {integrity: sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==}
+    engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.33.0:
-    resolution: {integrity: sha512-+zzU3V2TslRX2ETBRgQKsKytYBkJeLZ2xzUj4JohnZnxQnivoUvOvNbRBYWSYykQTO0Y4zb8NwZTYFUO+EpPBQ==}
-    engines: {node: '>=14'}
+  playwright@1.54.2:
+    resolution: {integrity: sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   points-on-curve@0.2.0:
@@ -19924,12 +19923,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.33.0':
+  '@playwright/test@1.54.2':
     dependencies:
-      '@types/node': 20.8.8
-      playwright-core: 1.33.0
-    optionalDependencies:
-      fsevents: 2.3.2
+      playwright: 1.54.2
 
   '@polka/url@1.0.0-next.28': {}
 
@@ -27206,11 +27202,13 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
-  playwright-core@1.33.0: {}
+  playwright-core@1.54.2: {}
 
-  playwright@1.33.0:
+  playwright@1.54.2:
     dependencies:
-      playwright-core: 1.33.0
+      playwright-core: 1.54.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   points-on-curve@0.2.0: {}
 

--- a/tests/e2e/builder/.gitignore
+++ b/tests/e2e/builder/.gitignore
@@ -1,2 +1,4 @@
 dist
 dist-*
+test-results
+

--- a/tests/e2e/builder/package.json
+++ b/tests/e2e/builder/package.json
@@ -16,7 +16,7 @@
     "@modern-js/e2e": "workspace:*",
     "@modern-js/builder": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "@playwright/test": "1.33.0",
+    "@playwright/test": "1.54.2",
     "@rsbuild/core": "1.4.13",
     "@types/lodash": "^4.17.20",
     "@types/node": "^20",


### PR DESCRIPTION
## Summary

Update playwright to 1.54.2 to be compatible with Ubuntu 24. This should fix the rsbuild-ecosystem-ci:

<img width="1576" height="648" alt="image" src="https://github.com/user-attachments/assets/a4ce75d8-e48d-455b-9ecc-2b9c7373d0cb" />

## Related Links

- https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/16725947780/job/47341497060#step:7:19636
- https://github.com/microsoft/playwright/issues/30368

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
