### PR TITLE
fix: server hooks not get when run onPrepare

### DIFF
--- a/.changeset/mighty-lamps-make.md
+++ b/.changeset/mighty-lamps-make.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: server hooks not get when run onPrepare
+
+fix: 修复服务端插件在 onPrepare 中获取 hooks 失败

--- a/packages/server/core/src/serverBase.ts
+++ b/packages/server/core/src/serverBase.ts
@@ -63,9 +63,9 @@ export class ServerBase<E extends Env = any> {
       handleSetupResult,
     });
     serverContext.serverBase = this;
+    this.serverContext = serverContext as unknown as ServerContext;
     // need after serverContext to run onPrepare
     await serverContext.hooks.onPrepare.call();
-    this.serverContext = serverContext as unknown as ServerContext;
     this.#applyMiddlewares();
 
     return this;


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
