### PR TITLE
chore: re-export rsbuildRscPlugin for compatibility with other framework

### DIFF
--- a/.changeset/spicy-pigs-return.md
+++ b/.changeset/spicy-pigs-return.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+chore: re-exports rsbuildRscPlugin for other framework
+chore: 为其他框架重导出 rsbuildRscPlugin

--- a/packages/cli/uni-builder/package.json
+++ b/packages/cli/uni-builder/package.json
@@ -19,6 +19,16 @@
       "default": "./dist/shared/rsc/index.js"
     }
   },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./dist/index.d.ts"
+      ],
+      "rsc": [
+        "./dist/shared/rsc/index.d.ts"
+      ]
+    }
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/cli/uni-builder/src/shared/rsc/index.ts
+++ b/packages/cli/uni-builder/src/shared/rsc/index.ts
@@ -1,2 +1,3 @@
 export { RscClientPlugin } from './plugins/rsc-client-plugin';
 export { RscServerPlugin } from './plugins/rsc-server-plugin';
+export { rsbuildRscPlugin } from './plugins/rsbuild-rsc-plugin';


### PR DESCRIPTION


## Summary

Re-exports rsbuildRscPlugin for other framework, Other framework using rsbuildRscPlugin to build rsc function.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
