### PR TITLE
fix: unify HelmetProvider usage in wrapRuntimeContextProvider

### DIFF
--- a/.changeset/free-chairs-argue.md
+++ b/.changeset/free-chairs-argue.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: HelmetProvider should add unity in wrapRuntimeContextProvider
+fix: HelmetProvider 应该统一加在 wrapRuntimeContextProvider

--- a/packages/runtime/plugin-runtime/src/core/browser/hydrate.tsx
+++ b/packages/runtime/plugin-runtime/src/core/browser/hydrate.tsx
@@ -1,7 +1,6 @@
 import { loadableReady } from '@loadable/component';
 import type React from 'react';
 import type { Root } from 'react-dom/client';
-import { HelmetProvider } from 'react-helmet-async';
 import { RenderLevel } from '../constants';
 import type { RuntimeContext } from '../context/runtime';
 import { wrapRuntimeContextProvider } from '../react/wrapper';
@@ -48,20 +47,10 @@ export function hydrateRoot(
         <WithCallback callback={callback}>{App}</WithCallback>
       );
       return ModernHydrate(
-        wrapRuntimeContextProvider(
-          <HelmetProvider>
-            <SSRApp />
-          </HelmetProvider>,
-          hydrateContext,
-        ),
+        wrapRuntimeContextProvider(<SSRApp />, hydrateContext),
       );
     } else {
-      return ModernRender(
-        wrapRuntimeContextProvider(
-          <HelmetProvider>{App}</HelmetProvider>,
-          context,
-        ),
-      );
+      return ModernRender(wrapRuntimeContextProvider(App, context));
     }
   }
 
@@ -73,12 +62,7 @@ export function hydrateRoot(
       renderLevel === RenderLevel.CLIENT_RENDER ||
       renderLevel === RenderLevel.SERVER_PREFETCH
     ) {
-      return ModernRender(
-        wrapRuntimeContextProvider(
-          <HelmetProvider>{App}</HelmetProvider>,
-          context,
-        ),
-      );
+      return ModernRender(wrapRuntimeContextProvider(App, context));
     } else if (renderLevel === RenderLevel.SERVER_RENDER) {
       return new Promise<Root | HTMLElement>(resolve => {
         if (isReact18()) {
@@ -88,12 +72,7 @@ export function hydrateRoot(
               <WithCallback callback={callback}>{App}</WithCallback>
             );
             ModernHydrate(
-              wrapRuntimeContextProvider(
-                <HelmetProvider>
-                  <SSRApp />
-                </HelmetProvider>,
-                hydrateContext,
-              ),
+              wrapRuntimeContextProvider(<SSRApp />, hydrateContext),
             ).then(root => {
               resolve(root);
             });
@@ -101,10 +80,7 @@ export function hydrateRoot(
         } else {
           loadableReady(() => {
             ModernHydrate(
-              wrapRuntimeContextProvider(
-                <HelmetProvider>{App}</HelmetProvider>,
-                hydrateContext,
-              ),
+              wrapRuntimeContextProvider(App, hydrateContext),
               callback,
             ).then(root => {
               resolve(root);
@@ -115,12 +91,7 @@ export function hydrateRoot(
     } else {
       // unknown renderlevel or renderlevel is server prefetch.
       console.warn(`unknow render level: ${renderLevel}, execute render()`);
-      return ModernRender(
-        wrapRuntimeContextProvider(
-          <HelmetProvider>{App}</HelmetProvider>,
-          context,
-        ),
-      );
+      return ModernRender(wrapRuntimeContextProvider(App, context));
     }
   }
 }

--- a/packages/runtime/plugin-runtime/src/core/react/wrapper.tsx
+++ b/packages/runtime/plugin-runtime/src/core/react/wrapper.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
+import { HelmetProvider, type HelmetServerState } from 'react-helmet-async';
 import { type RuntimeContext, RuntimeReactContext } from '../context';
 
 export function wrapRuntimeContextProvider(
   App: React.ReactElement,
   contextValue: RuntimeContext,
-) {
+  helmetContext?: { helmet?: HelmetServerState },
+): React.ReactElement {
   return React.createElement(
-    RuntimeReactContext.Provider,
-    { value: contextValue },
-    App,
+    HelmetProvider,
+    { context: helmetContext || {} },
+    React.createElement(
+      RuntimeReactContext.Provider,
+      { value: contextValue },
+      App,
+    ),
   );
 }

--- a/packages/runtime/plugin-runtime/src/core/server/stream/shared.tsx
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/shared.tsx
@@ -7,7 +7,6 @@ import type {
 } from '@modern-js/types/server';
 import checkIsBot from 'isbot';
 import type React from 'react';
-import { HelmetProvider } from 'react-helmet-async';
 import { JSX_SHELL_STREAM_END_MARK } from '../../../common';
 import type { RuntimeContext } from '../../context';
 import { wrapRuntimeContextProvider } from '../../react/wrapper';
@@ -146,12 +145,11 @@ export function createRenderStreaming(
     let rootElement = wrapRuntimeContextProvider(
       serverRoot,
       Object.assign(runtimeContext, { ssr: true }),
+      helmetContext,
     );
 
     rootElement = (
-      <HelmetProvider context={helmetContext}>
-        <StreamServerRootWrapper>{rootElement}</StreamServerRootWrapper>
-      </HelmetProvider>
+      <StreamServerRootWrapper>{rootElement}</StreamServerRootWrapper>
     );
 
     const stream = await createReadableStreamFromElement(request, rootElement, {

--- a/packages/runtime/plugin-runtime/src/core/server/string/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/string/index.ts
@@ -1,10 +1,7 @@
-import type { OnError, OnTiming } from '@modern-js/app-tools';
 import type { StaticHandlerContext } from '@modern-js/runtime-utils/remix-router';
 import { time } from '@modern-js/runtime-utils/time';
-import { parseHeaders } from '@modern-js/runtime-utils/universal/request';
-import React from 'react';
+import type React from 'react';
 import ReactDomServer from 'react-dom/server';
-import { HelmetProvider } from 'react-helmet-async';
 import { RenderLevel } from '../../constants';
 import { wrapRuntimeContextProvider } from '../../react/wrapper';
 import {
@@ -87,21 +84,17 @@ export const renderString: RenderString = async (
       useJsonScript: config.useJsonScript,
     }),
   ];
+  // Create request-level Helmet context for react-helmet-async
+  const helmetContext = {};
 
   const rootElement = wrapRuntimeContextProvider(
     serverRoot,
     Object.assign(runtimeContext, { ssr: true }),
+    helmetContext,
   );
 
-  // Create request-level Helmet context for react-helmet-async
-  const helmetContext = {};
-
   const html = await generateHtml(
-    React.createElement(
-      HelmetProvider,
-      { context: helmetContext },
-      rootElement,
-    ),
+    rootElement,
     htmlTemplate,
     chunkSet,
     collectors,


### PR DESCRIPTION
## Summary
- Unifies HelmetProvider handling by moving it inside wrapRuntimeContextProvider so both client render/hydrate and server string/stream paths share a single, consistent helmet context; 
- removes redundant wrappers and adds a patch changeset for @modern-js/runtime.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
