### PR TITLE
perf: server monitor add more tags for timing/counter event

### DIFF
--- a/.changeset/silent-tables-dress.md
+++ b/.changeset/silent-tables-dress.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/types': patch
+'@modern-js/server-core': patch
+---
+
+perf: server monitor add more tags for timing/counter event
+perf: server monitor 为 timing/couter 事件添加更多的 tags

--- a/packages/server/core/src/plugins/monitors.ts
+++ b/packages/server/core/src/plugins/monitors.ts
@@ -58,25 +58,33 @@ function createMonitors(): Monitors {
       log('trace', message, args);
     },
 
-    timing(name: string, dur: number, desc?: string, ...args: any[]) {
+    timing(
+      name: string,
+      dur: number,
+      desc?: string,
+      tags?: Record<string, any>,
+      ...args: any[]
+    ) {
       const event: TimingEvent = {
         type: 'timing',
         payload: {
           name,
           dur,
           desc,
+          tags,
           args,
         },
       };
       coreMonitors.forEach(monitor => monitor(event));
     },
 
-    counter(name: string, ...args: any[]) {
+    counter(name: string, tags?: Record<string, any>, ...args: any[]) {
       const event: CounterEvent = {
         type: 'counter',
         payload: {
           name,
           args,
+          tags,
         },
       };
       coreMonitors.forEach(monitor => monitor(event));

--- a/packages/toolkit/types/server/monitor.d.ts
+++ b/packages/toolkit/types/server/monitor.d.ts
@@ -16,6 +16,7 @@ export interface TimingEvent {
     name: string;
     dur: number;
     desc?: string;
+    tags?: Record<string, any>;
     args?: any[];
   };
 }
@@ -24,6 +25,7 @@ export interface CounterEvent {
   type: 'counter';
   payload: {
     name: string;
+    tags?: Record<string, any>;
     args?: any[];
   };
 }
@@ -43,6 +45,12 @@ export interface Monitors {
   trace(message: string, ...args: any[]): void;
 
   // 打点事件
-  timing(name: string, dur: number, ...args: any[]): void;
-  counter(name: string, ...args: any[]): void;
+  timing(
+    name: string,
+    dur: number,
+    desc?: string,
+    tags?: Record<string, any>,
+    ...args: any[]
+  ): void;
+  counter(name: string, tags?: Record<string, any>, ...args: any[]): void;
 }


### PR DESCRIPTION
## Summary

Add tags for timing/counter event.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
