### PR TITLE
fix: add necessary export

### DIFF
--- a/packages/toolkit/runtime-utils/package.json
+++ b/packages/toolkit/runtime-utils/package.json
@@ -40,22 +40,22 @@
     },
     "./server": {
       "types": "./dist/types/server/index.d.ts",
+      "modern:source": "./src/server/index.ts",
       "node": {
         "module": "./dist/esm/server/index.mjs",
         "import": "./dist/esm-node/server/index.mjs",
         "require": "./dist/cjs/server/index.js"
       },
-      "modern:source": "./src/server/index.ts",
       "default": "./dist/esm/server/index.mjs"
     },
     "./time": {
       "types": "./dist/types/time.d.ts",
+      "modern:source": "./src/time.ts",
       "node": {
         "module": "./dist/esm/time.mjs",
         "import": "./dist/esm-node/time.mjs",
         "require": "./dist/cjs/time.js"
       },
-      "modern:source": "./src/time.ts",
       "default": "./dist/esm/time.mjs"
     },
     "./universal/request": {


### PR DESCRIPTION
## Summary

这两个导出理论上不应该这样做，但目前一些代码中直接在 node 中使用了这些函数。

未来应该把这些导出放到 universal 中。


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
