### PR TITLE
fix: maintain string return type for afterStreamingRender for backward compatibility

### DIFF
--- a/.changeset/clear-roses-buy.md
+++ b/.changeset/clear-roses-buy.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: compatibility afterStreamingRender return string type
+fix: 兼容 afterStreamingRender 返回 string 类型


### PR DESCRIPTION
## Summary

According to the type definition of ServerPluginLegacy hooks afterStreamingRender, it's will return string. 
https://github.com/web-infra-dev/modern.js/blob/v2/packages/server/core/src/types/plugins/old.ts#L73-L78

So we need do compatibility to ensure it's can run correctly in old plugin.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
