### PR TITLE
chore: update rsc code to adapter other framework

### DIFF
--- a/.changeset/wet-carrots-bow.md
+++ b/.changeset/wet-carrots-bow.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/prod-server': patch
+'@modern-js/uni-builder': patch
+'@modern-js/server-core': patch
+---
+
+chore: update rsc code to adapter other framework
+
+chore: 更新 rsc 相关代码适配更多框架

--- a/packages/cli/uni-builder/src/shared/rsc/plugins/rsbuild-rsc-plugin.ts
+++ b/packages/cli/uni-builder/src/shared/rsc/plugins/rsbuild-rsc-plugin.ts
@@ -57,7 +57,7 @@ export const rsbuildRscPlugin = ({
 
   setup(api) {
     api.modifyBundlerChain({
-      handler: async (chain, { isServer, CHAIN_ID }) => {
+      handler: async (chain, { isServer, CHAIN_ID, isWebWorker }) => {
         if (!(await checkReactVersionAtLeast19(appDir))) {
           logger.error(
             'Enable react server component, please make sure the react and react-dom versions are greater than or equal to 19.0.0',
@@ -204,7 +204,7 @@ export const rsbuildRscPlugin = ({
           flightCssHandler();
           jsHandler();
           addServerRscPlugin();
-        } else {
+        } else if (!isWebWorker) {
           chain.name('client');
           chain.dependencies(['server']);
           addRscClientLoader();

--- a/packages/server/core/src/adapters/node/plugins/resource.ts
+++ b/packages/server/core/src/adapters/node/plugins/resource.ts
@@ -170,15 +170,16 @@ export async function getRscSSRManifest(pwd: string) {
   return rscSSRManifest;
 }
 
-export const injectRscManifestPlugin = (): ServerPluginLegacy => ({
+export const injectRscManifestPlugin = (
+  enableRsc: boolean,
+): ServerPluginLegacy => ({
   name: '@modern-js/plugin-inject-rsc-manifest',
   setup(api) {
     return {
       async prepare() {
         const { middlewares, distDirectory: pwd } = api.useAppContext();
-        const config = api.useConfigContext();
         // only rsc project need inject rsc manifest
-        if (!config.server?.rsc) {
+        if (!enableRsc) {
           return;
         }
 

--- a/packages/server/prod-server/src/apply.ts
+++ b/packages/server/prod-server/src/apply.ts
@@ -38,8 +38,9 @@ export async function applyPlugins(
   options: ProdServerOptions,
   nodeServer?: NodeServer | Http2SecureServer,
 ) {
-  const { pwd, appContext, config, logger: optLogger } = options;
+  const { pwd, appContext, config, logger: optLogger, serverConfig } = options;
 
+  const enableRsc = config.server?.rsc ?? serverConfig?.server?.rsc ?? false;
   const serverErrorHandler = options.serverConfig?.onError;
   const loadCachePwd = isProd() ? pwd : appContext.appDirectory || pwd;
   const cacheConfig = await loadCacheConfig(loadCachePwd);
@@ -93,7 +94,7 @@ export async function applyPlugins(
     injectConfigMiddlewarePlugin(middlewares, renderMiddlewares),
     ...(options.plugins || []),
     injectResourcePlugin(),
-    injectRscManifestPlugin(),
+    injectRscManifestPlugin(enableRsc),
     serverStaticPlugin(),
     faviconPlugin(),
     renderPlugin(),


### PR DESCRIPTION
## Summary

- Only client compiler should apply rscClientplugin 
- Should not injectServerManifest using `config.server.rsc` in plugin inside.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
