### PR TITLE
fix: static resource requests should not be valid loader requests

### DIFF
--- a/.changeset/yummy-apples-eat.md
+++ b/.changeset/yummy-apples-eat.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-data-loader': patch
+---
+
+fix: static resource requests should not be valid loader requests.
+fix: 静态资源请求不应该是合法的 loader 请求

--- a/packages/cli/plugin-data-loader/src/runtime/index.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/index.ts
@@ -52,6 +52,18 @@ function convertModernRedirectResponse(headers: Headers, basename: string) {
   });
 }
 
+export function hasFileExtension(pathname: string): boolean {
+  const lastSegment = pathname.split('/').pop() || '';
+  const dotIndex = lastSegment.lastIndexOf('.');
+
+  if (dotIndex === -1) {
+    return false;
+  }
+
+  const extension = lastSegment.substring(dotIndex).toLowerCase();
+  return extension !== '.html';
+}
+
 export const handleRequest: ServerLoaderBundle['handleRequest'] = async ({
   request,
   serverRoutes,
@@ -61,6 +73,13 @@ export const handleRequest: ServerLoaderBundle['handleRequest'] = async ({
 }): Promise<Response | void> => {
   const url = new URL(request.url);
   const routeId = url.searchParams.get(LOADER_ID_PARAM) as string;
+
+  // Check if pathname has file extension (excluding .html)
+  // Reject requests like /three/user/profile.js but allow /three/user/profile
+  if (hasFileExtension(url.pathname)) {
+    return;
+  }
+
   const entry = matchEntry(url.pathname, serverRoutes);
   // LOADER_ID_PARAM is the indicator for CSR data loader request.
   if (!routeId || !entry) {


### PR DESCRIPTION
## Summary

Filter requests from static resources to avoid being treated as loader requests.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
