### PR TITLE
docs: correct execution order of copy task

### DIFF
--- a/packages/document/module-doc/docs/en/guide/advance/in-depth-about-build.md
+++ b/packages/document/module-doc/docs/en/guide/advance/in-depth-about-build.md
@@ -313,9 +313,9 @@ export default defineConfig({
 When the `modern build` command is executed, the
 
 - Clear the output directory according to `buildConfig.outDir`.
+- Handle Copy tasks.
 - Compile `js/ts` source code to generate the JS build artifacts for bundle/bundleless.
 - Generate bundle/bundleless type files using `tsc`.
-- Handle Copy tasks.
 
 ## Build errors
 

--- a/packages/document/module-doc/docs/zh/guide/advance/in-depth-about-build.md
+++ b/packages/document/module-doc/docs/zh/guide/advance/in-depth-about-build.md
@@ -309,9 +309,9 @@ export default defineConfig({
 当执行 `modern build` 命令的时候，会发生
 
 - 根据 `buildConfig.outDir` 清理产物目录。
+- 处理 `copy` 任务。
 - 编译 `js/ts` 源代码生成 bundle / bundleless 的 JS 构建产物。
 - 使用 `tsc` 生成 bundle / bundleless 的类型文件。
-- 处理 `copy` 任务。
 
 ## 构建报错
 


### PR DESCRIPTION
## Summary
While debugging copying complied css to another dist dir, I  found in fact [copy] is exexcuted before complie not after, document place copy task at last, for prevet misundestanding , I change the task order in doc 

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
