### PR TITLE
fix: should modify resolve extensionAlias in modifyRspackConfig

### DIFF
--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -263,7 +263,7 @@ const generateEntryCode = (docPath: string, _entryName: string): string => {
   return `import React from 'react';
 import ReactDomServer from 'react-dom/server';
 import Document from ${JSON.stringify(docPath)};
-import { DocumentContext } from '${esmRuntimeAPI}';
+import { DocumentContext } from ${JSON.stringify(esmRuntimeAPI)};
 
 // expose to global for host to consume
 var g = (typeof globalThis !== 'undefined' ? globalThis : global);

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterBasic.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterBasic.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { SERVICE_WORKER_ENVIRONMENT_NAME } from '@modern-js/builder';
 import type { RsbuildPlugin, RspackChain } from '@rsbuild/core';
 import type { BuilderOptions } from '../types';
@@ -37,6 +36,31 @@ export const builderPluginAdapterBasic = (
         ],
       });
     });
+
+    // Use modifyRspackConfig to ensure extensionAlias has higher priority than rsbuild defaults
+    api.modifyRspackConfig((config, { target, environment }) => {
+      const isServiceWorker =
+        environment.name === SERVICE_WORKER_ENVIRONMENT_NAME;
+
+      if (target === 'node' || isServiceWorker) {
+        // Define extensionAlias for server and node files
+        // a .mjs file will resolve in order of .node.mjs, .server.mjs, .mjs
+        const extensionAlias: Record<string, string[]> = {
+          '.js': ['.node.js', '.server.js', '.js'],
+          '.jsx': ['.node.jsx', '.server.jsx', '.jsx'],
+          '.ts': ['.node.ts', '.server.ts', '.ts'],
+          '.tsx': ['.node.tsx', '.server.tsx', '.tsx'],
+          '.mjs': ['.node.mjs', '.server.mjs', '.mjs'],
+          '.json': ['.node.json', '.server.json', '.json'],
+        };
+
+        config.resolve ??= {};
+        config.resolve.extensionAlias = {
+          ...config.resolve.extensionAlias,
+          ...extensionAlias,
+        };
+      }
+    });
   },
 });
 
@@ -70,16 +94,4 @@ function applyNodeCompat(isServiceWorker: boolean, chain: RspackChain) {
       chain.resolve.extensions.prepend(ext);
     }
   }
-
-  const extensionAlias = {
-    '.js': ['.node.js', '.server.js', '.js'],
-    '.jsx': ['.node.jsx', '.server.jsx', '.jsx'],
-    '.ts': ['.node.ts', '.server.ts', '.ts'],
-    '.tsx': ['.node.tsx', '.server.tsx', '.tsx'],
-    '.mjs': ['.node.mjs', '.server.mjs', '.mjs'],
-    '.json': ['.node.json', '.server.json', '.json'],
-  };
-
-  // At present, it is mainly for the scene of async_storage and consistent with resolve.extensions
-  chain.resolve.extensionAlias.merge(extensionAlias);
 }


### PR DESCRIPTION
## Summary                                                   
                                                                                
  Summary                                                                       
                                                                                
  Fix resolve.extensionAlias configuration not taking effect in                 
  node/service-worker environments.                                             
                                                                                
  Changes                                                                       
                                                                                
  - Move extensionAlias configuration from modifyBundlerChain to                
  modifyRspackConfig: The previous implementation used                          
  chain.resolve.extensionAlias.merge() in modifyBundlerChain, which had lower   
  priority and would be overridden by Rsbuild's default configuration. By using 
  modifyRspackConfig, we ensure the custom extensionAlias settings take         
  precedence.                                                                   
  - Fix DocumentContext import path escaping: Changed from template string to   
  JSON.stringify() for proper escaping of special characters in the import path.
                                                                                
  Why                                                                           
                                                                                
  The extensionAlias configuration is used to resolve platform-specific files   
  (e.g., .node.js, .server.js) in node and service-worker environments. Without 
  this fix, the alias mapping was being overwritten by Rsbuild defaults, causing
   incorrect file resolution.                                                   
                                                                                
  ---                                                                           
                                                         
  概述                                                                          
                                                                                
  修复 resolve.extensionAlias 配置在 node/service-worker 环境下不生效的问题。   
                                                                                
  改动内容                                                                      
                                                                                
  - 将 extensionAlias 配置从 modifyBundlerChain 移动到                          
  modifyRspackConfig：之前的实现在 modifyBundlerChain 中使用                    
  chain.resolve.extensionAlias.merge() 设置配置，但该方式优先级较低，会被       
  Rsbuild 的默认配置覆盖。改用 modifyRspackConfig 可以确保自定义的              
  extensionAlias 配置具有更高优先级。                                           
  - 修复 DocumentContext 导入路径转义问题：将模板字符串改为使用 JSON.stringify()
   以正确转义路径中的特殊字符。                                                 
                                                                                
  修复原因                                                                      
                                                                                
  extensionAlias 配置用于在 node 和 service-worker 环境下解析平台特定文件（如   
  .node.js、.server.js）。在修复前，别名映射会被 Rsbuild                        
  默认配置覆盖，导致文件解析不正确。 


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
