### PR TITLE
fix: status should be 404 when render the DefaultNotFound page

### DIFF
--- a/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
@@ -55,7 +55,14 @@ export function getRouteComponents(
       routeElements.push(routeElement);
     }
   }
-  routeElements.push(<Route key="*" path="*" element={<DefaultNotFound />} />);
+  routeElements.push(
+    <Route
+      key="*"
+      path="*"
+      element={<DefaultNotFound />}
+      loader={() => new Response('404', { status: 404 })}
+    />,
+  );
   return routeElements;
 }
 


### PR DESCRIPTION
## Summary

This PR is mainly to solve the issue at https://github.com/web-infra-dev/modern.js/issues/7136, when rendering the default 404 page, the HTML status code should also be 404.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
