### PR TITLE
fix: stream ssr concat buffer first

### DIFF
--- a/.changeset/soft-plums-go.md
+++ b/.changeset/soft-plums-go.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: stream ssr should concat buffer first, then stringify buffer
+fix: stream ssr 先拼接 buffer, 再将 buffer 处理成字符串


### PR DESCRIPTION
## Summary
- stream ssr should concat buffer first, then stringify buffer

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
