### PR TITLE
chore: remove `jsnext:source` field

### DIFF
--- a/packages/cli/plugin-bff/package.json
+++ b/packages/cli/plugin-bff/package.json
@@ -16,14 +16,12 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/cli.ts",
   "types": "./src/cli.ts",
   "main": "./dist/cjs/cli.js",
   "module": "./dist/esm-node/cli.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/cli.d.ts",
-      "jsnext:source": "./src/cli.ts",
       "node": {
         "import": "./dist/esm-node/cli.mjs",
         "require": "./dist/cjs/cli.js"
@@ -32,7 +30,6 @@
     },
     "./cli": {
       "types": "./dist/types/cli.d.ts",
-      "jsnext:source": "./src/cli.ts",
       "node": {
         "import": "./dist/esm-node/cli.mjs",
         "require": "./dist/cjs/cli.js"
@@ -41,7 +38,6 @@
     },
     "./server-plugin": {
       "types": "./dist/types/server.d.ts",
-      "jsnext:source": "./src/server.ts",
       "node": {
         "import": "./dist/esm-node/server.mjs",
         "require": "./dist/cjs/server.js"
@@ -50,7 +46,6 @@
     },
     "./loader": {
       "types": "./dist/types/loader.d.ts",
-      "jsnext:source": "./src/loader.ts",
       "node": {
         "import": "./dist/esm-node/loader.mjs",
         "require": "./dist/cjs/loader.js"
@@ -59,7 +54,6 @@
     },
     "./server": {
       "types": "./dist/types/runtime/hono/index.d.ts",
-      "jsnext:source": "./src/runtime/hono/index.ts",
       "node": {
         "import": "./dist/esm-node/runtime/hono/index.mjs",
         "require": "./dist/cjs/runtime/hono/index.js"
@@ -68,7 +62,6 @@
     },
     "./client": {
       "types": "./dist/types/create-request/index.d.ts",
-      "jsnext:source": "./src/runtime/create-request/index.ts",
       "node": {
         "import": "./dist/esm-node/runtime/create-request/index.mjs",
         "require": "./dist/cjs/runtime/create-request/index.js"

--- a/packages/cli/plugin-data-loader/package.json
+++ b/packages/cli/plugin-data-loader/package.json
@@ -19,19 +19,16 @@
   "engines": {
     "node": ">=20"
   },
-  "jsnext:source": "./src/runtime/index.ts",
   "types": "./src/runtime/index.ts",
   "main": "./dist/cjs/runtime/index.js",
   "module": "./dist/esm/runtime/index.mjs",
   "exports": {
     "./loader": {
       "types": "./dist/types/cli/loader.d.ts",
-      "jsnext:source": "./src/cli/loader.ts",
       "default": "./dist/cjs/cli/loader.js"
     },
     "./runtime": {
       "types": "./dist/types/runtime/index.d.ts",
-      "jsnext:source": "./src/runtime/index.ts",
       "default": "./dist/esm/runtime/index.mjs"
     }
   },

--- a/packages/cli/plugin-ssg/package.json
+++ b/packages/cli/plugin-ssg/package.json
@@ -16,7 +16,6 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
@@ -33,7 +32,6 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "jsnext:source": "./src/index.ts",
       "node": {
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
@@ -42,7 +40,6 @@
     },
     "./cli": {
       "types": "./dist/types/index.d.ts",
-      "jsnext:source": "./src/index.ts",
       "node": {
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
@@ -51,7 +48,6 @@
     },
     "./types": {
       "types": "./dist/types/types.d.ts",
-      "jsnext:source": "./src/types.ts",
       "node": {
         "import": "./dist/esm-node/types.mjs",
         "require": "./dist/cjs/types.js"

--- a/packages/cli/plugin-styled-components/package.json
+++ b/packages/cli/plugin-styled-components/package.json
@@ -9,7 +9,6 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
@@ -43,7 +42,6 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "jsnext:source": "./src/index.ts",
       "node": {
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
@@ -52,7 +50,6 @@
     },
     "./runtime": {
       "types": "./dist/types/runtime.d.ts",
-      "jsnext:source": "./src/runtime.ts",
       "node": {
         "import": "./dist/esm-node/runtime.mjs",
         "require": "./dist/cjs/runtime.js"
@@ -61,7 +58,6 @@
     },
     "./styled": {
       "types": "./dist/types/styled.d.ts",
-      "jsnext:source": "./src/styled.ts",
       "node": {
         "import": "./dist/esm-node/styled.mjs",
         "require": "./dist/cjs/styled.js"

--- a/packages/runtime/plugin-i18n/package.json
+++ b/packages/runtime/plugin-i18n/package.json
@@ -20,39 +20,33 @@
   "engines": {
     "node": ">=20"
   },
-  "jsnext:source": "./src/cli/index.ts",
   "types": "./src/cli/index.ts",
   "main": "./dist/cjs/cli/index.cjs",
   "module": "./dist/esm/cli/index.js",
   "exports": {
     ".": {
       "types": "./dist/types/cli/index.d.ts",
-      "jsnext:source": "./src/cli/index.ts",
       "default": "./dist/cjs/cli/index.cjs"
     },
     "./package.json": "./package.json",
     "./cli": {
       "types": "./dist/types/cli/index.d.ts",
-      "jsnext:source": "./src/cli/index.ts",
       "default": "./dist/cjs/cli/index.cjs"
     },
     "./runtime": {
       "types": "./dist/types/runtime/index.d.ts",
-      "jsnext:source": "./src/runtime/index.ts",
       "import": "./dist/esm/runtime/index.js",
       "node": "./dist/esm-node/runtime/index.js",
       "default": "./dist/esm/runtime/index.js"
     },
     "./server": {
       "types": "./dist/types/server/index.d.ts",
-      "jsnext:source": "./src/server/index.ts",
       "import": "./dist/esm/server/index.js",
       "node": "./dist/esm-node/server/index.js",
       "default": "./dist/esm/server/index.js"
     },
     "./i18n": {
       "types": "./dist/types/runtime/i18n/index.d.ts",
-      "jsnext:source": "./src/runtime/i18n/index.ts",
       "import": "./dist/esm/runtime/i18n/index.js",
       "node": "./dist/esm-node/runtime/i18n/index.js",
       "default": "./dist/esm/runtime/i18n/index.js"

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -19,7 +19,6 @@
   "engines": {
     "node": ">=20"
   },
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
@@ -27,123 +26,100 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "react-server": "./dist/esm/react-server.mjs",
-      "jsnext:source": "./src/index.ts",
       "default": "./dist/esm/index.mjs"
     },
     "./internal": {
       "types": "./dist/types/internal.d.ts",
-      "jsnext:source": "./src/internal.ts",
       "default": "./dist/esm/internal.mjs"
     },
     "./package.json": "./package.json",
     "./context": {
       "types": "./dist/types/core/context/index.d.ts",
-      "jsnext:source": "./src/core/context/index.ts",
       "default": "./dist/esm/core/context/index.mjs"
     },
     "./plugin": {
       "types": "./dist/types/core/plugin/index.d.ts",
-      "jsnext:source": "./src/core/plugin/index.ts",
       "default": "./dist/esm/core/plugin/index.mjs"
     },
     "./react": {
       "types": "./dist/types/core/react/index.d.ts",
-      "jsnext:source": "./src/core/react/index.ts",
       "default": "./dist/esm/core/react/index.mjs"
     },
     "./browser": {
       "types": "./dist/types/core/browser/index.d.ts",
-      "jsnext:source": "./src/core/browser/index.ts",
       "default": "./dist/esm/core/browser/index.mjs"
     },
     "./loadable": {
       "types": "./dist/types/exports/loadable.d.ts",
-      "jsnext:source": "./src/exports/loadable.ts",
       "default": "./dist/esm/exports/loadable.mjs"
     },
     "./head": {
       "types": "./dist/types/exports/head.d.ts",
-      "jsnext:source": "./src/exports/head.ts",
       "default": "./dist/esm/exports/head.mjs"
     },
     "./server": {
       "types": "./dist/types/exports/server.d.ts",
-      "jsnext:source": "./src/exports/server.ts",
       "node": "./dist/cjs/exports/server.js",
       "default": "./dist/esm/exports/server.mjs"
     },
     "./ssr": {
       "types": "./dist/types/core/server/index.d.ts",
-      "jsnext:source": "./src/core/server/index.ts",
       "default": "./dist/esm/core/server/index.mjs"
     },
     "./ssr/server": {
       "types": "./dist/types/core/server/server.d.ts",
-      "jsnext:source": "./src/core/server/server.ts",
       "default": "./dist/esm/core/server/server.mjs"
     },
     "./document": {
       "types": "./dist/types/document/index.d.ts",
-      "jsnext:source": "./src/document/index.ts",
       "require": "./dist/cjs/document/index.js",
       "import": "./dist/esm/document/index.mjs",
       "default": "./dist/esm/document/index.mjs"
     },
     "./cli": {
       "types": "./dist/types/cli/index.d.ts",
-      "jsnext:source": "./src/cli/index.ts",
       "default": "./dist/cjs/cli/index.js"
     },
     "./router": {
       "types": "./dist/types/router/index.d.ts",
-      "jsnext:source": "./src/router/index.ts",
       "react-server": {
         "types": "./dist/types/router/runtime/rsc.d.ts",
-        "jsnext:source": "./src/router/runtime/rsc.ts",
         "default": "./dist/esm/router/runtime/rsc.mjs"
       },
       "default": "./dist/esm/router/index.mjs"
     },
     "./router/server": {
       "types": "./dist/types/router/runtime/server.d.ts",
-      "jsnext:source": "./src/router/runtime/server.ts",
       "default": "./dist/esm/router/runtime/server.mjs"
     },
     "./router/internal": {
       "types": "./dist/types/router/internal.d.ts",
-      "jsnext:source": "./src/router/internal.ts",
       "default": "./dist/esm/router/internal.mjs"
     },
     "./routerHelper": {
       "types": "./dist/types/router/runtime/routerHelper.d.ts",
-      "jsnext:source": "./src/router/runtime/routerHelper.ts",
       "default": "./dist/esm/router/runtime/routerHelper.mjs"
     },
     "./loadable-bundler-plugin": {
       "types": "./dist/types/cli/ssr/loadable-bundler-plugin.d.ts",
-      "jsnext:source": "./src/cli/ssr/loadable-bundler-plugin.ts",
       "node": "./dist/cjs/cli/ssr/loadable-bundler-plugin.js",
       "default": "./dist/cjs/cli/ssr/loadable-bundler-plugin.mjs"
     },
     "./rsc/server": {
       "types": "./dist/types/rsc/server.d.ts",
-      "jsnext:source": "./src/rsc/server.ts",
       "default": "./dist/esm/rsc/server.mjs"
     },
     "./rsc/client": {
       "types": "./dist/types/rsc/client.d.ts",
-      "jsnext:source": "./src/rsc/client.ts",
       "default": "./dist/esm/rsc/client.mjs"
     },
     "./cache": {
       "types": "./dist/types/cache/index.d.ts",
-      "jsnext:source": "./src/cache/index.ts",
       "require": "./dist/cjs/cache/index.js",
       "default": "./dist/esm/cache/index.mjs"
     },
     "./config-routes": {
       "types": "./dist/types/exports/config-routes.d.ts",
-      "jsnext:source": "./src/exports/config-routes.ts",
       "require": "./dist/cjs/exports/config-routes.js",
       "default": "./dist/cjs/exports/config-routes.js"
     }

--- a/packages/runtime/render/package.json
+++ b/packages/runtime/render/package.json
@@ -51,17 +51,14 @@
   "exports": {
     "./ssr": {
       "types": "./dist/types/server/ssr/index.d.ts",
-      "jsnext:source": "./src/server/ssr/index.ts",
       "default": "./dist/esm/server/ssr/index.js"
     },
     "./rsc": {
       "types": "./dist/types/server/rsc/index.d.ts",
-      "jsnext:source": "./src/server/rsc/index.ts",
       "default": "./dist/esm/server/rsc/index.js"
     },
     "./client": {
       "types": "./dist/types/client/index.d.ts",
-      "jsnext:source": "./src/client/index.tsx",
       "default": "./dist/esm/client/index.js"
     }
   },

--- a/packages/server/bff-runtime/package.json
+++ b/packages/server/bff-runtime/package.json
@@ -16,14 +16,12 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "exports": {
     ".": {
       "node": {
-        "jsnext:source": "./src/index.ts",
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
       },

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -16,7 +16,6 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm-node/index.mjs",
@@ -24,18 +23,15 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "modern:source": "./src/index.ts",
-      "jsnext:source": "./src/index.ts",
       "default": "./dist/cjs/index.js"
     },
     "./node": {
       "types": "./dist/types/adapters/node/index.d.ts",
       "modern:source": "./src/adapters/node/index.ts",
-      "jsnext:source": "./src/adapters/node/index.ts",
       "default": "./dist/cjs/adapters/node/index.js"
     },
     "./hono": {
       "types": "./dist/types/hono.d.ts",
-      "jsnext:source": "./src/hono.ts",
       "default": "./dist/cjs/hono.js"
     }
   },

--- a/packages/server/plugin-polyfill/package.json
+++ b/packages/server/plugin-polyfill/package.json
@@ -16,14 +16,12 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/cli.ts",
   "types": "./src/cli.ts",
   "main": "./dist/cjs/cli.js",
   "module": "./dist/esm/cli.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/cli.d.ts",
-      "jsnext:source": "./src/cli.ts",
       "node": {
         "import": "./dist/esm-node/cli.mjs",
         "require": "./dist/cjs/cli.js"
@@ -32,7 +30,6 @@
     },
     "./cli": {
       "types": "./dist/types/cli.d.ts",
-      "jsnext:source": "./src/cli.ts",
       "node": {
         "import": "./dist/esm-node/cli.mjs",
         "require": "./dist/cjs/cli.js"
@@ -41,7 +38,6 @@
     },
     "./server": {
       "types": "./dist/types/index.d.ts",
-      "jsnext:source": "./src/index.ts",
       "node": {
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"

--- a/packages/server/prod-server/package.json
+++ b/packages/server/prod-server/package.json
@@ -16,7 +16,6 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm-node/index.mjs",
@@ -29,7 +28,6 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "jsnext:source": "./src/index.ts",
       "modern:source": "./src/index.ts",
       "node": {
         "import": "./dist/esm-node/index.mjs",
@@ -39,7 +37,6 @@
     },
     "./netlify": {
       "types": "./dist/types/netlify.d.ts",
-      "jsnext:source": "./src/netlify.ts",
       "node": {
         "import": "./dist/esm-node/netlify.mjs",
         "require": "./dist/cjs/netlify.js"

--- a/packages/server/server-runtime/package.json
+++ b/packages/server/server-runtime/package.json
@@ -16,14 +16,12 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm-node/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "jsnext:source": "./src/index.ts",
       "modern:source": "./src/index.ts",
       "node": {
         "import": "./dist/esm-node/index.mjs",
@@ -33,7 +31,6 @@
     },
     "./cache": {
       "types": "./dist/types/cache.d.ts",
-      "jsnext:source": "./src/cache.ts",
       "node": {
         "import": "./dist/esm-node/cache.mjs",
         "require": "./dist/cjs/cache.js"

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -16,7 +16,6 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
@@ -24,7 +23,6 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "modern:source": "./src/index.ts",
-      "jsnext:source": "./src/index.ts",
       "node": {
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
@@ -33,7 +31,6 @@
     },
     "./hmr-client": {
       "types": "./dist/types/dev-tools/dev-middleware/hmr-client/index.d.ts",
-      "jsnext:source": "./src/dev-tools/dev-middleware/hmr-client/index.ts",
       "node": {
         "require": "./dist/cjs/dev-tools/dev-middleware/hmr-client/index.js"
       },

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -16,14 +16,12 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "jsnext:source": "./src/index.ts",
       "modern:source": "./src/index.ts",
       "node": {
         "import": "./dist/esm-node/index.mjs",

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -16,14 +16,12 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm-node/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "jsnext:source": "./src/index.ts",
       "node": {
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
@@ -32,7 +30,6 @@
     },
     "./builder": {
       "types": "./dist/types/builder/index.d.ts",
-      "jsnext:source": "./src/builder/index.ts",
       "node": {
         "import": "./dist/esm-node/builder/index.mjs",
         "require": "./dist/cjs/builder/index.js"
@@ -41,7 +38,6 @@
     },
     "./cli": {
       "types": "./dist/types/index.d.ts",
-      "jsnext:source": "./src/index.ts",
       "node": {
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
@@ -50,7 +46,6 @@
     },
     "./cli/run": {
       "types": "./dist/types/run/index.d.ts",
-      "jsnext:source": "./src/run/index.ts",
       "node": {
         "import": "./dist/esm-node/run/index.mjs",
         "require": "./dist/cjs/run/index.js"
@@ -59,12 +54,10 @@
     },
     "./types": {
       "types": "./lib/types.d.ts",
-      "jsnext:source": "./lib/types.d.ts",
       "default": "./lib/types.d.ts"
     },
     "./server": {
       "types": "./dist/types/exports/server.d.ts",
-      "jsnext:source": "./src/exports/server.ts",
       "node": {
         "import": "./dist/esm-node/exports/server.mjs",
         "require": "./dist/cjs/exports/server.js"

--- a/packages/toolkit/create/bin/run.js
+++ b/packages/toolkit/create/bin/run.js
@@ -9,7 +9,7 @@ const __dirname = path.dirname(__filename);
 const require = createRequire(import.meta.url);
 
 const pkgInfo = require(path.join(__dirname, '../package.json'));
-const srcPath = pkgInfo['jsnext:source'];
+const srcPath = pkgInfo['modern:source'];
 const distPath = pkgInfo.main;
 const project = path.join(__dirname, '../tsconfig.json');
 

--- a/packages/toolkit/create/package.json
+++ b/packages/toolkit/create/package.json
@@ -20,7 +20,6 @@
     "node": ">=20"
   },
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/toolkit/i18n-utils/package.json
+++ b/packages/toolkit/i18n-utils/package.json
@@ -16,7 +16,6 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
@@ -34,7 +33,6 @@
     ".": {
       "node": {
         "modern:source": "./src/index.ts",
-        "jsnext:source": "./src/index.ts",
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
       },
@@ -44,7 +42,6 @@
     "./language-detector": {
       "node": {
         "modern:source": "./src/languageDetector.ts",
-        "jsnext:source": "./src/languageDetector.ts",
         "import": "./dist/esm-node/languageDetector.mjs",
         "require": "./dist/cjs/languageDetector.js"
       },

--- a/packages/toolkit/plugin/package.json
+++ b/packages/toolkit/plugin/package.json
@@ -16,7 +16,6 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm-node/index.mjs",
@@ -25,7 +24,6 @@
       "types": "./dist/types/index.d.ts",
       "node": {
         "modern:source": "./src/index.ts",
-        "jsnext:source": "./src/index.ts",
         "import": "./dist/esm/index.mjs",
         "require": "./dist/cjs/index.js"
       },
@@ -33,19 +31,16 @@
     },
     "./run": {
       "types": "./dist/types/cli/run/index.d.ts",
-      "jsnext:source": "./src/cli/run/index.ts",
       "default": "./dist/cjs/cli/run/index.js"
     },
     "./cli": {
       "types": "./dist/types/cli/index.d.ts",
       "modern:source": "./src/cli/index.ts",
-      "jsnext:source": "./src/cli/index.ts",
       "default": "./dist/cjs/cli/index.js"
     },
     "./runtime": {
       "types": "./dist/types/runtime/index.d.ts",
       "modern:source": "./src/runtime/index.tsx",
-      "jsnext:source": "./src/runtime/index.tsx",
       "node": {
         "import": "./dist/esm/runtime/index.mjs",
         "require": "./dist/cjs/runtime/index.js"
@@ -55,7 +50,6 @@
     "./server": {
       "types": "./dist/types/server/index.d.ts",
       "modern:source": "./src/server/index.ts",
-      "jsnext:source": "./src/server/index.ts",
       "node": {
         "require": "./dist/cjs/server/index.js",
         "default": "./dist/cjs/server/index.js"

--- a/packages/toolkit/runtime-utils/package.json
+++ b/packages/toolkit/runtime-utils/package.json
@@ -21,28 +21,24 @@
     "./router": {
       "types": "./dist/types/router.d.ts",
       "modern:source": "./src/router.ts",
-      "jsnext:source": "./src/router.ts",
       "require": "./dist/cjs/router.js",
       "default": "./dist/esm/router.mjs"
     },
     "./router/rsc": {
       "types": "./dist/types/rsc.d.ts",
       "modern:source": "./src/rsc.ts",
-      "jsnext:source": "./src/rsc.ts",
       "require": "./dist/cjs/rsc.js",
       "default": "./dist/esm/rsc.mjs"
     },
     "./browser": {
       "types": "./dist/types/browser/index.d.ts",
       "modern:source": "./src/browser/index.ts",
-      "jsnext:source": "./src/browser/index.ts",
       "require": "./dist/cjs/browser/index.js",
       "default": "./dist/esm/browser/index.mjs"
     },
     "./node": {
       "types": "./dist/types/node/index.d.ts",
       "modern:source": "./src/node/index.ts",
-      "jsnext:source": "./src/node/index.ts",
       "node": {
         "require": "./dist/cjs/node/index.js",
         "import": "./dist/esm/node/index.mjs"
@@ -52,41 +48,35 @@
     "./server": {
       "types": "./dist/types/server/index.d.ts",
       "modern:source": "./src/server/index.ts",
-      "jsnext:source": "./src/server/index.ts",
       "require": "./dist/cjs/server/index.js",
       "default": "./dist/esm/server/index.mjs"
     },
     "./time": {
       "types": "./dist/types/time.d.ts",
       "modern:source": "./src/time.ts",
-      "jsnext:source": "./src/time.ts",
       "require": "./dist/cjs/time.js",
       "default": "./dist/esm/time.mjs"
     },
     "./universal/request": {
       "types": "./dist/universal/request.d.ts",
       "modern:source": "./src/universal/request.ts",
-      "jsnext:source": "./src/universal/request.ts",
       "require": "./dist/cjs/universal/request.js",
       "default": "./dist/esm/universal/request.mjs"
     },
     "./parsed": {
       "types": "./dist/types/parsed.d.ts",
       "modern:source": "./src/parsed.ts",
-      "jsnext:source": "./src/parsed.ts",
       "require": "./dist/cjs/parsed.js",
       "default": "./dist/esm/parsed.mjs"
     },
     "./storer": {
       "types": "./dist/types/node/storer/index.d.ts",
       "modern:source": "./src/node/storer/index.ts",
-      "jsnext:source": "./src/node/storer/index.ts",
       "require": "./dist/cjs/node/storer/index.js",
       "default": "./dist/esm/node/storer/index.mjs"
     },
     "./fileReader": {
       "modern:source": "./src/node/fileReader.ts",
-      "jsnext:source": "./src/node/fileReader.ts",
       "types": "./dist/types/node/fileReader.d.ts",
       "require": "./dist/cjs/node/fileReader.js",
       "default": "./dist/esm/node/fileReader.mjs"
@@ -94,21 +84,18 @@
     "./url": {
       "types": "./dist/types/url.d.ts",
       "modern:source": "./src/url.ts",
-      "jsnext:source": "./src/url.ts",
       "require": "./dist/cjs/url.js",
       "default": "./dist/esm/url.mjs"
     },
     "./merge": {
       "types": "./dist/types/merge.d.ts",
       "modern:source": "./src/merge.ts",
-      "jsnext:source": "./src/merge.ts",
       "require": "./dist/cjs/merge.js",
       "default": "./dist/esm/merge.mjs"
     },
     "./cache": {
       "types": "./dist/types/universal/cache.d.ts",
       "modern:source": "./src/universal/cache.ts",
-      "jsnext:source": "./src/universal/cache.ts",
       "require": "./dist/cjs/universal/cache.js",
       "default": "./dist/esm/universal/cache.mjs"
     }

--- a/packages/toolkit/sandpack-react/package.json
+++ b/packages/toolkit/sandpack-react/package.json
@@ -16,14 +16,12 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "jsnext:source": "./src/index.ts",
       "node": {
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"

--- a/packages/toolkit/types/package.json
+++ b/packages/toolkit/types/package.json
@@ -24,7 +24,6 @@
     },
     "./server": {
       "types": "./server/index.d.ts",
-      "jsnext:source": "./server/index.d.ts",
       "default": "./server/index.d.ts"
     }
   },

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -16,7 +16,6 @@
     "modern.js"
   ],
   "version": "3.0.0-alpha.1",
-  "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
@@ -24,7 +23,6 @@
   "exports": {
     ".": {
       "modern:source": "./src/index.ts",
-      "jsnext:source": "./src/index.ts",
       "types": "./dist/types/index.d.ts",
       "node": {
         "require": "./dist/cjs/index.js",
@@ -35,41 +33,34 @@
     },
     "./logger": {
       "modern:source": "./src/cli/logger.ts",
-      "jsnext:source": "./src/cli/logger.ts",
       "default": "./dist/cjs/cli/logger.js"
     },
     "./chain-id": {
       "modern:source": "./src/cli/constants/chainId.ts",
-      "jsnext:source": "./src/cli/constants/chainId.ts",
       "default": "./dist/cjs/cli/constants/chainId.js"
     },
     "./require": {
       "modern:source": "./src/cli/require.ts",
-      "jsnext:source": "./src/cli/require.ts",
       "import": "./dist/esm/cli/require.js",
       "default": "./dist/cjs/cli/require.js"
     },
     "./env": {
       "modern:source": "./src/cli/is/env.ts",
-      "jsnext:source": "./src/cli/is/env.ts",
       "import": "./dist/esm/cli/is/env.js",
       "default": "./dist/cjs/cli/is/env.js"
     },
     "./universal": {
       "modern:source": "./src/universal/index.ts",
-      "jsnext:source": "./src/universal/index.ts",
       "import": "./dist/esm/universal/index.mjs",
       "default": "./dist/cjs/universal/index.js"
     },
     "./universal/constants": {
       "modern:source": "./src/universal/constants.ts",
-      "jsnext:source": "./src/universal/constants.ts",
       "import": "./dist/esm/universal/constants.mjs",
       "default": "./dist/cjs/universal/constants.js"
     },
     "./universal/plugin-dag-sort": {
       "modern:source": "./src/universal/pluginDagSort.ts",
-      "jsnext:source": "./src/universal/pluginDagSort.ts",
       "import": "./dist/esm/universal/pluginDagSort.mjs",
       "default": "./dist/cjs/universal/pluginDagSort.js"
     },
@@ -105,12 +96,10 @@
         "default": "./dist/cjs/cli/logger.js"
       },
       "./require": {
-        "jsnext:source": "./src/cli/require.ts",
         "import": "./dist/esm/cli/require.js",
         "default": "./dist/cjs/cli/require.js"
       },
       "./env": {
-        "jsnext:source": "./src/cli/is/env.ts",
         "import": "./dist/esm/cli/is/env.js",
         "default": "./dist/cjs/cli/is/env.js"
       },

--- a/tests/jest.resolver.js
+++ b/tests/jest.resolver.js
@@ -1,7 +1,7 @@
 const enhanceResolve = require('enhanced-resolve');
 
 const resolver = enhanceResolve.create.sync({
-  conditionNames: ['jsnext:source', 'require', 'node', 'default'],
+  conditionNames: ['require', 'node', 'default'],
   extensions: ['.js', '.json', '.node', '.ts', '.tsx'],
 });
 


### PR DESCRIPTION
## Summary

remove `jsnext:source` field. `jsnext:source`  is only used in jest unit test.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
