### PR TITLE
fix: ensure csrRender skip non-RSC pages

### DIFF
--- a/.changeset/thick-islands-tease.md
+++ b/.changeset/thick-islands-tease.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: MPA should apply csrRender function for every single page
+fix: MPA 项目一个为每个单页面应用不同的 csrRender 逻辑

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -424,7 +424,11 @@ async function csrRender(
   options: SSRRenderOptions,
 ): Promise<Response> {
   const { html, rscClientManifest } = options;
-  if (!rscClientManifest || process.env.MODERN_DISABLE_INJECT_RSC_DATA) {
+  if (
+    !rscClientManifest ||
+    process.env.MODERN_DISABLE_INJECT_RSC_DATA ||
+    !options.routeInfo.isRSC
+  ) {
     return new Response(html, {
       status: 200,
       headers: new Headers({


### PR DESCRIPTION
## Summary

Ensures CSR rendering skips RSC data injection for non-RSC MPA pages by gating on routeInfo.isRSC, preventing unwanted RSC payload in regular CSR pages; 

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
