### PR TITLE
fix: should read html templates only in getHtmlTemplates function

### DIFF
--- a/.changeset/evil-pugs-appear.md
+++ b/.changeset/evil-pugs-appear.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: should read html templates only in getHtmlTemplates function
+fix: 在 getHtmlTemplates 函数中读取 html 模板

--- a/packages/server/core/src/adapters/node/plugins/resource.ts
+++ b/packages/server/core/src/adapters/node/plugins/resource.ts
@@ -20,8 +20,12 @@ import type {
 import { uniqueKeyByRoute } from '../../../utils';
 
 export async function getHtmlTemplates(pwd: string, routes: ServerRoute[]) {
+  // Only process routes with entryName, which are HTML template routes.
+  // Public static file routes don't have entryName and shouldn't be processed here.
+  const htmlRoutes = routes.filter(route => route.entryName);
+
   const htmls = await Promise.all(
-    routes.map(async route => {
+    htmlRoutes.map(async route => {
       let html: string | undefined;
       try {
         const htmlPath = path.join(pwd, route.entryPath);


### PR DESCRIPTION
## Summary

fix: https://github.com/web-infra-dev/modern.js/issues/7954

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
