### PR TITLE
fix: solve the problem of react19 streaming rendering failure

### DIFF
--- a/.changeset/short-hornets-smile.md
+++ b/.changeset/short-hornets-smile.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: solve the problem of react19 streaming rendering failure
+fix: 解决 react19 下流式渲染失效的问题

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ playground/
 .netlify/
 
 .swc/
+
+.swe
+.cursor
+.claude
+AGENTS.md

--- a/packages/runtime/plugin-runtime/src/core/server/stream/deferredScript.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/deferredScript.ts
@@ -1,0 +1,90 @@
+import type { DeferredData } from '@modern-js/runtime-utils/browser';
+import { runRouterDataFnStr } from '../../../router/runtime/constants';
+
+export type DeferredDataLike = Pick<DeferredData, 'data' | 'pendingKeys'> & {
+  data?: Record<string, unknown>;
+  pendingKeys?: string[];
+};
+
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+export function escapeAttr(value: string): string {
+  return value.replace(/[&<>"']/g, ch => HTML_ESCAPE_MAP[ch]);
+}
+
+export function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+export function isDeferredDataLike(v: unknown): v is DeferredDataLike {
+  if (!isRecord(v)) return false;
+  const hasPending =
+    'pendingKeys' in v && Array.isArray((v as any).pendingKeys);
+  const hasData = 'data' in v && isRecord((v as any).data);
+  return hasPending && hasData;
+}
+
+export function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return !!value && typeof (value as { then?: unknown }).then === 'function';
+}
+
+export function toErrorInfo(error: unknown): {
+  message: string;
+  stack?: string;
+} {
+  if (error && typeof error === 'object') {
+    const maybeMsg = (error as { message?: unknown }).message;
+    const maybeStack = (error as { stack?: string }).stack;
+    return {
+      message:
+        typeof maybeMsg === 'string' ? maybeMsg : String(maybeMsg ?? error),
+      stack: process.env.NODE_ENV !== 'production' ? maybeStack : undefined,
+    };
+  }
+  return { message: String(error) };
+}
+
+export function buildDeferredDataScript(
+  nonce: string | undefined,
+  args: unknown[],
+): string {
+  const payload = JSON.stringify(args);
+  const escaped = escapeAttr(payload);
+  const nonceAttr = nonce ? ` nonce="${nonce}"` : '';
+  return `<script async${nonceAttr} data-fn-name="r" data-script-src="modern-run-router-data-fn" data-fn-args='${escaped}' suppressHydrationWarning>${runRouterDataFnStr}</script>`;
+}
+
+export function enqueueFromEntries(
+  entries: Array<[string, unknown]>,
+  nonce: string | undefined,
+  emit: (script: string) => void,
+): void {
+  entries.forEach(([routeId, value]) => {
+    if (!isDeferredDataLike(value)) return;
+    const pendingKeys = new Set<string>(value.pendingKeys ?? []);
+    pendingKeys.forEach((key: string) => {
+      const tracked = value.data?.[key];
+      if (isPromiseLike(tracked)) {
+        (tracked as Promise<unknown>).then(
+          (val: unknown) =>
+            emit(buildDeferredDataScript(nonce, [routeId, key, val])),
+          (err: unknown) =>
+            emit(
+              buildDeferredDataScript(nonce, [
+                routeId,
+                key,
+                undefined,
+                toErrorInfo(err),
+              ]),
+            ),
+        );
+      }
+    });
+  });
+}

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -280,12 +280,6 @@ function useRouterCreation(props: any, options: UseRouterCreationOptions) {
     }
 
     const modifiedRoutes = hooks.modifyRoutes.call(routes);
-    console.log(
-      'modifiedRoutes111111',
-      modifiedRoutes,
-      _basename,
-      hydrationData,
-    );
 
     const router = supportHtml5History
       ? createBrowserRouter(modifiedRoutes, {

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/user/[id]/page.data.ts
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/user/[id]/page.data.ts
@@ -1,0 +1,17 @@
+import { type LoaderFunctionArgs, defer } from '@modern-js/runtime/router';
+import type { User } from './page';
+
+export const loader = ({ params }: LoaderFunctionArgs) => {
+  const userId = params.id;
+
+  const user = new Promise<User>(resolve => {
+    setTimeout(() => {
+      resolve({
+        name: `user${userId}`,
+        age: 18,
+      });
+    }, 2000);
+  });
+
+  return { data: user };
+};

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/user/[id]/page.tsx
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/user/[id]/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { useLoaderData } from '@modern-js/runtime/router';
+import { Suspense, use } from 'react';
+
+export interface User {
+  name: string;
+  age: number;
+}
+
+interface Data {
+  data: Promise<User>;
+}
+
+const UserInfo = ({ p }: { p: Promise<User> }) => {
+  const user = use(p);
+  return (
+    <div>
+      name: {user.name}, age: {user.age}
+    </div>
+  );
+};
+
+const Page = () => {
+  const data = useLoaderData() as Data;
+
+  return (
+    <div>
+      user info:
+      <Suspense fallback={<div id="loading">loading user data ...</div>}>
+        <UserInfo p={data.data} />
+      </Suspense>
+    </div>
+  );
+};
+
+export default Page;

--- a/tests/integration/ssr/fixtures/streaming/src/routes/user/[id]/page.tsx
+++ b/tests/integration/ssr/fixtures/streaming/src/routes/user/[id]/page.tsx
@@ -19,6 +19,7 @@ const Page = () => {
       <Suspense fallback={<div id="loading">loading user data ...</div>}>
         <Await resolve={data.data}>
           {(user: User) => {
+            console.log('render user');
             return (
               <div id="data">
                 {user.name}-{user.age}

--- a/tests/integration/ssr/tests/streaming.test.ts
+++ b/tests/integration/ssr/tests/streaming.test.ts
@@ -1,3 +1,4 @@
+import http from 'http';
 import path, { join } from 'path';
 import puppeteer, { type Browser, type Page } from 'puppeteer';
 import {
@@ -54,6 +55,67 @@ async function errorThrownInLoader(page: Page, appPort: number) {
   expect(body).toMatch(/Something went wrong!.*error occurs/);
 }
 
+async function streamingOrderOnServer(appPort: number) {
+  await new Promise<void>((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: 'localhost',
+        port: appPort,
+        path: '/user/1',
+        method: 'GET',
+      },
+      res => {
+        let buffer = '';
+        let fallbackIndex = -1;
+        let finalIndex = -1;
+        res.setEncoding('utf8');
+        res.on('data', chunk => {
+          buffer += chunk;
+          if (fallbackIndex === -1) {
+            fallbackIndex = buffer.toString().indexOf('loading user data');
+          }
+          if (finalIndex === -1) {
+            finalIndex = buffer
+              .toString()
+              .indexOf('name&quot;:&quot;user1&quot;,&quot;age&quot;:18');
+          }
+          if (fallbackIndex !== -1 && finalIndex !== -1) {
+            try {
+              expect(fallbackIndex).toBeGreaterThanOrEqual(0);
+              expect(finalIndex).toBeGreaterThan(fallbackIndex);
+              resolve();
+            } catch (e) {
+              reject(e);
+            } finally {
+              req.destroy();
+            }
+          }
+        });
+        res.on('end', () => {
+          if (fallbackIndex !== -1 && finalIndex !== -1) {
+            try {
+              expect(finalIndex).toBeGreaterThan(fallbackIndex);
+              resolve();
+            } catch (e) {
+              reject(e);
+            }
+          } else {
+            reject(
+              new Error('Did not observe fallback and final content in stream'),
+            );
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+    setTimeout(() => {
+      reject(new Error('Timeout waiting for streaming response'));
+      req.destroy();
+    }, 8000);
+  });
+}
+
 describe('Streaming SSR', () => {
   let app: any;
   let appPort: number;
@@ -92,5 +154,9 @@ describe('Streaming SSR', () => {
 
   test('error thrown in loader', async () => {
     await errorThrownInLoader(page, appPort);
+  });
+
+  test('should render fallback before final content', async () => {
+    await streamingOrderOnServer(appPort);
   });
 });


### PR DESCRIPTION
## Summary

After upgrading to react19, you will see the streaming ssr project page, which will wait for the data to be obtained before returning. After investigation, I found the reason is that react returns the first chunk to Modern.js runtime too late.

In our original implementation, because the `Await` component throws a promise, the SSR root segment is marked as `POSTPONED` by React 19, causing the first chunk to respond late.

With the `DeferredScript` component, we can't prevent React 19 from marking the root segment as `POSTPONED`, so we write the scripts in `createReadableStream`.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
