### PR TITLE
fix: stream ssr should concat buffer first

### DIFF
--- a/.changeset/grumpy-regions-join.md
+++ b/.changeset/grumpy-regions-join.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: stream ssr should concat buffer first, then stringify buffer
+fix: stream ssr 先拼接 buffer, 再将 buffer 处理成字符串

--- a/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
@@ -63,7 +63,7 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
       }
     });
 
-    const chunkVec: string[] = [];
+    const chunkVec: Buffer[] = [];
 
     return new Promise(resolve => {
       const { pipe: reactStreamingPipe } = renderToPipeableStream(
@@ -94,17 +94,19 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
                 transform(chunk, _encoding, callback) {
                   try {
                     if (shellChunkStatus !== ShellChunkStatus.FINISH) {
-                      chunkVec.push(chunk.toString());
-                      /**
+                      chunkVec.push(
+                        Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
+                      ); /**
                        * The shell content of App may be splitted by multiple chunks to transform,
                        * when any node value's size is larger than the React limitation, refer to:
                        * https://github.com/facebook/react/blob/v18.2.0/packages/react-server/src/ReactServerStreamConfigNode.js#L53.
                        * So we use the `SHELL_STREAM_END_MARK` to mark the shell content' tail.
                        */
-                      let concatedChunk = chunkVec.join('');
-                      if (
-                        concatedChunk.includes(ESCAPED_SHELL_STREAM_END_MARK)
-                      ) {
+                      const chunkStr = chunk.toString('utf-8');
+                      if (chunkStr.includes(ESCAPED_SHELL_STREAM_END_MARK)) {
+                        let concatedChunk = Buffer.concat(
+                          chunkVec as any,
+                        ).toString('utf-8');
                         concatedChunk = concatedChunk.replace(
                           ESCAPED_SHELL_STREAM_END_MARK,
                           '',


### PR DESCRIPTION
## Summary
- stream ssr should concat buffer first, then stringify buffer

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
