### PR TITLE
fix: avoid caching unexpected response result

### DIFF
--- a/.changeset/busy-animals-stand.md
+++ b/.changeset/busy-animals-stand.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: Avoid caching unexpected responses
+fix: 避免不受期待的响应被缓存

--- a/packages/server/core/src/plugins/render/ssrRender.ts
+++ b/packages/server/core/src/plugins/render/ssrRender.ts
@@ -18,7 +18,7 @@ import type {
   RequestHandlerOptions,
 } from '../../types/requestHandler';
 import { getPathname, parseHeaders } from '../../utils';
-import { getCacheResult, matchCacheControl } from './ssrCache';
+import { getCacheResult, matchCacheControl, shouldUseCache } from './ssrCache';
 import { createRequestHandlerConfig } from './utils';
 
 // TODO: It's a type combine by RenderOptions and CreateRenderOptions, improve it.
@@ -135,7 +135,7 @@ export async function ssrRender(
 
   let response: Response;
 
-  if (cacheControl) {
+  if (cacheControl && shouldUseCache(request)) {
     response = await getCacheResult(request, {
       cacheControl,
       container: cacheConfig?.container,


### PR DESCRIPTION
## Summary

1. Avoid caching responses with unexpected HTTP status codes
2. Skip cache processing for RSC (React Server Components) requests

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
