### PR TITLE
fix(scripts): check-dependencies not work on windows cmd

### DIFF
--- a/scripts/check-dependencies.js
+++ b/scripts/check-dependencies.js
@@ -10,7 +10,7 @@ const ignoreDeps = [
 ];
 
 const command = `npx check-dependency-version-consistency@latest . ${ignoreDeps
-  .map(dep => `--ignore-dep '${dep}'`)
+  .map(dep => `--ignore-dep "${dep}"`)
   .join(' ')}`;
 
 console.log(`> ${command}`);


### PR DESCRIPTION
## Summary

脚本中使用单引号。在Windows CMD命令行下，单引号不能作为字符串分隔符，仅支持双引号。因此该脚本会报错：`Specified option '--ignore-dep 'fs-extra'', but no version mismatches detected for this dependency.`

The script uses single quotes. In the Windows CMD command line, single quotes cannot be used as string delimiters; only double quotes are supported. Therefore, the script will report the following error: `Specified option '--ignore-dep 'fs-extra'', but no version mismatches detected for this dependency.`

<img width="831" height="86" alt="image" src="https://github.com/user-attachments/assets/ec6f96e2-e4fd-48bb-ab18-b86424ca291a" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
