### PR TITLE
fix: server.port should be passed to rsbuild

### DIFF
--- a/packages/cli/builder/src/shared/devServer.ts
+++ b/packages/cli/builder/src/shared/devServer.ts
@@ -20,13 +20,16 @@ const defaultDevConfig = {
 export const transformToRsbuildServerOptions = (
   dev: NonNullable<BuilderConfig['dev']>,
   devServer: ToolsDevServerConfig,
+  server?: BuilderConfig['server'],
 ): {
   rsbuildDev: DevConfig;
   rsbuildServer: ServerConfig;
 } => {
   const { host, https, startUrl, beforeStartUrl, ...devConfig } = dev;
 
-  const port = process.env.PORT ? Number(process.env.PORT) : 8080;
+  const port = process.env.PORT
+    ? Number(process.env.PORT)
+    : (server?.port ?? 8080);
   const rsbuildDev: DevConfig = merge(defaultDevConfig, devConfig);
   // setupMiddlewares apply by @modern-js/server
   delete rsbuildDev.setupMiddlewares;

--- a/packages/cli/builder/src/shared/parseCommonConfig.ts
+++ b/packages/cli/builder/src/shared/parseCommonConfig.ts
@@ -188,6 +188,7 @@ export async function parseCommonConfig(
   const { rsbuildDev, rsbuildServer } = transformToRsbuildServerOptions(
     dev || {},
     devServer || {},
+    builderConfig.server,
   );
 
   rsbuildConfig.server = removeUndefinedKey(rsbuildServer);

--- a/packages/cli/builder/src/types.ts
+++ b/packages/cli/builder/src/types.ts
@@ -271,6 +271,7 @@ export type BuilderConfig = {
   };
   server?: {
     rsc?: boolean;
+    port?: number;
   };
   performance?: RsbuildConfig['performance'];
   security?: Omit<SecurityConfig, 'sri'>;


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
