### PR TITLE
feat: i18n plugin support backend sdk

### DIFF
--- a/packages/runtime/plugin-i18n/src/runtime/i18n/backend/index.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/i18n/backend/index.ts
@@ -7,6 +7,18 @@ export const mergeBackendOptions = (
   backend?: BaseBackendOptions,
   userInitOptions?: I18nInitOptions,
 ) => {
+  const hasSdkFunction =
+    typeof userInitOptions?.backend?.sdk === 'function' ||
+    (backend?.enabled && backend?.sdk && typeof backend.sdk === 'function');
+
+  if (hasSdkFunction) {
+    return baseMergeBackendOptions(
+      {} as BackendOptions,
+      backend as BackendOptions,
+      userInitOptions?.backend,
+    );
+  }
+
   const mergedBackend = backend?.enabled
     ? baseMergeBackendOptions(
         DEFAULT_I18NEXT_BACKEND_OPTIONS,

--- a/packages/runtime/plugin-i18n/src/runtime/i18n/backend/middleware.node.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/i18n/backend/middleware.node.ts
@@ -1,6 +1,14 @@
 import Backend from 'i18next-fs-backend';
+import type { BaseBackendOptions } from '../../../shared/type';
 import type { I18nInstance } from '../instance';
+import { SdkBackend } from './sdk-backend';
 
-export const useI18nextBackend = (i18nInstance: I18nInstance) => {
+export const useI18nextBackend = (
+  i18nInstance: I18nInstance,
+  backend?: BaseBackendOptions,
+) => {
+  if (backend?.sdk && typeof backend.sdk === 'function') {
+    return i18nInstance.use(SdkBackend);
+  }
   return i18nInstance.use(Backend);
 };

--- a/packages/runtime/plugin-i18n/src/runtime/i18n/backend/middleware.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/i18n/backend/middleware.ts
@@ -1,6 +1,14 @@
 import Backend from 'i18next-http-backend';
+import type { BaseBackendOptions } from '../../../shared/type';
 import type { I18nInstance } from '../instance';
+import { SdkBackend } from './sdk-backend';
 
-export const useI18nextBackend = (i18nInstance: I18nInstance) => {
+export const useI18nextBackend = (
+  i18nInstance: I18nInstance,
+  backend?: BaseBackendOptions,
+) => {
+  if (backend?.sdk && typeof backend.sdk === 'function') {
+    return i18nInstance.use(SdkBackend);
+  }
   return i18nInstance.use(Backend);
 };

--- a/packages/runtime/plugin-i18n/src/runtime/i18n/backend/sdk-backend.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/i18n/backend/sdk-backend.ts
@@ -1,0 +1,197 @@
+import type { I18nSdkLoadOptions, I18nSdkLoader } from '../../../shared/type';
+import type { Resources } from '../instance';
+
+/**
+ * i18next backend options interface
+ */
+interface BackendOptions {
+  sdk?: I18nSdkLoader;
+  [key: string]: unknown;
+}
+
+/**
+ * Custom i18next backend that uses SDK to load resources
+ */
+export class SdkBackend {
+  static type = 'backend';
+  type = 'backend' as const;
+  sdk?: I18nSdkLoader;
+  private allResourcesCache: Resources | null = null;
+  private loadingPromises = new Map<string, Promise<unknown>>();
+
+  constructor(_services: unknown, _options: Record<string, unknown>) {
+    void _services;
+    void _options;
+  }
+
+  init(
+    _services: unknown,
+    backendOptions: BackendOptions,
+    _i18nextOptions: unknown,
+  ): void {
+    void _services;
+    void _i18nextOptions;
+    this.sdk = backendOptions?.sdk;
+    if (!this.sdk) {
+      throw new Error(
+        'SdkBackend requires an SDK function to be provided in backend options',
+      );
+    }
+  }
+
+  read(
+    language: string,
+    namespace: string,
+    callback: (error: Error | null, data: unknown) => void,
+  ) {
+    if (!this.sdk) {
+      callback(new Error('SDK function not initialized'), null);
+      return;
+    }
+
+    if (this.allResourcesCache) {
+      const cached = this.extractFromCache(language, namespace);
+      if (cached !== null) {
+        callback(null, cached);
+        return;
+      }
+    }
+
+    const cacheKey = `${language}:${namespace}`;
+    const existingPromise = this.loadingPromises.get(cacheKey);
+    if (existingPromise) {
+      existingPromise
+        .then(data => {
+          const formattedData = this.formatResources(data, language, namespace);
+          callback(null, formattedData);
+        })
+        .catch(error => {
+          callback(
+            error instanceof Error ? error : new Error(String(error)),
+            null,
+          );
+        });
+      return;
+    }
+
+    try {
+      const result = this.callSdk(language, namespace);
+      const loadPromise =
+        result instanceof Promise ? result : Promise.resolve(result);
+
+      this.loadingPromises.set(cacheKey, loadPromise);
+
+      loadPromise
+        .then(data => {
+          const formattedData = this.formatResources(data, language, namespace);
+          this.updateCache(language, namespace, formattedData);
+          this.loadingPromises.delete(cacheKey);
+          callback(null, formattedData);
+        })
+        .catch(error => {
+          this.loadingPromises.delete(cacheKey);
+          callback(
+            error instanceof Error ? error : new Error(String(error)),
+            null,
+          );
+        });
+    } catch (error) {
+      callback(error instanceof Error ? error : new Error(String(error)), null);
+    }
+  }
+
+  private callSdk(
+    language: string,
+    namespace: string,
+  ): Promise<Resources> | Resources {
+    if (!this.sdk) {
+      throw new Error('SDK function not initialized');
+    }
+
+    const options: I18nSdkLoadOptions = { lng: language, ns: namespace };
+    return this.sdk(options);
+  }
+
+  private extractFromCache(
+    language: string,
+    namespace: string,
+  ): Record<string, string> | null {
+    if (!this.allResourcesCache) {
+      return null;
+    }
+
+    const langData = this.allResourcesCache[language];
+    if (!langData || typeof langData !== 'object') {
+      return null;
+    }
+
+    const nsData = langData[namespace];
+    if (!nsData || typeof nsData !== 'object') {
+      return null;
+    }
+
+    return nsData as Record<string, string>;
+  }
+
+  private updateCache(
+    language: string,
+    namespace: string,
+    data: unknown,
+  ): void {
+    if (!this.allResourcesCache) {
+      this.allResourcesCache = {};
+    }
+
+    if (!this.allResourcesCache[language]) {
+      this.allResourcesCache[language] = {};
+    }
+
+    if (data && typeof data === 'object') {
+      this.allResourcesCache[language][namespace] = data as Record<
+        string,
+        string
+      >;
+    }
+  }
+
+  private formatResources(
+    data: unknown,
+    language: string,
+    namespace: string,
+  ): Record<string, string> {
+    if (!data || typeof data !== 'object') {
+      return {};
+    }
+
+    const dataObj = data as Record<string, unknown>;
+
+    const langData = dataObj[language];
+    if (langData && typeof langData === 'object') {
+      const nsData = (langData as Record<string, unknown>)[namespace];
+      if (nsData && typeof nsData === 'object') {
+        return nsData as Record<string, string>;
+      }
+    }
+
+    const hasLanguageKeys = Object.keys(dataObj).some(
+      key => dataObj[key] && typeof dataObj[key] === 'object',
+    );
+    if (!hasLanguageKeys) {
+      return dataObj as Record<string, string>;
+    }
+
+    return {};
+  }
+
+  create(
+    _languages: string[],
+    _namespace: string,
+    _key: string,
+    _fallbackValue: string,
+  ): void {
+    // Not implemented - translations are managed by the external SDK service.
+    // This method is called by i18next when saveMissing is enabled and addPath is configured.
+    // For SDK backend, missing translations should be managed through the external SDK service,
+    // not saved at runtime.
+  }
+}

--- a/packages/runtime/plugin-i18n/src/shared/type.ts
+++ b/packages/runtime/plugin-i18n/src/shared/type.ts
@@ -1,4 +1,7 @@
-import type { LanguageDetectorOptions } from '../runtime/i18n/instance';
+import type {
+  LanguageDetectorOptions,
+  Resources,
+} from '../runtime/i18n/instance';
 
 export interface BaseLocaleDetectionOptions {
   localePathRedirect?: boolean;
@@ -12,10 +15,115 @@ export interface LocaleDetectionOptions extends BaseLocaleDetectionOptions {
   localeDetectionByEntry?: Record<string, BaseLocaleDetectionOptions>;
 }
 
+/**
+ * Options for loading i18n resources via SDK
+ */
+export interface I18nSdkLoadOptions {
+  /** Single language code to load (e.g., 'en', 'zh') */
+  lng?: string;
+  /** Single namespace to load (e.g., 'translation', 'common') */
+  ns?: string;
+  /** Multiple language codes to load */
+  lngs?: string[];
+  /** Multiple namespaces to load */
+  nss?: string[];
+  /** Load all available languages and namespaces */
+  all?: boolean;
+}
+
+/**
+ * SDK function to load i18n resources
+ * Supports multiple loading modes:
+ * 1. Single resource: sdk({ lng: 'en', ns: 'translation' })
+ * 2. Batch by languages: sdk({ lngs: ['en', 'zh'], ns: 'translation' })
+ * 3. Batch by namespaces: sdk({ lng: 'en', nss: ['translation', 'common'] })
+ * 4. Batch by both: sdk({ lngs: ['en', 'zh'], nss: ['translation', 'common'] })
+ * 5. Load all: sdk({ all: true }) or sdk()
+ *
+ * @param options - Loading options
+ * @returns Promise that resolves to resources object or the resources object directly
+ *          Resources format: { [lng]: { [ns]: { [key]: value } } }
+ */
+export type I18nSdkLoader = (
+  options: I18nSdkLoadOptions,
+) => Promise<Resources> | Resources;
+
 export interface BaseBackendOptions {
   enabled?: boolean;
   loadPath?: string;
   addPath?: string;
+  /**
+   * SDK function to load i18n resources dynamically
+   *
+   * **Important**: In `modern.config.ts`, you can only set this to `true` or any identifier
+   * to enable SDK mode. The actual SDK function must be provided in `modern.runtime.ts`
+   * via `initOptions.backend.sdk`.
+   *
+   * When provided, this will be used instead of the default HTTP/FS backend
+   *
+   * @example In modern.config.ts - enable SDK mode
+   * ```ts
+   * backend: {
+   *   enabled: true,
+   *   sdk: true, // or any identifier, just to enable SDK mode
+   * }
+   * ```
+   *
+   * @example In modern.runtime.ts - provide the actual SDK function
+   * ```ts
+   * export default defineRuntimeConfig({
+   *   i18n: {
+   *     initOptions: {
+   *       backend: {
+   *         sdk: async (options) => {
+   *           // Your SDK implementation
+   *           if (options.all) {
+   *             return await mySdk.getAllResources();
+   *           }
+   *           if (options.lng && options.ns) {
+   *             return await mySdk.getResource(options.lng, options.ns);
+   *           }
+   *           // Handle other cases...
+   *         }
+   *       }
+   *     }
+   *   }
+   * });
+   * ```
+   *
+   * @example Single resource loading
+   * ```ts
+   * sdk: async (options) => {
+   *   if (options.lng && options.ns) {
+   *     const response = await fetch(`/api/i18n/${options.lng}/${options.ns}`);
+   *     return response.json();
+   *   }
+   * }
+   * ```
+   *
+   * @example Load all resources at once
+   * ```ts
+   * sdk: async (options) => {
+   *   if (options?.all) {
+   *     // Load all languages and namespaces
+   *     return await mySdk.getAllResources();
+   *   }
+   *   // Handle other cases...
+   * }
+   * ```
+   *
+   * @example Batch loading
+   * ```ts
+   * sdk: async (options) => {
+   *   if (options?.lngs && options?.nss) {
+   *     // Load multiple languages and namespaces
+   *     return await mySdk.getBatchResources(options.lngs, options.nss);
+   *   }
+   *   // Handle single or other cases...
+   * }
+   * ```
+   */
+  sdk?: I18nSdkLoader | boolean | string;
 }
 
 export interface BackendOptions extends BaseBackendOptions {

--- a/tests/integration/i18n/routes-csr/modern.config.ts
+++ b/tests/integration/i18n/routes-csr/modern.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
         languages: ['zh', 'en'],
         fallbackLanguage: 'en',
       },
+      backend: {
+        enabled: true,
+        sdk: true,
+      },
     }),
   ],
 });

--- a/tests/integration/i18n/routes-csr/src/mock-sdk.ts
+++ b/tests/integration/i18n/routes-csr/src/mock-sdk.ts
@@ -1,0 +1,56 @@
+import type {
+  I18nSdkLoadOptions,
+  I18nSdkLoader,
+  Resources,
+} from '@modern-js/plugin-i18n/runtime';
+
+/**
+ * Mock SDK loader for testing
+ * Simulates loading i18n resources from an external SDK
+ */
+export const createMockSdkLoader = (): I18nSdkLoader => {
+  const mockResources: Resources = {
+    en: {
+      translation: {
+        key: 'Hello World',
+        about: 'About',
+      },
+    },
+    zh: {
+      translation: {
+        key: '你好，世界',
+        about: '关于',
+      },
+    },
+  };
+
+  return async (options: I18nSdkLoadOptions): Promise<Resources> => {
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    if (options.all || (!options.lng && !options.lngs)) {
+      return mockResources;
+    }
+
+    if (options.lngs) {
+      const namespaces = options.nss || [options.ns || 'translation'];
+      const result: Resources = {};
+      for (const lng of options.lngs) {
+        result[lng] = {};
+        for (const ns of namespaces) {
+          result[lng][ns] = mockResources[lng]?.[ns] || {};
+        }
+      }
+      return result;
+    }
+
+    const lng = options.lng || 'en';
+    const namespaces = options.nss || [options.ns || 'translation'];
+    const result: Resources = {
+      [lng]: {},
+    };
+    for (const ns of namespaces) {
+      result[lng][ns] = mockResources[lng]?.[ns] || {};
+    }
+    return result;
+  };
+};

--- a/tests/integration/i18n/routes-csr/src/modern.runtime.tsx
+++ b/tests/integration/i18n/routes-csr/src/modern.runtime.tsx
@@ -1,23 +1,13 @@
 import { defineRuntimeConfig } from '@modern-js/runtime';
 import i18next from 'i18next';
+import { createMockSdkLoader } from './mock-sdk';
 
 export default defineRuntimeConfig({
   i18n: {
     i18nInstance: i18next,
     initOptions: {
-      resources: {
-        en: {
-          translation: {
-            key: 'Hello World',
-            about: 'About',
-          },
-        },
-        zh: {
-          translation: {
-            key: '你好，世界',
-            about: '关于',
-          },
-        },
+      backend: {
+        sdk: createMockSdkLoader(),
       },
     },
   },


### PR DESCRIPTION
## Summary
本 PR 为 i18n 插件添加了 SDK backend 支持，允许用户通过自定义 SDK 函数加载翻译资源，而不是使用默认的 HTTP/FS backend。这使得可以集成外部翻译服务和动态资源加载。

### 功能特性

#### 1. 自定义 SDK Backend 实现

- **新的 `SdkBackend` 类**：使用 SDK 函数加载资源的自定义 i18next backend
- **多种加载模式**：支持单个资源、按语言/命名空间批量加载，以及一次性加载所有资源
- **缓存机制**：实现资源缓存以避免重复请求
- **Promise 去重**：防止对同一资源的多个并发请求

#### 2. 配置支持

- **在 `modern.config.ts` 中启用 SDK 模式**：将 `backend.sdk` 设置为 `true` 或任何标识符以启用 SDK 模式
- **在 `modern.runtime.ts` 中提供 SDK 函数**：通过 `initOptions.backend.sdk` 传递实际的 SDK 函数
- **向后兼容**：现有的 HTTP/FS backend 配置继续工作

#### 3. SDK Loader 接口

SDK 函数支持灵活的加载选项：

```typescript
type I18nSdkLoader = (options: I18nSdkLoadOptions) => Promise<Resources> | Resources;

interface I18nSdkLoadOptions {
  lng?: string;        // 单个语言
  ns?: string;         // 单个命名空间
  lngs?: string[];     // 多个语言
  nss?: string[];      // 多个命名空间
  all?: boolean;       // 加载所有资源
}
```

#### 4. 加载模式

1. **单个资源**：`sdk({ lng: 'en', ns: 'translation' })`
2. **按语言批量**：`sdk({ lngs: ['en', 'zh'], ns: 'translation' })`
3. **按命名空间批量**：`sdk({ lng: 'en', nss: ['translation', 'common'] })`
4. **同时按语言和命名空间批量**：`sdk({ lngs: ['en', 'zh'], nss: ['translation', 'common'] })`
5. **加载全部**：`sdk({ all: true })` 或 `sdk()`

### 使用方法

#### 步骤 1：在 `modern.config.ts` 中启用 SDK 模式

```typescript
export default defineConfig({
  plugins: [
    pluginI18n({
      localeDetection: {
        languages: ['zh', 'en'],
        fallbackLanguage: 'en',
      },
      backend: {
        enabled: true,
        sdk: true, // 启用 SDK 模式
      },
    }),
  ],
});
```

#### 步骤 2：在 `modern.runtime.ts` 中提供 SDK 函数

```typescript
import { defineRuntimeConfig } from '@modern-js/runtime';

export default defineRuntimeConfig({
  i18n: {
    initOptions: {
      backend: {
        sdk: async (options) => {
          // 您的 SDK 实现
          if (options.all) {
            return await mySdk.getAllResources();
          }
          if (options.lng && options.ns) {
            return await mySdk.getResource(options.lng, options.ns);
          }
          // 处理其他情况...
        },
      },
    },
  },
});
```

### 实现细节

#### Backend 选择逻辑

- 当通过 `userInitOptions.backend.sdk` 提供 SDK 函数时，使用 SDK backend
- 否则，回退到默认的 HTTP/FS backend
- SDK 模式不需要 `loadPath` 或 `addPath` 配置

#### 资源格式

SDK 函数应返回 i18next 格式的资源：

```typescript
{
  [lng]: {
    [ns]: {
      [key]: value
    }
  }
}
```

示例：
```typescript
{
  en: {
    translation: {
      key: 'Hello World',
      about: 'About',
    },
  },
  zh: {
    translation: {
      key: '你好，世界',
      about: '关于',
    },
  },
}
```

---

This PR adds SDK backend support to the i18n plugin, allowing users to load translation resources through custom SDK functions instead of the default HTTP/FS backend. This enables integration with external translation services and dynamic resource loading.

### Features

#### 1. Custom SDK Backend Implementation

- **New `SdkBackend` class**: A custom i18next backend that uses SDK functions to load resources
- **Multiple loading modes**: Supports single resource, batch loading by languages/namespaces, and loading all resources at once
- **Caching mechanism**: Implements resource caching to avoid duplicate requests
- **Promise deduplication**: Prevents multiple simultaneous requests for the same resource

#### 2. Configuration Support

- **Enable SDK mode in `modern.config.ts`**: Set `backend.sdk` to `true` or any identifier to enable SDK mode
- **Provide SDK function in `modern.runtime.ts`**: Pass the actual SDK function via `initOptions.backend.sdk`
- **Backward compatible**: Existing HTTP/FS backend configurations continue to work

#### 3. SDK Loader Interface

The SDK function supports flexible loading options:

```typescript
type I18nSdkLoader = (options: I18nSdkLoadOptions) => Promise<Resources> | Resources;

interface I18nSdkLoadOptions {
  lng?: string;        // Single language
  ns?: string;         // Single namespace
  lngs?: string[];     // Multiple languages
  nss?: string[];      // Multiple namespaces
  all?: boolean;       // Load all resources
}
```

#### 4. Loading Modes

1. **Single resource**: `sdk({ lng: 'en', ns: 'translation' })`
2. **Batch by languages**: `sdk({ lngs: ['en', 'zh'], ns: 'translation' })`
3. **Batch by namespaces**: `sdk({ lng: 'en', nss: ['translation', 'common'] })`
4. **Batch by both**: `sdk({ lngs: ['en', 'zh'], nss: ['translation', 'common'] })`
5. **Load all**: `sdk({ all: true })` or `sdk()`

### Usage

#### Step 1: Enable SDK mode in `modern.config.ts`

```typescript
export default defineConfig({
  plugins: [
    pluginI18n({
      localeDetection: {
        languages: ['zh', 'en'],
        fallbackLanguage: 'en',
      },
      backend: {
        enabled: true,
        sdk: true, // Enable SDK mode
      },
    }),
  ],
});
```

#### Step 2: Provide SDK function in `modern.runtime.ts`

```typescript
import { defineRuntimeConfig } from '@modern-js/runtime';

export default defineRuntimeConfig({
  i18n: {
    initOptions: {
      backend: {
        sdk: async (options) => {
          // Your SDK implementation
          if (options.all) {
            return await mySdk.getAllResources();
          }
          if (options.lng && options.ns) {
            return await mySdk.getResource(options.lng, options.ns);
          }
          // Handle other cases...
        },
      },
    },
  },
});
```

### Implementation Details

#### Backend Selection Logic

- When SDK function is provided via `userInitOptions.backend.sdk`, the SDK backend is used
- Otherwise, falls back to default HTTP/FS backend
- SDK mode doesn't require `loadPath` or `addPath` configuration

#### Resource Format

The SDK function should return resources in i18next format:

```typescript
{
  [lng]: {
    [ns]: {
      [key]: value
    }
  }
}
```

Example:
```typescript
{
  en: {
    translation: {
      key: 'Hello World',
      about: 'About',
    },
  },
  zh: {
    translation: {
      key: '你好，世界',
      about: '关于',
    },
  },
}
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
