### PR TITLE
docs: update documentation to reflect deprecation of webpack

### DIFF
--- a/packages/document/main-doc/docs/en/configure/app/tools/webpack-chain.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/webpack-chain.mdx
@@ -17,6 +17,10 @@ Compared with `tools.webpack`, **webpack-chain not only supports chained calls, 
 
 > `tools.webpackChain` is executed earlier than tools.webpack and thus will be overridden by changes in `tools.webpack`.
 
+:::tip
+Modern.js has deprecated support for webpack, which will be removed in the next major version. It is recommended to use Rspack as the bundler.
+:::
+
 ### Utils
 
 #### env

--- a/packages/document/main-doc/docs/en/configure/app/tools/webpack.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/webpack.mdx
@@ -6,7 +6,7 @@ title: webpack
 
 import { Badge } from '@theme';
 
-<Badge type="danger" >Webpack Only</Badge>
+<Badge type="danger">Webpack Only</Badge>
 
 - **Type:** `Object | Function | undefined`
 - **Default:** `undefined`
@@ -14,6 +14,10 @@ import { Badge } from '@theme';
 `tools.webpack` is used to configure [webpack](https://webpack.js.org/).
 
 > `tools.bundlerChain` is also used to modify the webpack configuration, and the function is more powerful. It is recommended to use `tools.bundlerChain` first.
+
+:::tip
+Modern.js has deprecated support for webpack, which will be removed in the next major version. It is recommended to use Rspack as the bundler.
+:::
 
 ### Object Type
 

--- a/packages/document/main-doc/docs/en/guides/concept/builder.mdx
+++ b/packages/document/main-doc/docs/en/guides/concept/builder.mdx
@@ -2,12 +2,12 @@
 sidebar_position: 2
 ---
 
-# Build Engine
+# Build Tool
 
-Modern.js internally encapsulates [Rsbuild](https://rsbuild.rs/), and supports seamless switching between Webpack and Rspack bundlers.
+Modern.js internally encapsulates [Rsbuild](https://rsbuild.rs/), and supports seamless switching between Rspack and webpack.
 
-::: tip What is Rsbuild?
-Rsbuild is a build tool based on Rspack. It is an enhanced Rspack CLI, easy-to-use, and ready-to-use out of the box.
+:::tip
+Modern.js has deprecated support for webpack, which will be removed in the next major version. It is recommended to use Rspack as the bundler.
 :::
 
 ## Build Architecture
@@ -16,7 +16,7 @@ From the building perspective, Modern.js can be divided into three-layers, from 
 
 - Upper-level framework: Modern.js (open source) and EdenX (internal).
 - Build tool: Rsbuild.
-- Bundler: Webpack and Rspack.
+- Bundler: Rspack and webpack.
 
 <img
   src="https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/build-layers-02193.png"

--- a/packages/document/main-doc/docs/en/guides/get-started/quick-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/get-started/quick-start.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 ## Environment
 
-import Prerequisites from "@site-docs-en/components/prerequisites"
+import Prerequisites from '@site-docs-en/components/prerequisites';
 
 <Prerequisites />
 
@@ -30,13 +30,13 @@ npx @modern-js/create@latest myapp
 
 ## Initialize
 
-import InitApp from "@site-docs-en/components/init-app"
+import InitApp from '@site-docs-en/components/init-app';
 
 <InitApp />
 
 ## Development
 
-import DebugApp from "@site-docs-en/components/debug-app"
+import DebugApp from '@site-docs-en/components/debug-app';
 
 <DebugApp />
 
@@ -56,9 +56,11 @@ export default defineConfig({
   server: {
     ssr: true,
   },
-  plugins: [appTools({
-      bundler: 'rspack', // Set to 'webpack' to enable webpack
-  }),],
+  plugins: [
+    appTools({
+      bundler: 'rspack',
+    }),
+  ],
 });
 ```
 
@@ -152,6 +154,6 @@ Open `http://localhost:8080/` in the browser, and the content should be consiste
 
 ## Deployment
 
-import Deploy from "@site-docs-en/components/deploy"
+import Deploy from '@site-docs-en/components/deploy';
 
 <Deploy />

--- a/packages/document/main-doc/docs/en/guides/get-started/tech-stack.mdx
+++ b/packages/document/main-doc/docs/en/guides/get-started/tech-stack.mdx
@@ -38,9 +38,11 @@ We recommend using pnpm for faster installation speed.
 
 ## Bundler
 
-Modern.js uses [Webpack 5](https://webpack.js.org/) or [Rspack](https://rspack.rs/) to bundle your web applications.
+Modern.js uses [Rspack](https://rspack.rs/) or [webpack 5](https://webpack.js.org/) to bundle your web applications.
 
-The default bundler used is Webpack 5. You can refer to ["Using Rspack"](/en/guides/advanced-features/rspack-start) to switch to the faster Rspack.
+:::tip
+Modern.js has deprecated support for webpack, which will be removed in the next major version. It is recommended to use Rspack as the bundler.
+:::
 
 ## Transpiler
 

--- a/packages/document/main-doc/docs/en/guides/topic-detail/module-federation/usage.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/module-federation/usage.mdx
@@ -206,7 +206,7 @@ export default defineConfig({
   },
   plugins: [
     appTools({
-      bundler: 'rspack', // Set to 'webpack' to enable webpack
+      bundler: 'rspack',
     }),
     moduleFederationPlugin(),
   ],

--- a/packages/document/main-doc/docs/zh/configure/app/tools/webpack-chain.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/webpack-chain.mdx
@@ -20,6 +20,10 @@ import { Badge } from '@theme';
 
 > `tools.webpackChain` 的执行时机早于 tools.webpack，因此会被 `tools.webpack` 中的修改所覆盖。
 
+:::tip
+Modern.js 对于 webpack 的支持已经废弃，并将在下一个大版本中移除，推荐优先使用 Rspack 作为打包工具。
+:::
+
 ### 工具集合
 
 #### env

--- a/packages/document/main-doc/docs/zh/configure/app/tools/webpack.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/webpack.mdx
@@ -6,7 +6,7 @@ title: webpack
 
 import { Badge } from '@theme';
 
-<Badge type="danger" >仅支持 Webpack</Badge>
+<Badge type="danger">仅支持 Webpack</Badge>
 
 - **类型：** `Object | Function | undefined`
 - **默认值：** `undefined`
@@ -14,6 +14,10 @@ import { Badge } from '@theme';
 `tools.webpack` 选项用于配置原生的 [webpack](https://webpack.js.org/)。
 
 > `tools.bundlerChain` 同样可以修改 webpack 配置，并且功能更加强大，建议优先使用 `tools.bundlerChain`。
+
+:::tip
+Modern.js 对于 webpack 的支持已经废弃，并将在下一个大版本中移除，推荐优先使用 Rspack 作为打包工具。
+:::
 
 ### Object 类型
 

--- a/packages/document/main-doc/docs/zh/guides/concept/builder.mdx
+++ b/packages/document/main-doc/docs/zh/guides/concept/builder.mdx
@@ -4,10 +4,10 @@ sidebar_position: 2
 
 # 构建工具
 
-Modern.js 构建是基于 [Rsbuild](https://rsbuild.rs/) 实现的，并支持在 Webpack 和 Rspack 两种打包工具间无缝切换。
+Modern.js 构建是基于 [Rsbuild](https://rsbuild.rs/) 实现的，并支持在 Rspack 和 webpack 两种打包工具间无缝切换。
 
-:::tip 什么是 Rsbuild
-Rsbuild 是基于 Rspack 的构建工具，是一个增强版的 Rspack CLI，更易用、开箱即用。
+:::tip
+Modern.js 对于 webpack 的支持已经废弃，并将在下一个大版本中移除，推荐优先使用 Rspack 作为打包工具。
 :::
 
 ## 构建架构
@@ -16,7 +16,7 @@ Rsbuild 是基于 Rspack 的构建工具，是一个增强版的 Rspack CLI，�
 
 - 研发框架：Modern.js（开源）和 EdenX（内部）。
 - 构建工具：Rsbuild。
-- 打包工具：Webpack 和 Rspack。
+- 打包工具：Rspack 和 webpack。
 
 <img
   src="https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/build-layers-02193.png"

--- a/packages/document/main-doc/docs/zh/guides/get-started/quick-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/get-started/quick-start.mdx
@@ -58,7 +58,7 @@ export default defineConfig({
   },
   plugins: [
     appTools({
-      bundler: 'rspack', // Set to 'webpack' to enable webpack
+      bundler: 'rspack',
     }),
   ],
 });

--- a/packages/document/main-doc/docs/zh/guides/get-started/tech-stack.mdx
+++ b/packages/document/main-doc/docs/zh/guides/get-started/tech-stack.mdx
@@ -38,9 +38,11 @@ Modern.js 可以与社区中任意的包管理器搭配使用，比如 [npm](htt
 
 ## 打包工具
 
-Modern.js 使用 [Webpack 5](https://webpack.js.org/) 或 [Rspack](https://rspack.rs/) 来打包你的 Web 应用。
+Modern.js 使用 [Rspack](https://rspack.rs/) 或 [webpack 5](https://webpack.js.org/) 来打包你的 Web 应用。
 
-默认使用的打包工具为 Webpack 5，你可以参考 [使用 Rspack](/guides/advanced-features/rspack-start) 来切换到更快的 Rspack。
+:::tip
+Modern.js 对于 webpack 的支持已经废弃，并将在下一个大版本中移除，推荐优先使用 Rspack 作为打包工具。
+:::
 
 ## 转译工具
 

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/module-federation/usage.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/module-federation/usage.mdx
@@ -31,7 +31,6 @@ export default defineConfig({
     moduleFederationPlugin(),
   ],
 });
-
 ```
 
 ## 生产者导出模块
@@ -205,7 +204,7 @@ export default defineConfig({
   },
   plugins: [
     appTools({
-      bundler: 'rspack', // Set to 'webpack' to enable webpack
+      bundler: 'rspack',
     }),
     moduleFederationPlugin(),
   ],

--- a/packages/generator/generators/mwa-generator/src/index.ts
+++ b/packages/generator/generators/mwa-generator/src/index.ts
@@ -90,7 +90,7 @@ export const handleTemplateFile = async (
   const { packageName, packagePath, language, packageManager } = ans;
   const { packagesInfo } = context.config;
 
-  const bundler = `'rspack', // Set to 'webpack' to enable webpack`;
+  const bundler = `'rspack',`;
 
   const projectPath = getMWAProjectPath(
     packagePath as string,


### PR DESCRIPTION
## Summary

Update documentation and template to reflect deprecation of webpack. Modern.js will remove webpack support in the next major release.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
