### PR TITLE
test: fix unstable test snapshots due to NODE_ENV side effect

### DIFF
--- a/packages/cli/builder/tests/default.test.ts
+++ b/packages/cli/builder/tests/default.test.ts
@@ -1,12 +1,15 @@
 import { join } from 'path';
 import type { RsbuildPlugin } from '@rsbuild/core';
-import { describe, expect, it } from '@rstest/core';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { createBuilder } from '../src';
 
 describe('builder rspack', () => {
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+
   it('should generator rspack config correctly', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
 
     const rsbuild = await createBuilder({
       bundlerType: 'rspack',
@@ -30,13 +33,10 @@ describe('builder rspack', () => {
     expect(
       rsbuildConfig.plugins?.map(p => (p as RsbuildPlugin)?.name),
     ).toMatchSnapshot();
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should generator rspack config correctly when prod', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createBuilder({
       bundlerType: 'rspack',
@@ -49,13 +49,10 @@ describe('builder rspack', () => {
     } = await rsbuild.inspectConfig();
 
     expect(bundlerConfigs[0]).toMatchSnapshot();
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should generator rspack config correctly when node', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createBuilder({
       bundlerType: 'rspack',
@@ -76,13 +73,10 @@ describe('builder rspack', () => {
     } = await rsbuild.inspectConfig();
 
     expect(bundlerConfigs[0]).toMatchSnapshot();
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should generator rspack config correctly when service-worker', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createBuilder({
       bundlerType: 'rspack',
@@ -103,7 +97,5 @@ describe('builder rspack', () => {
     } = await rsbuild.inspectConfig();
 
     expect(bundlerConfigs[0]).toMatchSnapshot();
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 });

--- a/packages/cli/builder/tests/environment.test.ts
+++ b/packages/cli/builder/tests/environment.test.ts
@@ -1,11 +1,14 @@
 import { join } from 'path';
-import { describe, expect, it } from '@rstest/core';
+import { afterEach, describe, expect, it, rstest } from '@rstest/core';
+import { after } from 'lodash';
 import { createBuilder } from '../src';
 
 describe('builder environment compat', () => {
+  afterEach(() => {
+    rstest.unstubAllEnvs();
+  });
   it('should generator environment config correctly', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'development';
+    rstest.stubEnv('NODE_ENV', 'development');
 
     const rsbuild = await createBuilder({
       bundlerType: 'rspack',
@@ -38,7 +41,5 @@ describe('builder environment compat', () => {
     ]);
 
     expect(bundlerConfigs).toMatchSnapshot();
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 });

--- a/packages/cli/builder/tests/parseConfig.test.ts
+++ b/packages/cli/builder/tests/parseConfig.test.ts
@@ -1,13 +1,11 @@
 import type { OutputConfig } from '@rsbuild/core';
-import { afterAll, afterEach, describe, expect, test } from '@rstest/core';
+import { afterAll, afterEach, describe, expect, rs, test } from '@rstest/core';
 import { parseCommonConfig } from '../src/shared/parseCommonConfig';
 import type { BuilderConfig } from '../src/types';
 
 describe('parseCommonConfig', () => {
-  const env = process.env.NODE_ENV;
-
-  afterAll(() => {
-    process.env.NODE_ENV = env;
+  afterEach(() => {
+    rs.unstubAllEnvs();
   });
 
   test('merge config', async () => {
@@ -69,7 +67,7 @@ describe('parseCommonConfig', () => {
   });
 
   test('dev.xxx', async () => {
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
     expect(
       (
         await parseCommonConfig({
@@ -97,7 +95,7 @@ describe('parseCommonConfig', () => {
       ).rsbuildConfig,
     ).toMatchSnapshot();
 
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
     expect(
       (
         await parseCommonConfig({
@@ -137,12 +135,6 @@ describe('parseCommonConfig', () => {
   });
 
   describe('CSS source map configuration', () => {
-    const originalEnv = process.env.NODE_ENV;
-
-    afterEach(() => {
-      process.env.NODE_ENV = originalEnv;
-    });
-
     test('should not set css source map when output.sourceMap is true', async () => {
       const config = await parseCommonConfig({
         output: {
@@ -193,7 +185,7 @@ describe('parseCommonConfig', () => {
     });
 
     test('should set css source map to true when output.sourceMap.css is undefined in development', async () => {
-      process.env.NODE_ENV = 'development';
+      rs.stubEnv('NODE_ENV', 'development');
 
       const config = await parseCommonConfig({
         output: {
@@ -210,7 +202,7 @@ describe('parseCommonConfig', () => {
     });
 
     test('should set css source map to false when output.sourceMap.css is undefined in production', async () => {
-      process.env.NODE_ENV = 'production';
+      rs.stubEnv('NODE_ENV', 'production');
 
       const config = await parseCommonConfig({
         output: {
@@ -227,7 +219,7 @@ describe('parseCommonConfig', () => {
     });
 
     test('should set css source map to true when output.sourceMap is undefined in development', async () => {
-      process.env.NODE_ENV = 'development';
+      rs.stubEnv('NODE_ENV', 'development');
 
       const config = await parseCommonConfig({
         output: {},
@@ -239,7 +231,7 @@ describe('parseCommonConfig', () => {
     });
 
     test('should set css source map to false when output.sourceMap is undefined in production', async () => {
-      process.env.NODE_ENV = 'production';
+      rs.stubEnv('NODE_ENV', 'production');
 
       const config = await parseCommonConfig({
         output: {},
@@ -251,7 +243,7 @@ describe('parseCommonConfig', () => {
     });
 
     test('should respect explicitly set css source map in development', async () => {
-      process.env.NODE_ENV = 'development';
+      rs.stubEnv('NODE_ENV', 'development');
 
       const config = await parseCommonConfig({
         output: {
@@ -268,7 +260,7 @@ describe('parseCommonConfig', () => {
     });
 
     test('should respect explicitly set css source map in production', async () => {
-      process.env.NODE_ENV = 'production';
+      rs.stubEnv('NODE_ENV', 'production');
 
       const config = await parseCommonConfig({
         output: {

--- a/packages/cli/builder/tests/postcssLegacy.test.ts
+++ b/packages/cli/builder/tests/postcssLegacy.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from '@rstest/core';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { createBuilder } from '../src';
 import { matchRules, unwrapConfig } from './helper';
 
 describe('plugin-postcssLegacy', () => {
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+
   it('should register postcss plugin by browserslist', async () => {
     const rsbuild = await createBuilder({
       bundlerType: 'rspack',
@@ -49,9 +53,7 @@ describe('plugin-postcssLegacy', () => {
   });
 
   it('should register postcss plugin correctly when injectStyles is enabled in dev environment', async () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
-
+    rs.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createBuilder({
       bundlerType: 'rspack',
       config: {
@@ -65,13 +67,10 @@ describe('plugin-postcssLegacy', () => {
     const config = await unwrapConfig(rsbuild);
 
     expect(matchRules({ config, testFile: 'a.css' })).toMatchSnapshot();
-
-    process.env.NODE_ENV = originalNodeEnv;
   });
 
   it('should register postcss plugin correctly when injectStyles is enabled in production environment', async () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createBuilder({
       bundlerType: 'rspack',
@@ -86,8 +85,6 @@ describe('plugin-postcssLegacy', () => {
     const config = await unwrapConfig(rsbuild);
 
     expect(matchRules({ config, testFile: 'a.css' })).toMatchSnapshot();
-
-    process.env.NODE_ENV = originalNodeEnv;
   });
 });
 

--- a/packages/cli/builder/tests/sourcemap.test.ts
+++ b/packages/cli/builder/tests/sourcemap.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, it } from '@rstest/core';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { createBuilder } from '../src';
 import { unwrapConfig } from './helper';
 
 describe('output.sourceMap', () => {
-  it('should use default value', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'development';
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+  it('should use default value in development', async () => {
+    rs.stubEnv('NODE_ENV', 'development');
 
     const rsbuild = await createBuilder({
       cwd: '',
@@ -16,13 +18,10 @@ describe('output.sourceMap', () => {
     const config = await unwrapConfig(rsbuild);
 
     expect(config.devtool).toBe('cheap-module-source-map');
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should use default value in production', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createBuilder({
       cwd: '',
@@ -33,13 +32,10 @@ describe('output.sourceMap', () => {
     const config = await unwrapConfig(rsbuild);
 
     expect(config.devtool).toBe('hidden-source-map');
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should use sourceMap when defined', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createBuilder({
       cwd: '',
@@ -54,13 +50,10 @@ describe('output.sourceMap', () => {
     const config = await unwrapConfig(rsbuild);
 
     expect(config.devtool).toBe('source-map');
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should use sourceMap false', async () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
 
     const rsbuild = await createBuilder({
       cwd: '',
@@ -75,7 +68,5 @@ describe('output.sourceMap', () => {
     const config = await unwrapConfig(rsbuild);
 
     expect(config.devtool).toBe(false);
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 });

--- a/packages/toolkit/utils/tests/getBrowserslist.test.ts
+++ b/packages/toolkit/utils/tests/getBrowserslist.test.ts
@@ -2,6 +2,9 @@ import path from 'path';
 import { defaults, getBrowserslist } from '../src';
 
 describe('get browserslist', () => {
+  afterEach(() => {
+    rstest.unstubAllEnvs();
+  });
   const fixture = path.resolve(__dirname, './fixtures/browserlist');
 
   test(`should load browserslist from package.json`, () => {
@@ -20,7 +23,7 @@ describe('get browserslist', () => {
   });
 
   test(`should load browserslist base on environment`, () => {
-    process.env.NODE_ENV = 'development';
+    rstest.stubEnv('NODE_ENV', 'development');
     expect(getBrowserslist(path.join(fixture, 'develop'))).toEqual([
       'last 1 chrome version',
     ]);

--- a/packages/toolkit/utils/tests/is.test.ts
+++ b/packages/toolkit/utils/tests/is.test.ts
@@ -1,6 +1,9 @@
 import { isEmpty, isSSGEntry, isSSR, isTest, isUseSSRBundle } from '../src';
 
 describe('validate', () => {
+  afterEach(() => {
+    rstest.unstubAllEnvs();
+  });
   it('should validate empty object correctly', () => {
     expect(isEmpty({})).toBeTruthy();
     expect(isEmpty({ foo: 'bar' })).toBeFalsy();
@@ -49,15 +52,11 @@ describe('validate', () => {
   });
 
   it('should validate test env correctly', () => {
-    const { NODE_ENV } = process.env;
-
-    process.env.NODE_ENV = 'test';
+    rs.stubEnv('NODE_ENV', 'test');
     expect(isTest()).toBeTruthy();
 
-    process.env.NODE_ENV = 'production';
+    rs.stubEnv('NODE_ENV', 'production');
     expect(isTest()).toBeFalsy();
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should detect ssg config correctly', () => {

--- a/packages/toolkit/utils/tests/prettyInstructions.test.ts
+++ b/packages/toolkit/utils/tests/prettyInstructions.test.ts
@@ -1,3 +1,4 @@
+import { after } from '../compiled/lodash';
 import { prettyInstructions } from '../src';
 
 const mockNetworkInterfaces = {
@@ -93,6 +94,9 @@ rstest.mock('../compiled/chalk', () => {
 });
 
 describe('prettyInstructions', () => {
+  afterEach(() => {
+    rstest.unstubAllEnvs();
+  });
   test('basic usage', () => {
     const mockAppContext = {
       entrypoints: mockEntrypoints,
@@ -116,8 +120,7 @@ describe('prettyInstructions', () => {
   });
 
   test('should print https URLs', () => {
-    const { NODE_ENV } = process.env;
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
 
     const mockAppContext = {
       entrypoints: mockEntrypoints,
@@ -133,12 +136,10 @@ describe('prettyInstructions', () => {
     });
 
     expect(message).toMatchSnapshot();
-
-    process.env.NODE_ENV = NODE_ENV;
   });
 
   test('should print host correctly', () => {
-    process.env.NODE_ENV = 'development';
+    rs.stubEnv('NODE_ENV', 'development');
 
     const mockAppContext = {
       entrypoints: mockEntrypoints,


### PR DESCRIPTION
## Summary


fix unstable test snapshots due to NODE_ENV side effect.

https://rstest.rs/api/runtime-api/rstest/utilities#rsteststubenv
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
