### PR TITLE
feat(app-tools): add info command to display project entries information

### DIFF
--- a/.changeset/tiny-planes-build.md
+++ b/.changeset/tiny-planes-build.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+feat(app-tools): add info command to display project entries information
+feat(app-tools): 新增 info 命令，用于展示项目的 entries 信息

--- a/packages/solutions/app-tools/src/commands/index.ts
+++ b/packages/solutions/app-tools/src/commands/index.ts
@@ -6,6 +6,7 @@ import type {
   BuildOptions,
   DeployOptions,
   DevOptions,
+  InfoOptions,
   InspectOptions,
 } from '../utils/types';
 
@@ -106,5 +107,18 @@ export const inspectCommand = (
     .action(async (options: InspectOptions) => {
       const { inspect } = await import('./inspect.js');
       inspect(api, options);
+    });
+};
+
+export const infoCommand = (program: Command, api: CLIPluginAPI<AppTools>) => {
+  program
+    .command('info')
+    .usage('[options]')
+    .description(i18n.t(localeKeys.command.info.describe))
+    .option('-c --config <config>', i18n.t(localeKeys.command.shared.config))
+    .option('--json', 'output as JSON format for machine reading')
+    .action(async (options: InfoOptions) => {
+      const { info } = await import('./info.js');
+      await info(api, options);
     });
 };

--- a/packages/solutions/app-tools/src/commands/info.ts
+++ b/packages/solutions/app-tools/src/commands/info.ts
@@ -1,0 +1,165 @@
+import type { CLIPluginAPI } from '@modern-js/plugin';
+import type { Entrypoint } from '@modern-js/types';
+import { getEntryOptions, isApiOnly } from '@modern-js/utils';
+import type { AppNormalizedConfig, AppTools } from '../types';
+import { isMainEntry } from '../utils/routes';
+import type { InfoOptions } from '../utils/types';
+
+export interface EntryInfo {
+  entryName: string;
+  isMainEntry: boolean;
+  entry: string;
+  isAutoMount: boolean;
+  isCustomSourceEntry: boolean;
+  customEntry: boolean;
+  ssr: boolean | 'stream' | 'string';
+  ssg: boolean;
+}
+
+export interface ProjectInfo {
+  entries: EntryInfo[];
+  apiOnly: boolean;
+}
+
+export const info = async (
+  api: CLIPluginAPI<AppTools>,
+  options: InfoOptions = {},
+): Promise<void> => {
+  const normalizedConfig = api.getNormalizedConfig() as AppNormalizedConfig;
+  const appContext = api.getAppContext();
+  const hooks = api.getHooks();
+
+  const apiOnly = await isApiOnly(
+    appContext.appDirectory,
+    normalizedConfig.source?.entriesDir,
+    appContext.apiDirectory,
+  );
+
+  if (apiOnly) {
+    const projectInfo: ProjectInfo = {
+      entries: [],
+      apiOnly: true,
+    };
+    printProjectInfo(projectInfo, options.json);
+    return;
+  }
+
+  const [{ getBundleEntry }] = await Promise.all([
+    import('../plugins/analyze/getBundleEntry.js'),
+  ]);
+
+  // get runtime entry points
+  const { entrypoints } = await hooks.modifyEntrypoints.call({
+    entrypoints: await getBundleEntry(
+      hooks,
+      appContext as any,
+      normalizedConfig,
+    ),
+  });
+
+  const {
+    source: { mainEntryName },
+    server: { ssr, ssrByEntries },
+    output: { ssg, ssgByEntries },
+  } = normalizedConfig;
+  const { packageName } = appContext;
+
+  const entries: EntryInfo[] = entrypoints.map((entrypoint: Entrypoint) => {
+    const { entryName, entry, isAutoMount, isCustomSourceEntry, customEntry } =
+      entrypoint;
+    const isMain = isMainEntry(entryName, mainEntryName);
+
+    // Get SSR options for this entry
+    const ssrOptions = getEntryOptions(
+      entryName,
+      isMain,
+      ssr,
+      ssrByEntries,
+      packageName,
+    );
+
+    // Get SSG options for this entry
+    const ssgOptions = getEntryOptions(
+      entryName,
+      isMain,
+      ssg,
+      ssgByEntries,
+      packageName,
+    );
+
+    // Determine SSR mode
+    let ssrMode: boolean | 'stream' | 'string' = false;
+    if (ssrOptions) {
+      if (typeof ssrOptions === 'boolean') {
+        // When ssr is boolean true, default mode is 'stream'
+        ssrMode = 'stream';
+      } else if (typeof ssrOptions === 'object') {
+        // When ssr is object, default mode is 'stream' unless explicitly set to 'string'
+        ssrMode = ssrOptions.mode === 'string' ? 'string' : 'stream';
+      }
+    }
+
+    return {
+      entryName,
+      isMainEntry: isMain,
+      entry,
+      isAutoMount: isAutoMount ?? true,
+      isCustomSourceEntry: isCustomSourceEntry ?? false,
+      customEntry: customEntry ?? false,
+      ssr: ssrMode,
+      ssg: Boolean(ssgOptions),
+    };
+  });
+
+  const projectInfo: ProjectInfo = {
+    entries,
+    apiOnly: false,
+  };
+
+  printProjectInfo(projectInfo, options.json);
+};
+
+function printProjectInfo(projectInfo: ProjectInfo, jsonOnly?: boolean): void {
+  if (jsonOnly) {
+    // Output pure JSON for machine reading
+    console.log(JSON.stringify(projectInfo, null, 2));
+    return;
+  }
+
+  // Output as JSON for easy parsing by agents
+  console.log('');
+  console.log('===== Modern.js Project Info =====');
+  console.log('');
+  console.log(JSON.stringify(projectInfo, null, 2));
+  console.log('');
+  console.log('===== Entry Details =====');
+  console.log('');
+
+  if (projectInfo.apiOnly) {
+    console.log('This is an API-only project (no page entries).');
+    return;
+  }
+
+  if (projectInfo.entries.length === 0) {
+    console.log('No entries found.');
+    return;
+  }
+
+  for (const entry of projectInfo.entries) {
+    console.log(`Entry: ${entry.entryName}`);
+    console.log(`  - Path: ${entry.entry}`);
+    console.log(`  - Main Entry: ${entry.isMainEntry}`);
+    console.log(`  - Auto Mount: ${entry.isAutoMount}`);
+    console.log(`  - Custom Entry: ${entry.customEntry}`);
+    console.log(`  - Custom Source Entry: ${entry.isCustomSourceEntry}`);
+    console.log(`  - Rendering Mode:`);
+    if (entry.ssg) {
+      console.log(`    - SSG: enabled`);
+    } else if (entry.ssr) {
+      console.log(`    - SSR: ${entry.ssr} mode`);
+    } else {
+      console.log(`    - CSR: enabled (default)`);
+    }
+    console.log('');
+  }
+}

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -13,6 +13,7 @@ import {
   buildCommand,
   deployCommand,
   devCommand,
+  infoCommand,
   inspectCommand,
   serverCommand,
 } from './commands';
@@ -90,6 +91,7 @@ export const appTools = (): CliPlugin<AppTools> => ({
       serverCommand(program, api);
       deployCommand(program, api);
       inspectCommand(program, api);
+      infoCommand(program, api);
       deprecatedCommands(program);
     });
 

--- a/packages/solutions/app-tools/src/locale/en.ts
+++ b/packages/solutions/app-tools/src/locale/en.ts
@@ -34,5 +34,8 @@ export const EN_LOCALE = {
       output: 'specify inspect content output path',
       verbose: 'show full function definitions in output',
     },
+    info: {
+      describe: 'show project information',
+    },
   },
 };

--- a/packages/solutions/app-tools/src/locale/zh.ts
+++ b/packages/solutions/app-tools/src/locale/zh.ts
@@ -33,5 +33,8 @@ export const ZH_LOCALE = {
       output: '指定在 dist 目录下输出的路径',
       verbose: '在结果中展示函数的完整内容',
     },
+    info: {
+      describe: '展示项目信息',
+    },
   },
 };

--- a/packages/solutions/app-tools/src/run/index.ts
+++ b/packages/solutions/app-tools/src/run/index.ts
@@ -65,6 +65,7 @@ export async function createRunOptions({
     'start',
     'serve',
     'inspect',
+    'info',
     'upgrade',
   ];
 

--- a/packages/solutions/app-tools/src/utils/types.ts
+++ b/packages/solutions/app-tools/src/utils/types.ts
@@ -25,3 +25,8 @@ export type InspectOptions = {
   output: string;
   verbose?: boolean;
 };
+
+export type InfoOptions = {
+  config?: string;
+  json?: boolean;
+};


### PR DESCRIPTION
Add a new `modern info` command that outputs project page information including:
- Entry name and path
- Whether it's the main entry
- Rendering mode (CSR/SSR/SSG)
- Auto mount and custom entry settings

This command helps agents and developers quickly understand project structure. Supports `--json` option for machine-readable output.

## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
