### PR TITLE
fix: remove resolve.modules from default builder config

### DIFF
--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterBasic.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterBasic.ts
@@ -31,11 +31,6 @@ export const builderPluginAdapterBasic = (
       const { appContext } = options;
       const { metaName } = appContext;
 
-      // This helps symlinked packages to resolve packages correctly, such as `react/jsx-runtime`, typically for monorepo.
-      chain.resolve.modules
-        .add('node_modules')
-        .add(path.join(api.context.rootPath, 'node_modules'));
-
       chain.watchOptions({
         ignored: [
           `[\\\\/](?:node_modules(?![\\\\/]\\.${metaName})|.git)[\\\\/]`,

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -290,5 +290,17 @@
     "jest": "^29.7.0",
     "typescript": "^5"
   },
+  "peerDependencies": {
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
+  },
   "sideEffects": false
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2423,6 +2423,12 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      react:
+        specifier: ^19.2.0
+        version: 19.2.0
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.0(react@19.2.0)
       rslog:
         specifier: ^1.2.11
         version: 1.2.11
@@ -4710,6 +4716,12 @@ importers:
       '@source-code-build/utils':
         specifier: workspace:*
         version: link:../utils
+      react:
+        specifier: ^19.2.0
+        version: 19.2.0
+      react-dom:
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
 
   tests/integration/source-code-build/utils:
     devDependencies:

--- a/tests/integration/source-code-build/components/package.json
+++ b/tests/integration/source-code-build/components/package.json
@@ -27,5 +27,9 @@
   },
   "dependencies": {
     "@source-code-build/utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^19.2.0",
+    "react-dom": "19.2.0"
   }
 }


### PR DESCRIPTION
## Summary

In order to avoid the project in monorepo from using an unexpected dependency version, remove `resolve.modules` from the default configuration.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
