### PR TITLE
fix: skip sri plugin application for webpack in rsbuild

### DIFF
--- a/tests/e2e/builder/cases/sri/index.test.ts
+++ b/tests/e2e/builder/cases/sri/index.test.ts
@@ -13,6 +13,11 @@ test('security.sri', async ({ page }) => {
       },
     },
   });
+  // SKIP for webpack
+  // sri plugin no longer applied for webpack in rsbuild
+  if (process.env.PROVIDE_TYPE !== 'rspack') {
+    return;
+  }
 
   const files = await builder.unwrapOutputJSON();
   const htmlFileName = Object.keys(files).find(f => f.endsWith('.html'))!;


### PR DESCRIPTION
## Summary

sri plugin only apply rspack in rsbuild

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
