### PR TITLE
feat: custom entries support entry.tsx and entry.server.tsx

### DIFF
--- a/packages/runtime/plugin-runtime/src/router/cli/entry.ts
+++ b/packages/runtime/plugin-runtime/src/router/cli/entry.ts
@@ -21,7 +21,8 @@ export const modifyEntrypoints = (entrypoints: Entrypoint[]) => {
     }
     if (entrypoint?.isCustomSourceEntry) {
       if (entrypoint.fileSystemRoutes) {
-        entrypoint.nestedRoutesEntry = entrypoint.entry;
+        entrypoint.nestedRoutesEntry =
+          entrypoint.absoluteEntryDir || entrypoint.entry;
       }
       return entrypoint;
     }

--- a/packages/solutions/app-tools/src/plugins/analyze/getBundleEntry.ts
+++ b/packages/solutions/app-tools/src/plugins/analyze/getBundleEntry.ts
@@ -9,7 +9,11 @@ import {
 } from '@modern-js/utils';
 import type { AppNormalizedConfig } from '../../types';
 import type { AppToolsContext, AppToolsHooks } from '../../types/plugin';
-import { getFileSystemEntry } from './getFileSystemEntry';
+import {
+  getFileSystemEntry,
+  hasEntry,
+  hasServerEntry,
+} from './getFileSystemEntry';
 import { isSubDirOrEqual } from './utils';
 
 const ensureExtensions = (file: string) => {
@@ -68,24 +72,34 @@ export const getBundleEntry = async (
     Object.keys(entries).forEach(name => {
       const value = entries[name];
       const entryName = typeof value === 'string' ? value : value.entry;
+      const entryFile = ensureAbsolutePath(appDirectory, entryName);
+      const entryDir = path.dirname(entryFile);
+      const customEntryFile = hasEntry(entryDir);
+      const serverEntryFile = hasServerEntry(entryDir);
       const isAutoMount =
         typeof value === 'string' ? true : !value.disableMount;
       const entrypoint: Entrypoint = {
         entryName: name,
         isMainEntry: false,
-        entry: ensureAbsolutePath(appDirectory, entryName),
-        absoluteEntryDir: isDirectory(
-          ensureAbsolutePath(appDirectory, entryName),
-        )
-          ? ensureAbsolutePath(appDirectory, entryName)
-          : path.dirname(ensureAbsolutePath(appDirectory, entryName)),
+        entry:
+          typeof value === 'string'
+            ? entryFile
+            : value.customEntry
+              ? customEntryFile || entryFile
+              : entryFile,
+        absoluteEntryDir: isDirectory(entryFile)
+          ? entryFile
+          : path.dirname(entryFile),
         isAutoMount,
-        fileSystemRoutes: fs
-          .statSync(ensureAbsolutePath(appDirectory, entryName))
-          .isDirectory()
-          ? {}
-          : undefined,
+        fileSystemRoutes: fs.statSync(entryFile).isDirectory() ? {} : undefined,
         isCustomSourceEntry: true,
+        customEntry: typeof value === 'string' ? false : value.customEntry,
+        customServerEntry:
+          typeof value === 'string'
+            ? false
+            : value.customEntry
+              ? serverEntryFile
+              : false,
       };
 
       if (!ifAlreadyExists(defaults, entrypoint)) {

--- a/packages/solutions/app-tools/src/plugins/analyze/getFileSystemEntry.ts
+++ b/packages/solutions/app-tools/src/plugins/analyze/getFileSystemEntry.ts
@@ -12,12 +12,12 @@ import { ENTRY_FILE_NAME } from './constants';
 
 export type { Entrypoint };
 
-const hasEntry = (dir: string) =>
+export const hasEntry = (dir: string) =>
   findExists(
     JS_EXTENSIONS.map(ext => path.resolve(dir, `${ENTRY_FILE_NAME}${ext}`)),
   );
 
-const hasServerEntry = (dir: string) =>
+export const hasServerEntry = (dir: string) =>
   findExists(
     JS_EXTENSIONS.map(ext =>
       path.resolve(dir, `${ENTRY_FILE_NAME}.server${ext}`),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3838,6 +3838,21 @@ importers:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
 
+  tests/integration/entries/fixtures/app-custom-entries:
+    dependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../../../packages/solutions/app-tools
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../../../packages/runtime/plugin-runtime
+      react:
+        specifier: ^19.1.1
+        version: 19.1.1
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.1.1(react@19.1.1)
+
   tests/integration/entries/fixtures/app-custom-routes:
     dependencies:
       '@modern-js/app-tools':

--- a/tests/integration/entries/fixtures/app-custom-entries/modern.config.ts
+++ b/tests/integration/entries/fixtures/app-custom-entries/modern.config.ts
@@ -1,0 +1,22 @@
+import { appTools, defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig({
+  source: {
+    disableDefaultEntries: true,
+    entries: {
+      main: 'src/app-custom-entries/App.tsx',
+      'entry-1': {
+        entry: 'src/entry-1/App.tsx',
+        customEntry: true,
+      },
+      'entry-2': {
+        entry: 'src/entry-2/routes',
+        customEntry: true,
+      },
+    },
+  },
+  server: {
+    ssr: true,
+  },
+  plugins: [appTools()],
+});

--- a/tests/integration/entries/fixtures/app-custom-entries/package.json
+++ b/tests/integration/entries/fixtures/app-custom-entries/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "app-custom-entries",
+  "version": "2.66.0",
+  "scripts": {
+    "dev": "modern dev"
+  },
+  "dependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/runtime": "workspace:*",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
+  }
+}

--- a/tests/integration/entries/fixtures/app-custom-entries/src/app-custom-entries/App.tsx
+++ b/tests/integration/entries/fixtures/app-custom-entries/src/app-custom-entries/App.tsx
@@ -1,0 +1,3 @@
+export default function App() {
+  return <div>Modern APP</div>;
+}

--- a/tests/integration/entries/fixtures/app-custom-entries/src/app-custom-entries/entry.tsx
+++ b/tests/integration/entries/fixtures/app-custom-entries/src/app-custom-entries/entry.tsx
@@ -1,0 +1,6 @@
+import { render } from '@modern-js/runtime/browser';
+import { createRoot } from '@modern-js/runtime/react';
+
+const ModernRoot = createRoot();
+
+render(<ModernRoot />);

--- a/tests/integration/entries/fixtures/app-custom-entries/src/entry-1/App.tsx
+++ b/tests/integration/entries/fixtures/app-custom-entries/src/entry-1/App.tsx
@@ -1,0 +1,3 @@
+export default function App() {
+  return <div id="text">Modern APP-1</div>;
+}

--- a/tests/integration/entries/fixtures/app-custom-entries/src/entry-1/entry.server.tsx
+++ b/tests/integration/entries/fixtures/app-custom-entries/src/entry-1/entry.server.tsx
@@ -1,0 +1,17 @@
+import {
+  type HandleRequest,
+  createRequestHandler,
+  renderString,
+} from '@modern-js/runtime/ssr/server';
+
+const handleRequest: HandleRequest = async (request, ServerRoot, options) => {
+  const body = await renderString(request, <ServerRoot />, options);
+  const newBody = `<div id="server">custom entry-1-server</div>${body}`;
+  return new Response(newBody, {
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+    },
+  });
+};
+
+export default createRequestHandler(handleRequest);

--- a/tests/integration/entries/fixtures/app-custom-entries/src/entry-1/entry.tsx
+++ b/tests/integration/entries/fixtures/app-custom-entries/src/entry-1/entry.tsx
@@ -1,0 +1,11 @@
+import { render } from '@modern-js/runtime/browser';
+import { createRoot } from '@modern-js/runtime/react';
+
+const ModernRoot = createRoot();
+
+render(
+  <>
+    <p id="wrapper">custom entry-1</p>
+    <ModernRoot />
+  </>,
+);

--- a/tests/integration/entries/fixtures/app-custom-entries/src/entry-2/entry.server.tsx
+++ b/tests/integration/entries/fixtures/app-custom-entries/src/entry-2/entry.server.tsx
@@ -1,0 +1,17 @@
+import {
+  type HandleRequest,
+  createRequestHandler,
+  renderString,
+} from '@modern-js/runtime/ssr/server';
+
+const handleRequest: HandleRequest = async (request, ServerRoot, options) => {
+  const body = await renderString(request, <ServerRoot />, options);
+  const newBody = `<div id="server">custom entry-2-server</div>${body}`;
+  return new Response(newBody, {
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+    },
+  });
+};
+
+export default createRequestHandler(handleRequest);

--- a/tests/integration/entries/fixtures/app-custom-entries/src/entry-2/entry.tsx
+++ b/tests/integration/entries/fixtures/app-custom-entries/src/entry-2/entry.tsx
@@ -1,0 +1,11 @@
+import { render } from '@modern-js/runtime/browser';
+import { createRoot } from '@modern-js/runtime/react';
+
+const ModernRoot = createRoot();
+
+render(
+  <>
+    <p id="wrapper">custom entry-2</p>
+    <ModernRoot />
+  </>,
+);

--- a/tests/integration/entries/fixtures/app-custom-entries/src/entry-2/routes/layout.tsx
+++ b/tests/integration/entries/fixtures/app-custom-entries/src/entry-2/routes/layout.tsx
@@ -1,0 +1,9 @@
+import { Outlet } from '@modern-js/runtime/router';
+
+export default () => {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+};

--- a/tests/integration/entries/fixtures/app-custom-entries/src/entry-2/routes/page.tsx
+++ b/tests/integration/entries/fixtures/app-custom-entries/src/entry-2/routes/page.tsx
@@ -1,0 +1,9 @@
+const Page = () => {
+  return (
+    <div>
+      <div id="text">Modern APP-2</div>
+    </div>
+  );
+};
+
+export default Page;

--- a/tests/integration/entries/fixtures/app-custom-entries/src/entry-2/routes/user/page.tsx
+++ b/tests/integration/entries/fixtures/app-custom-entries/src/entry-2/routes/user/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div>User</div>;
+};
+
+export default Page;

--- a/tests/integration/entries/fixtures/app-custom-entries/tsconfig.json
+++ b/tests/integration/entries/fixtures/app-custom-entries/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "outDir": "dist",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": ["src", "tests", "modern.config.ts"]
+}

--- a/tests/integration/entries/tests/app-custom-entries.test.ts
+++ b/tests/integration/entries/tests/app-custom-entries.test.ts
@@ -1,0 +1,76 @@
+import path from 'path';
+import puppeteer, { type Browser, type Page } from 'puppeteer';
+import {
+  getPort,
+  killApp,
+  launchApp,
+  launchOptions,
+} from '../../../utils/modernTestUtils';
+
+const fixtures = path.resolve(__dirname, '../fixtures');
+
+describe('app-custom-entries', () => {
+  let app: unknown;
+  let page: Page;
+  let browser: Browser;
+  let appPort: number;
+  beforeAll(async () => {
+    const appDir = path.join(fixtures, 'app-custom-entries');
+    appPort = await getPort();
+    app = await launchApp(appDir, appPort);
+
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
+  });
+  afterAll(async () => {
+    if (browser) {
+      browser.close();
+    }
+    if (app) {
+      await killApp(app);
+    }
+  });
+
+  test('main', async () => {
+    await page.goto(`http://localhost:${appPort}`, {
+      waitUntil: ['networkidle0'],
+    });
+    const root = await page.$('#root');
+    const targetText = await page.evaluate(el => el?.textContent, root);
+    expect(targetText?.trim()).toEqual('Modern APP');
+  });
+  test('entry-1', async () => {
+    await page.goto(`http://localhost:${appPort}/entry-1`, {
+      waitUntil: ['networkidle0'],
+    });
+    const text = await page.$('#text');
+    const targetText = await page.evaluate(el => el?.textContent, text);
+    const wrapper = await page.$('#wrapper');
+    const targetTextWrapper = await page.evaluate(
+      el => el?.textContent,
+      wrapper,
+    );
+    const server = await page.$('#server');
+    const targetTextServer = await page.evaluate(el => el?.textContent, server);
+    expect(targetText?.trim()).toEqual('Modern APP-1');
+    expect(targetTextWrapper?.trim()).toEqual('custom entry-1');
+    expect(targetTextServer?.trim()).toEqual('custom entry-1-server');
+  });
+  test('entry-2', async () => {
+    await page.goto(`http://localhost:${appPort}/entry-2`, {
+      waitUntil: ['networkidle0'],
+    });
+    const text = await page.$('#text');
+    const targetText = await page.evaluate(el => el?.textContent, text);
+    const wrapper = await page.$('#wrapper');
+    const targetTextWrapper = await page.evaluate(
+      el => el?.textContent,
+      wrapper,
+    );
+    const server = await page.$('#server');
+    const targetTextServer = await page.evaluate(el => el?.textContent, server);
+    expect(targetText?.trim()).toEqual('Modern APP-2');
+    expect(targetTextWrapper?.trim()).toEqual('custom entry-2');
+    expect(targetTextServer?.trim()).toEqual('custom entry-2-server');
+  });
+});


### PR DESCRIPTION
## Summary

#### Background

In Modern.js, when a developer uses `source.disableDefaultEntries: true` and defines custom entries via `source.entries`, the framework currently does not automatically discover and use conventional entry files like `entry.tsx` (client entry) or `entry.server.tsx` (server entry) from the entry's corresponding directory. This prevents custom entries from leveraging the framework's convention-based entry capabilities.

#### Solution

This PR introduces a new boolean option, `customEntry`, for each entry object defined in `source.entries`.

When `customEntry` is set to `true`, it re-enables the framework's conventional entry discovery logic for that specific entry:

1.  **Auto-discover Client Entry**: The framework will automatically look for an `entry.tsx` file within the specified entry's directory (or the directory of the specified file). If found, it will be used as the actual client entry, overriding the original value of the `entry` field.
2.  **Auto-discover Server Entry**: Similarly, the framework will also look for an `entry.server.tsx` file in the same directory and use it as the entry for Server-Side Rendering (SSR).

#### Usage

Enable this feature by setting `customEntry: true` for a specific entry.

**Example 1: `entry` points to a directory**
```ts
// modern.config.ts
export default {
  source: {
    disableDefaultEntries: true,
    entries: {
      'my-entry': {
        entry: './src/my-entry/routes',
        customEntry: true, 
      },
    },
  },
};
```

**Example 2: `entry` points to a file**
```ts
// modern.config.ts
export default {
  source: {
    disableDefaultEntries: true,
    entries: {
      'my-entry': {
        entry: './src/my-entry/App.tsx',
        customEntry: true, 
      },
    },
  },
};
```

In both of the scenarios above, the framework will inspect the `src/my-entry/` directory. If an `entry.tsx` file exists, it will be used as the client entry. Additionally, if an `entry.server.tsx` file exists, it will be automatically used as the server entry.

---

#### 变更背景 (Background)

在 Modern.js 中，当开发者使用 `source.disableDefaultEntries: true` 并通过 `source.entries` 来指定自定义入口时，框架当前不会自动查找并使用该入口对应目录下的 `entry.tsx` (客户端入口) 或 `entry.server.tsx` (服务端入口) 文件。这使得自定义入口无法利用框架的约定入口能力。

#### 解决方案 (Solution)

此 PR 引入了一个新的配置项 `customEntry: boolean`，用于 `source.entries` 中的每个入口对象。

当 `customEntry` 设置为 `true` 时，它会为该入口重新启用框架的常规入口发现逻辑：

1.  **自动查找客户端入口**: 框架会自动在指定的入口目录（或指定文件所在的目录）下查找 `entry.tsx` 文件。如果找到，它将被用作实际的客户端入口，并覆盖 `entry` 字段的原始值。
2.  **自动查找服务端入口**: 同样地，框架也会在该目录下查找 `entry.server.tsx` 文件，并将其用作服务端渲染 (SSR) 的入口。

#### 如何使用 (Usage)

通过为指定的入口设置 `customEntry: true` 来启用此功能。

**示例 1: `entry` 指向一个目录**
```ts
// modern.config.ts
export default {
  source: {
    disableDefaultEntries: true,
    entries: {
      'my-entry': {
        entry: './src/my-entry/routes',
        customEntry: true, 
      },
    },
  },
};
```

**示例 2: `entry` 指向一个文件**
```ts
// modern.config.ts
export default {
  source: {
    disableDefaultEntries: true,
    entries: {
      'my-entry': {
        entry: './src/my-entry/App.tsx',
        customEntry: true, 
      },
    },
  },
};
```

在以上两种情况中，框架都会检查 `src/my-entry/` 目录。如果 `entry.tsx` 文件存在，它将被用作客户端入口。同时，如果 `entry.server.tsx` 文件存在，它将被自动用作服务端入口。

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
