### PR TITLE
refactor: fix all export in packages

### DIFF
--- a/packages/cli/builder/package.json
+++ b/packages/cli/builder/package.json
@@ -12,7 +12,10 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm-node/index.mjs",
+      "node": {
+        "import": "./dist/esm-node/index.mjs",
+        "require": "./dist/cjs/index.js"
+      },
       "default": "./dist/cjs/index.js"
     }
   },

--- a/packages/cli/plugin-bff/package.json
+++ b/packages/cli/plugin-bff/package.json
@@ -18,7 +18,6 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/cli.ts",
   "main": "./dist/cjs/cli.js",
-  "module": "./dist/esm-node/cli.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/cli.d.ts",
@@ -44,14 +43,6 @@
       },
       "default": "./dist/cjs/server.js"
     },
-    "./loader": {
-      "types": "./dist/types/loader.d.ts",
-      "node": {
-        "import": "./dist/esm-node/loader.mjs",
-        "require": "./dist/cjs/loader.js"
-      },
-      "default": "./dist/cjs/loader.js"
-    },
     "./server": {
       "types": "./dist/types/runtime/hono/index.d.ts",
       "node": {
@@ -61,12 +52,8 @@
       "default": "./dist/cjs/runtime/hono/index.js"
     },
     "./client": {
-      "types": "./dist/types/create-request/index.d.ts",
-      "node": {
-        "import": "./dist/esm-node/runtime/create-request/index.mjs",
-        "require": "./dist/cjs/runtime/create-request/index.js"
-      },
-      "default": "./dist/cjs/runtime/create-request/index.js"
+      "types": "./dist/types/runtime/create-request/index.d.ts",
+      "default": "./dist/esm/runtime/create-request/index.mjs"
     }
   },
   "typesVersions": {
@@ -102,7 +89,8 @@
     "@modern-js/server-utils": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@swc/helpers": "^0.5.17",
-    "type-is": "^1.6.18"
+    "type-is": "^1.6.18",
+    "qs": "^6.14.1"
   },
   "devDependencies": {
     "@modern-js/app-tools": "workspace:*",
@@ -118,7 +106,8 @@
     "@types/type-is": "^1.6.7",
     "memfs": "^3.5.3",
     "typescript": "^5",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "@types/qs": "^6.14.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/cli/plugin-bff/src/runtime/create-request/index.ts
+++ b/packages/cli/plugin-bff/src/runtime/create-request/index.ts
@@ -1,3 +1,4 @@
+/* @modern-js/create-request will auto select server or client implementation */
 import {
   configure,
   createRequest,

--- a/packages/cli/plugin-bff/src/utils/createHonoRoutes.ts
+++ b/packages/cli/plugin-bff/src/utils/createHonoRoutes.ts
@@ -6,8 +6,8 @@ import {
   ValidationError,
   isWithMetaHandler,
 } from '@modern-js/bff-core';
-import { parse } from '@modern-js/create-request/qs';
 import type { Context, Next } from '@modern-js/server-core';
+import { parse } from 'qs';
 import typeIs from 'type-is';
 
 type Handler = APIHandlerInfo['handler'];

--- a/packages/cli/plugin-data-loader/package.json
+++ b/packages/cli/plugin-data-loader/package.json
@@ -21,7 +21,6 @@
   },
   "types": "./src/runtime/index.ts",
   "main": "./dist/cjs/runtime/index.js",
-  "module": "./dist/esm/runtime/index.mjs",
   "exports": {
     "./loader": {
       "types": "./dist/types/cli/loader.d.ts",

--- a/packages/cli/plugin-data-loader/src/cli/loader.ts
+++ b/packages/cli/plugin-data-loader/src/cli/loader.ts
@@ -1,5 +1,5 @@
 import { promisify } from 'util';
-import { logger } from '@modern-js/utils/logger';
+import { logger } from '@modern-js/utils';
 import type { Rspack } from '@rsbuild/core';
 import { generateClient } from './generateClient';
 

--- a/packages/cli/plugin-ssg/package.json
+++ b/packages/cli/plugin-ssg/package.json
@@ -18,14 +18,10 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.mjs",
   "typesVersions": {
     "*": {
       ".": [
         "./dist/types/index.d.ts"
-      ],
-      "types": [
-        "./dist/types/types.d.ts"
       ]
     }
   },
@@ -36,7 +32,7 @@
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
       },
-      "default": "./dist/esm/index.mjs"
+      "default": "./dist/cjs/index.js"
     },
     "./cli": {
       "types": "./dist/types/index.d.ts",
@@ -44,15 +40,7 @@
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
       },
-      "default": "./dist/esm/index.mjs"
-    },
-    "./types": {
-      "types": "./dist/types/types.d.ts",
-      "node": {
-        "import": "./dist/esm-node/types.mjs",
-        "require": "./dist/cjs/types.js"
-      },
-      "default": "./dist/esm/types.mjs"
+      "default": "./dist/cjs/index.js"
     }
   },
   "scripts": {

--- a/packages/cli/plugin-styled-components/package.json
+++ b/packages/cli/plugin-styled-components/package.json
@@ -11,7 +11,20 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.mjs",
+  "export": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": {
+        "import": "./dist/esm-node/index.mjs",
+        "require": "./dist/cjs/index.js"
+      },
+      "default": "./dist/cjs/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/types/runtime.d.ts",
+      "default": "./dist/esm/runtime.mjs"
+    }
+  },
   "scripts": {
     "dev": "rslib build --watch",
     "build": "rslib build"
@@ -46,22 +59,14 @@
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
       },
-      "default": "./dist/esm/index.mjs"
+      "default": "./dist/cjs/index.js"
     },
     "./runtime": {
       "types": "./dist/types/runtime.d.ts",
-      "node": {
-        "import": "./dist/esm-node/runtime.mjs",
-        "require": "./dist/cjs/runtime.js"
-      },
       "default": "./dist/esm/runtime.mjs"
     },
     "./styled": {
       "types": "./dist/types/styled.d.ts",
-      "node": {
-        "import": "./dist/esm-node/styled.mjs",
-        "require": "./dist/cjs/styled.js"
-      },
       "default": "./dist/esm/styled.mjs"
     }
   },

--- a/packages/runtime/plugin-i18n/package.json
+++ b/packages/runtime/plugin-i18n/package.json
@@ -21,48 +21,42 @@
   },
   "types": "./dist/types/cli/index.d.ts",
   "main": "./dist/cjs/cli/index.js",
-  "module": "./dist/esm/cli/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/cli/index.d.ts",
-      "import": "./dist/esm/cli/index.mjs",
+      "node": {
+        "import": "./dist/esm-node/cli/index.mjs",
+        "require": "./dist/cjs/cli/index.js"
+      },
       "default": "./dist/cjs/cli/index.js"
     },
     "./package.json": "./package.json",
     "./cli": {
       "types": "./dist/types/cli/index.d.ts",
       "node": {
-        "require": "./dist/cjs/cli/index.js",
-        "import": "./dist/esm-node/cli/index.mjs"
+        "import": "./dist/esm-node/cli/index.mjs",
+        "require": "./dist/cjs/cli/index.js"
       },
       "default": "./dist/cjs/cli/index.js"
     },
     "./runtime": {
       "types": "./dist/types/runtime/index.d.ts",
       "node": {
-        "require": "./dist/cjs/runtime/index.js",
-        "import": "./dist/esm-node/runtime/index.mjs"
+        "module": "./dist/esm/runtime/index.mjs"
       },
-      "import": "./dist/esm/runtime/index.mjs",
-      "default": "./dist/cjs/runtime/index.js"
+      "default": "./dist/esm/runtime/index.mjs"
     },
     "./server": {
       "types": "./dist/types/server/index.d.ts",
       "node": {
-        "require": "./dist/cjs/server/index.js",
-        "import": "./dist/esm-node/server/index.mjs"
+        "import": "./dist/esm-node/server/index.mjs",
+        "require": "./dist/cjs/server/index.js"
       },
-      "import": "./dist/esm/server/index.mjs",
       "default": "./dist/cjs/server/index.js"
     },
     "./i18n": {
       "types": "./dist/types/runtime/i18n/index.d.ts",
-      "node": {
-        "require": "./dist/cjs/runtime/i18n/index.js",
-        "import": "./dist/esm-node/runtime/i18n/index.mjs"
-      },
-      "import": "./dist/esm/runtime/i18n/index.mjs",
-      "default": "./dist/cjs/runtime/i18n/index.js"
+      "default": "./dist/esm/runtime/i18n/index.mjs"
     }
   },
   "typesVersions": {

--- a/packages/runtime/plugin-image/package.json
+++ b/packages/runtime/plugin-image/package.json
@@ -8,13 +8,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.cjs"
     },
     "./runtime": {
       "types": "./dist/runtime.d.ts",
-      "import": "./dist/runtime.js",
-      "require": "./dist/runtime.cjs"
+      "default": "./dist/runtime.js"
     },
     "./types": {
       "types": "./dist/types.d.ts"

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -57,11 +57,6 @@
       "types": "./dist/types/exports/head.d.ts",
       "default": "./dist/esm/exports/head.mjs"
     },
-    "./server": {
-      "types": "./dist/types/exports/server.d.ts",
-      "node": "./dist/cjs/exports/server.js",
-      "default": "./dist/esm/exports/server.mjs"
-    },
     "./ssr": {
       "types": "./dist/types/core/server/index.d.ts",
       "default": "./dist/esm/core/server/index.mjs"
@@ -72,15 +67,13 @@
     },
     "./document": {
       "types": "./dist/types/document/index.d.ts",
-      "require": "./dist/cjs/document/index.js",
-      "import": "./dist/esm/document/index.mjs",
       "default": "./dist/esm/document/index.mjs"
     },
     "./cli": {
       "types": "./dist/types/cli/index.d.ts",
       "node": {
-        "require": "./dist/cjs/cli/index.js",
-        "import": "./dist/esm-node/cli/index.mjs"
+        "import": "./dist/esm-node/cli/index.mjs",
+        "require": "./dist/cjs/cli/index.js"
       },
       "default": "./dist/cjs/cli/index.js"
     },
@@ -106,8 +99,11 @@
     },
     "./loadable-bundler-plugin": {
       "types": "./dist/types/cli/ssr/loadable-bundler-plugin.d.ts",
-      "node": "./dist/cjs/cli/ssr/loadable-bundler-plugin.js",
-      "default": "./dist/cjs/cli/ssr/loadable-bundler-plugin.mjs"
+      "node": {
+        "import": "./dist/esm-node/cli/ssr/loadable-bundler-plugin.mjs",
+        "require": "./dist/cjs/cli/ssr/loadable-bundler-plugin.js"
+      },
+      "default": "./dist/cjs/cli/ssr/loadable-bundler-plugin.js"
     },
     "./rsc/server": {
       "types": "./dist/types/rsc/server.d.ts",
@@ -119,12 +115,14 @@
     },
     "./cache": {
       "types": "./dist/types/cache/index.d.ts",
-      "require": "./dist/cjs/cache/index.js",
       "default": "./dist/esm/cache/index.mjs"
     },
     "./config-routes": {
       "types": "./dist/types/exports/config-routes.d.ts",
-      "require": "./dist/cjs/exports/config-routes.js",
+      "node": {
+        "import": "./dist/esm-node/exports/config-routes.mjs",
+        "require": "./dist/cjs/exports/config-routes.js"
+      },
       "default": "./dist/cjs/exports/config-routes.js"
     }
   },
@@ -168,9 +166,6 @@
       ],
       "router": [
         "./dist/types/router/index.d.ts"
-      ],
-      "router/rsc": [
-        "./dist/types/router/runtime/rsc.d.ts"
       ],
       "router/server": [
         "./dist/types/router/runtime/server.d.ts"

--- a/packages/runtime/render/package.json
+++ b/packages/runtime/render/package.json
@@ -52,26 +52,14 @@
   "exports": {
     "./ssr": {
       "types": "./dist/types/server/ssr/index.d.ts",
-      "node": {
-        "import": "./dist/esm-node/server/ssr/index.mjs",
-        "require": "./dist/cjs/server/ssr/index.js"
-      },
       "default": "./dist/esm/server/ssr/index.js"
     },
     "./rsc": {
       "types": "./dist/types/server/rsc/index.d.ts",
-      "node": {
-        "import": "./dist/esm-node/server/rsc/index.mjs",
-        "require": "./dist/cjs/server/rsc/index.js"
-      },
       "default": "./dist/esm/server/rsc/index.js"
     },
     "./client": {
       "types": "./dist/types/client/index.d.ts",
-      "node": {
-        "import": "./dist/esm-node/client/index.mjs",
-        "require": "./dist/cjs/client/index.js"
-      },
       "default": "./dist/esm/client/index.js"
     }
   },

--- a/packages/server/bff-core/package.json
+++ b/packages/server/bff-core/package.json
@@ -18,11 +18,9 @@
   "version": "3.0.0-alpha.1",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm-node/index.mjs",
       "node": {
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"

--- a/packages/server/bff-core/src/client/generateClient.ts
+++ b/packages/server/bff-core/src/client/generateClient.ts
@@ -37,8 +37,6 @@ export type GenClientOptions = {
   domain?: string;
 };
 
-export const DEFAULT_CLIENT_REQUEST_CREATOR = '@modern-js/create-request';
-
 export const INNER_CLIENT_REQUEST_CREATOR = '@modern-js/plugin-bff/client';
 
 export const generateClient = async ({

--- a/packages/server/bff-runtime/package.json
+++ b/packages/server/bff-runtime/package.json
@@ -18,14 +18,14 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "node": {
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
       },
-      "default": "./dist/esm/index.js"
+      "default": "./dist/cjs/index.js"
     }
   },
   "scripts": {

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -18,7 +18,6 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm-node/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -32,10 +31,18 @@
     "./node": {
       "types": "./dist/types/adapters/node/index.d.ts",
       "modern:source": "./src/adapters/node/index.ts",
+      "node": {
+        "import": "./dist/esm-node/adapters/node/index.mjs",
+        "require": "./dist/cjs/adapters/node/index.js"
+      },
       "default": "./dist/cjs/adapters/node/index.js"
     },
     "./hono": {
       "types": "./dist/types/hono.d.ts",
+      "node": {
+        "import": "./dist/esm-node/hono.mjs",
+        "require": "./dist/cjs/hono.js"
+      },
       "default": "./dist/cjs/hono.js"
     }
   },

--- a/packages/server/create-request/package.json
+++ b/packages/server/create-request/package.json
@@ -19,8 +19,6 @@
   "modern:source": "./src/node.ts",
   "types": "./src/browser.ts",
   "main": "./dist/cjs/node.js",
-  "module": "./dist/esm/node.mjs",
-  "browser": "./dist/esm/browser.mjs",
   "files": [
     "dist",
     "hook.d.ts"
@@ -29,7 +27,7 @@
     ".": {
       "types": "./dist/types/browser.d.ts",
       "modern:source": "./src/browser.ts",
-      "node": "./dist/esm-node/node.mjs",
+      "node": "./dist/esm/node.mjs",
       "default": "./dist/esm/browser.mjs"
     },
     "./client": {
@@ -37,37 +35,10 @@
       "modern:source": "./src/browser.ts",
       "default": "./dist/esm/browser.mjs"
     },
-    "./modern": {
-      "modern:source": "./src/browser.ts",
-      "default": "./dist/esm-node/browser.mjs"
-    },
     "./server": {
       "types": "./dist/types/node.d.ts",
       "modern:source": "./src/node.ts",
-      "node": {
-        "import": "./dist/esm-node/node.mjs",
-        "require": "./dist/cjs/node.js"
-      },
-      "default": "./dist/cjs/node.js"
-    },
-    "./browser": {
-      "types": "./dist/types/browser.d.ts",
-      "modern:source": "./src/browser.ts",
-      "default": "./dist/esm/browser.mjs"
-    },
-    "./default": {
-      "types": "./dist/types/node.d.ts",
-      "modern:source": "./src/node.ts",
-      "node": {
-        "import": "./dist/esm-node/node.mjs",
-        "require": "./dist/cjs/node.js"
-      },
-      "default": "./dist/cjs/node.js"
-    },
-    "./qs": {
-      "types": "./dist/types/qs.d.ts",
-      "modern:source": "./src/qs.ts",
-      "default": "./dist/cjs/qs.js"
+      "default": "./dist/esm/node.mjs"
     }
   },
   "typesVersions": {
@@ -78,19 +49,7 @@
       "client": [
         "./dist/types/browser.d.ts"
       ],
-      "modern": [
-        "./dist/types/browser.d.ts"
-      ],
       "server": [
-        "./dist/types/node.d.ts"
-      ],
-      "qs": [
-        "./dist/types/qs.d.ts"
-      ],
-      "browser": [
-        "./dist/types/browser.d.ts"
-      ],
-      "default": [
         "./dist/types/node.d.ts"
       ]
     }

--- a/packages/server/plugin-polyfill/package.json
+++ b/packages/server/plugin-polyfill/package.json
@@ -18,7 +18,6 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/cli.ts",
   "main": "./dist/cjs/cli.js",
-  "module": "./dist/esm/cli.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/cli.d.ts",
@@ -26,7 +25,7 @@
         "import": "./dist/esm-node/cli.mjs",
         "require": "./dist/cjs/cli.js"
       },
-      "default": "./dist/esm/cli.mjs"
+      "default": "./dist/cjs/cli.js"
     },
     "./cli": {
       "types": "./dist/types/cli.d.ts",
@@ -34,7 +33,7 @@
         "import": "./dist/esm-node/cli.mjs",
         "require": "./dist/cjs/cli.js"
       },
-      "default": "./dist/esm/cli.mjs"
+      "default": "./dist/cjs/cli.js"
     },
     "./server": {
       "types": "./dist/types/index.d.ts",
@@ -42,7 +41,7 @@
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
       },
-      "default": "./dist/esm/index.mjs"
+      "default": "./dist/cjs/index.js"
     }
   },
   "typesVersions": {

--- a/packages/server/prod-server/package.json
+++ b/packages/server/prod-server/package.json
@@ -18,7 +18,6 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm-node/index.mjs",
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "build": "rslib build",

--- a/packages/server/server-runtime/package.json
+++ b/packages/server/server-runtime/package.json
@@ -18,7 +18,6 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm-node/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -32,10 +31,11 @@
     "./cache": {
       "types": "./dist/types/cache.d.ts",
       "node": {
+        "module": "./dist/esm/cache.mjs",
         "import": "./dist/esm-node/cache.mjs",
         "require": "./dist/cjs/cache.js"
       },
-      "default": "./dist/cjs/cache.js"
+      "default": "./dist/esm/cache.mjs"
     }
   },
   "typesVersions": {

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -18,7 +18,6 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -27,23 +26,13 @@
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
       },
-      "default": "./dist/esm/index.mjs"
-    },
-    "./hmr-client": {
-      "types": "./dist/types/dev-tools/dev-middleware/hmr-client/index.d.ts",
-      "node": {
-        "require": "./dist/cjs/dev-tools/dev-middleware/hmr-client/index.js"
-      },
-      "default": "./dist/cjs/dev-tools/dev-middleware/hmr-client/index.js"
+      "default": "./dist/cjs/index.js"
     }
   },
   "typesVersions": {
     "*": {
       ".": [
         "./dist/types/index.d.ts"
-      ],
-      "hmr-client": [
-        "./dist/types/dev-tools/dev-middleware/hmr-client/index.d.ts"
       ]
     }
   },

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -18,7 +18,6 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -27,7 +26,7 @@
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
       },
-      "default": "./dist/esm/index.mjs"
+      "default": "./dist/cjs/index.js"
     }
   },
   "typesVersions": {

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -18,7 +18,6 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm-node/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -55,14 +54,6 @@
     "./types": {
       "types": "./lib/types.d.ts",
       "default": "./lib/types.d.ts"
-    },
-    "./server": {
-      "types": "./dist/types/exports/server.d.ts",
-      "node": {
-        "import": "./dist/esm-node/exports/server.mjs",
-        "require": "./dist/cjs/exports/server.js"
-      },
-      "default": "./dist/cjs/exports/server.js"
     }
   },
   "engines": {
@@ -78,12 +69,6 @@
       ],
       "types": [
         "./lib/types.d.ts"
-      ],
-      "server": [
-        "./dist/types/exports/server.d.ts"
-      ],
-      "deploy": [
-        "./dist/types/plugins/deploy/exports.d.ts"
       ],
       "builder": [
         "./dist/types/builder/index.d.ts"

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -291,6 +291,7 @@ function applySSRDataLoader(chain: RspackChain, options: BuilderOptions) {
     .rule('ssr-data-loader')
     .test(reg)
     .use('data-loader')
+    // TODO: support ESM
     .loader(require.resolve('@modern-js/plugin-data-loader/loader'))
     .end();
 }

--- a/packages/toolkit/i18n-utils/package.json
+++ b/packages/toolkit/i18n-utils/package.json
@@ -18,7 +18,6 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.mjs",
   "typesVersions": {
     "*": {
       ".": [
@@ -31,22 +30,22 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "node": {
         "modern:source": "./src/index.ts",
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
       },
-      "types": "./dist/types/index.d.ts",
-      "default": "./dist/esm/index.mjs"
+      "default": "./dist/cjs/index.js"
     },
     "./language-detector": {
+      "types": "./dist/types/languageDetector.d.ts",
       "node": {
         "modern:source": "./src/languageDetector.ts",
         "import": "./dist/esm-node/languageDetector.mjs",
         "require": "./dist/cjs/languageDetector.js"
       },
-      "types": "./dist/types/languageDetector.d.ts",
-      "default": "./dist/esm/languageDetector.mjs"
+      "default": "./dist/cjs/languageDetector.js"
     }
   },
   "scripts": {
@@ -73,20 +72,20 @@
     "types": "./dist/types/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/types/index.d.ts",
         "node": {
           "import": "./dist/esm-node/index.mjs",
           "require": "./dist/cjs/index.js"
         },
-        "types": "./dist/types/index.d.ts",
-        "default": "./dist/esm/index.mjs"
+        "default": "./dist/cjs/index.js"
       },
       "./language-detector": {
+        "types": "./dist/types/languageDetector.d.ts",
         "node": {
           "import": "./dist/esm-node/languageDetector.mjs",
           "require": "./dist/cjs/languageDetector.js"
         },
-        "types": "./dist/types/languageDetector.d.ts",
-        "default": "./dist/esm/languageDetector.mjs"
+        "default": "./dist/cjs/languageDetector.js"
       }
     }
   }

--- a/packages/toolkit/plugin/package.json
+++ b/packages/toolkit/plugin/package.json
@@ -18,12 +18,12 @@
   "version": "3.0.0-alpha.1",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm-node/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "modern:source": "./src/index.ts",
       "node": {
-        "modern:source": "./src/index.ts",
+        "module": "./dist/esm/index.mjs",
         "import": "./dist/esm-node/index.mjs",
         "require": "./dist/cjs/index.js"
       },
@@ -31,8 +31,8 @@
     },
     "./run": {
       "types": "./dist/types/cli/run/index.d.ts",
+      "modern:source": "./src/cli/run/index.ts",
       "node": {
-        "modern:source": "./src/cli/run/index.ts",
         "import": "./dist/esm-node/cli/run/index.mjs",
         "require": "./dist/cjs/cli/run/index.js"
       },
@@ -40,8 +40,8 @@
     },
     "./cli": {
       "types": "./dist/types/cli/index.d.ts",
+      "modern:source": "./src/cli/index.ts",
       "node": {
-        "modern:source": "./src/cli/index.ts",
         "import": "./dist/esm-node/cli/index.mjs",
         "require": "./dist/cjs/cli/index.js"
       },
@@ -49,22 +49,17 @@
     },
     "./runtime": {
       "types": "./dist/types/runtime/index.d.ts",
-      "node": {
-        "modern:source": "./src/runtime/index.tsx",
-        "import": "./dist/esm-node/runtime/index.mjs",
-        "require": "./dist/cjs/runtime/index.js"
-      },
+      "modern:source": "./src/runtime/index.tsx",
       "default": "./dist/esm/runtime/index.mjs"
     },
     "./server": {
       "types": "./dist/types/server/index.d.ts",
+      "modern:source": "./src/server/index.ts",
       "node": {
-        "modern:source": "./src/server/index.ts",
-        "require": "./dist/cjs/server/index.js",
         "import": "./dist/esm-node/server/index.mjs",
-        "default": "./dist/cjs/server/index.js"
+        "require": "./dist/cjs/server/index.js"
       },
-      "default": "./dist/esm/server/index.mjs"
+      "default": "./dist/cjs/server/index.js"
     }
   },
   "typesVersions": {

--- a/packages/toolkit/runtime-utils/package.json
+++ b/packages/toolkit/runtime-utils/package.json
@@ -21,91 +21,79 @@
     "./router": {
       "types": "./dist/types/router.d.ts",
       "modern:source": "./src/router.ts",
-      "require": "./dist/cjs/router.js",
-      "import": "./dist/esm/router.mjs",
       "default": "./dist/esm/router.mjs"
     },
     "./router/rsc": {
       "types": "./dist/types/rsc.d.ts",
       "modern:source": "./src/rsc.ts",
-      "require": "./dist/cjs/rsc.js",
-      "import": "./dist/esm/rsc.mjs",
       "default": "./dist/esm/rsc.mjs"
     },
     "./browser": {
       "types": "./dist/types/browser/index.d.ts",
       "modern:source": "./src/browser/index.ts",
-      "require": "./dist/cjs/browser/index.js",
-      "import": "./dist/esm/browser/index.mjs",
       "default": "./dist/esm/browser/index.mjs"
     },
     "./node": {
       "types": "./dist/types/node/index.d.ts",
       "modern:source": "./src/node/index.ts",
-      "import": "./dist/esm/node/index.mjs",
       "default": "./dist/esm/node/index.mjs"
     },
     "./server": {
       "types": "./dist/types/server/index.d.ts",
       "modern:source": "./src/server/index.ts",
-      "require": "./dist/cjs/server/index.js",
-      "import": "./dist/esm/server/index.mjs",
       "default": "./dist/esm/server/index.mjs"
     },
     "./time": {
       "types": "./dist/types/time.d.ts",
       "modern:source": "./src/time.ts",
-      "require": "./dist/cjs/time.js",
-      "import": "./dist/esm/time.mjs",
       "default": "./dist/esm/time.mjs"
     },
     "./universal/request": {
-      "types": "./dist/universal/request.d.ts",
+      "types": "./dist/types/universal/request.d.ts",
       "modern:source": "./src/universal/request.ts",
-      "require": "./dist/cjs/universal/request.js",
-      "import": "./dist/esm/universal/request.mjs",
       "default": "./dist/esm/universal/request.mjs"
     },
     "./parsed": {
       "types": "./dist/types/parsed.d.ts",
       "modern:source": "./src/parsed.ts",
-      "require": "./dist/cjs/parsed.js",
-      "import": "./dist/esm/parsed.mjs",
       "default": "./dist/esm/parsed.mjs"
     },
     "./storer": {
       "types": "./dist/types/node/storer/index.d.ts",
       "modern:source": "./src/node/storer/index.ts",
-      "require": "./dist/cjs/node/storer/index.js",
-      "import": "./dist/esm/node/storer/index.mjs",
-      "default": "./dist/esm/node/storer/index.mjs"
+      "node": {
+        "import": "./dist/esm-node/node/storer/index.mjs",
+        "require": "./dist/cjs/node/storer/index.js"
+      },
+      "default": "./dist/cjs/node/storer/index.js"
     },
     "./fileReader": {
-      "modern:source": "./src/node/fileReader.ts",
       "types": "./dist/types/node/fileReader.d.ts",
-      "require": "./dist/cjs/node/fileReader.js",
-      "import": "./dist/esm/node/fileReader.mjs",
-      "default": "./dist/esm/node/fileReader.mjs"
+      "modern:source": "./src/node/fileReader.ts",
+      "node": {
+        "import": "./dist/esm-node/node/fileReader.mjs",
+        "require": "./dist/cjs/node/fileReader.js"
+      },
+      "default": "./dist/cjs/node/fileReader.js"
     },
     "./url": {
       "types": "./dist/types/url.d.ts",
       "modern:source": "./src/url.ts",
-      "require": "./dist/cjs/url.js",
-      "import": "./dist/esm/url.mjs",
       "default": "./dist/esm/url.mjs"
     },
     "./merge": {
       "types": "./dist/types/merge.d.ts",
       "modern:source": "./src/merge.ts",
-      "require": "./dist/cjs/merge.js",
-      "import": "./dist/esm/merge.mjs",
       "default": "./dist/esm/merge.mjs"
     },
     "./cache": {
       "types": "./dist/types/universal/cache.d.ts",
       "modern:source": "./src/universal/cache.ts",
-      "require": "./dist/cjs/universal/cache.js",
-      "import": "./dist/esm/universal/cache.mjs",
+      "node": {
+        "module": "./dist/esm/universal/cache.mjs",
+        "import": "./dist/esm-node/universal/cache.mjs",
+        "require": "./dist/cjs/universal/cache.js"
+      },
       "default": "./dist/esm/universal/cache.mjs"
     }
   },

--- a/packages/toolkit/sandpack-react/package.json
+++ b/packages/toolkit/sandpack-react/package.json
@@ -22,10 +22,6 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": {
-        "import": "./dist/esm-node/index.mjs",
-        "require": "./dist/cjs/index.js"
-      },
       "default": "./dist/esm/index.mjs"
     }
   },

--- a/packages/toolkit/types/package.json
+++ b/packages/toolkit/types/package.json
@@ -32,9 +32,6 @@
       ".": [
         "./index.d.ts"
       ],
-      "hoist-non-react-statics": [
-        "./packages/hoist-non-react-statics.d.ts"
-      ],
       "server": [
         "./server/index.d.ts"
       ]

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -24,40 +24,26 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "node": {
-        "require": "./dist/cjs/index.js",
-        "import": "./dist/esm-node/index.mjs"
+        "import": "./dist/esm-node/index.mjs",
+        "require": "./dist/cjs/index.js"
       },
-      "import": "./dist/esm-node/index.mjs",
       "default": "./dist/cjs/index.js"
     },
-    "./logger": {
-      "import": "./dist/esm-node/cli/logger.mjs",
-      "default": "./dist/cjs/cli/logger.js"
-    },
-    "./chain-id": "./dist/cjs/cli/constants/chainId.js",
-    "./require": {
-      "import": "./dist/esm/cli/require.js",
-      "default": "./dist/cjs/cli/require.js"
-    },
-    "./env": {
-      "import": "./dist/esm/cli/is/env.js",
-      "default": "./dist/cjs/cli/is/env.js"
-    },
     "./universal": {
-      "import": "./dist/esm/universal/index.mjs",
       "node": {
-        "require": "./dist/cjs/universal/index.js",
-        "import": "./dist/esm-node/universal/index.mjs"
+        "module": "./dist/esm/universal/index.mjs",
+        "import": "./dist/esm-node/universal/index.mjs",
+        "require": "./dist/cjs/universal/index.js"
       },
-      "default": "./dist/cjs/universal/index.js"
+      "default": "./dist/esm/universal/index.mjs"
     },
     "./universal/constants": {
-      "import": "./dist/esm/universal/constants.mjs",
-      "default": "./dist/cjs/universal/constants.js"
-    },
-    "./universal/plugin-dag-sort": {
-      "import": "./dist/esm/universal/pluginDagSort.mjs",
-      "default": "./dist/cjs/universal/pluginDagSort.js"
+      "node": {
+        "module": "./dist/esm/universal/constants.mjs",
+        "import": "./dist/esm-node/universal/constants.mjs",
+        "require": "./dist/cjs/universal/constants.js"
+      },
+      "default": "./dist/esm/universal/constants.mjs"
     },
     "./commander": {
       "import": "./dist/compiled/commander/index.mjs",
@@ -92,26 +78,11 @@
   },
   "typesVersions": {
     "*": {
-      "logger": [
-        "./dist/types/cli/logger.d.ts"
-      ],
-      "chain-id": [
-        "./dist/types/cli/constants/chainId.d.ts"
-      ],
-      "require": [
-        "./dist/types/cli/require.d.ts"
-      ],
-      "env": [
-        "./dist/types/cli/is/env.d.ts"
-      ],
       "universal": [
         "./dist/types/universal/index.d.ts"
       ],
       "universal/constants": [
         "./dist/types/universal/constants.d.ts"
-      ],
-      "universal/plugin-dag-sort": [
-        "./dist/types/universal/pluginDagSort.d.ts"
       ],
       "execa": [
         "./dist/compiled/execa/index.d.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@swc/helpers':
         specifier: ^0.5.17
         version: 0.5.17
+      qs:
+        specifier: ^6.14.1
+        version: 6.14.1
       type-is:
         specifier: ^1.6.18
         version: 1.6.18
@@ -307,6 +310,9 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.19.27
+      '@types/qs':
+        specifier: ^6.14.0
+        version: 6.14.0
       '@types/type-is':
         specifier: ^1.6.7
         version: 1.6.7

--- a/scripts/rslib/src/index.ts
+++ b/scripts/rslib/src/index.ts
@@ -45,15 +45,6 @@ export const rslibConfig: RslibConfig = {
           'process.env.MODERN_LIB_FORMAT': '"esm"',
         },
       },
-      /**
-       * which file (xxx.js or xxx.server.js) should be bundled should be decided by rspack.
-       */
-      redirect: {
-        js: {
-          extension: true,
-          path: false,
-        },
-      },
       autoExtension: true,
       output: {
         distPath: {


### PR DESCRIPTION
## Summary                                                                                                                                            
                                                                                                                                                     
  - 统一 package.json 的 exports 配置：修复所有 packages 中的导出条件，移除冗余的 module 字段，确保 Node.js 环境下正确使用 node 条件导出             
  - 规范化 runtime 包的导出：对于纯 runtime/browser 使用的包（如 ./runtime、./client），移除不必要的 node 条件导出，直接使用 ESM 作为默认导出        
  - 清理不必要的导出路径：移除 plugin-bff/loader、plugin-ssg/types、plugin-runtime/server、create-request/browser 等未使用的导出入口                 
  - 依赖调整：将 qs 直接作为依赖添加到 plugin-bff，替代从 @modern-js/create-request/qs 导入的方式      


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
