### PR TITLE
Release v3.0.0-alpha.2

### DIFF
--- a/benchmark/bundle-diff/package.json
+++ b/benchmark/bundle-diff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/bundle-diff-benchmark",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "private": true,
   "scripts": {
     "dev": "modern dev",

--- a/packages/cli/builder/CHANGELOG.md
+++ b/packages/cli/builder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/builder
 
+## 3.0.0-alpha.2
+
+### Patch Changes
+
+- @modern-js/utils@3.0.0-alpha.2
+- @modern-js/flight-server-transform-plugin@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/cli/builder/package.json
+++ b/packages/cli/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/builder",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "description": "A builder for Modern.js",
   "repository": {
     "type": "git",

--- a/packages/cli/flight-server-transform-plugin/CHANGELOG.md
+++ b/packages/cli/flight-server-transform-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/flight-server-transform-plugin
 
+## 3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ## 3.0.0-alpha.0

--- a/packages/cli/flight-server-transform-plugin/package.json
+++ b/packages/cli/flight-server-transform-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/flight-server-transform-plugin",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/modern.js",

--- a/packages/cli/plugin-bff/CHANGELOG.md
+++ b/packages/cli/plugin-bff/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @modern-js/plugin-bff
 
+## 3.0.0-alpha.2
+
+### Minor Changes
+
+- ecd247c: feat: esm runtime
+
+### Patch Changes
+
+- 96b5424: fix: dev hono context error
+  fix: 修复 dev 环境 hono context
+- Updated dependencies [96b5424]
+- Updated dependencies [eecb927]
+- Updated dependencies [ecd247c]
+- Updated dependencies [952f6fe]
+- Updated dependencies [e21ac60]
+- Updated dependencies [79f0efd]
+  - @modern-js/server-core@3.0.0-alpha.2
+  - @modern-js/bff-core@3.0.0-alpha.2
+  - @modern-js/create-request@3.0.0-alpha.2
+  - @modern-js/server-utils@3.0.0-alpha.2
+  - @modern-js/builder@3.0.0-alpha.2
+  - @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/cli/plugin-bff/package.json
+++ b/packages/cli/plugin-bff/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/cli.ts",
   "main": "./dist/cjs/cli.js",
   "exports": {

--- a/packages/cli/plugin-data-loader/CHANGELOG.md
+++ b/packages/cli/plugin-data-loader/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/plugin-data-loader
 
+## 3.0.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies [ecd247c]
+  - @modern-js/runtime-utils@3.0.0-alpha.2
+  - @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/cli/plugin-data-loader/package.json
+++ b/packages/cli/plugin-data-loader/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "engines": {
     "node": ">=20"
   },

--- a/packages/cli/plugin-ssg/CHANGELOG.md
+++ b/packages/cli/plugin-ssg/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/plugin-ssg
 
+## 3.0.0-alpha.2
+
+### Patch Changes
+
+- @modern-js/prod-server@3.0.0-alpha.2
+- @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/cli/plugin-ssg/package.json
+++ b/packages/cli/plugin-ssg/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "typesVersions": {

--- a/packages/cli/plugin-styled-components/package.json
+++ b/packages/cli/plugin-styled-components/package.json
@@ -8,7 +8,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "export": {

--- a/packages/document/CHANGELOG.md
+++ b/packages/document/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/main-doc
 
+## 3.0.0-alpha.2
+
+### Patch Changes
+
+- @modern-js/sandpack-react@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -21,7 +21,7 @@
     "build": "rspress build",
     "preview": "rspress preview"
   },
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/runtime/plugin-i18n/package.json
+++ b/packages/runtime/plugin-i18n/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "engines": {
     "node": ">=20"
   },
@@ -103,7 +103,7 @@
     "react-dom": ">=17.0.2",
     "i18next": ">=25.7.4",
     "react-i18next": ">=15.7.4",
-    "@modern-js/runtime": "workspace:^3.0.0-alpha.1"
+    "@modern-js/runtime": "workspace:^3.0.0-alpha.2"
   },
   "peerDependenciesMeta": {
     "i18next": {

--- a/packages/runtime/plugin-image/package.json
+++ b/packages/runtime/plugin-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/image",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/runtime/plugin-runtime/CHANGELOG.md
+++ b/packages/runtime/plugin-runtime/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @modern-js/runtime
 
+## 3.0.0-alpha.2
+
+### Minor Changes
+
+- ecd247c: feat: esm runtime
+
+### Patch Changes
+
+- 4c5b645: refactor: update rsc, streaming ssr runtime code
+  refactor: 更新 rsc, streeaming ssr 运行时代码
+- Updated dependencies [ecd247c]
+- Updated dependencies [952f6fe]
+- Updated dependencies [4c5b645]
+  - @modern-js/runtime-utils@3.0.0-alpha.2
+  - @modern-js/render@3.0.0-alpha.2
+  - @modern-js/types@3.0.0-alpha.2
+  - @modern-js/plugin-data-loader@3.0.0-alpha.2
+  - @modern-js/plugin@3.0.0-alpha.2
+  - @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "engines": {
     "node": ">=20"
   },

--- a/packages/runtime/render/CHANGELOG.md
+++ b/packages/runtime/render/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @modern-js/render
 
+## 3.0.0-alpha.2
+
+### Minor Changes
+
+- ecd247c: feat: esm runtime
+
+### Patch Changes
+
+- 4c5b645: refactor: update rsc, streaming ssr runtime code
+  refactor: 更新 rsc, streeaming ssr 运行时代码
+- Updated dependencies [952f6fe]
+  - @modern-js/types@3.0.0-alpha.2
+  - @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/runtime/render/package.json
+++ b/packages/runtime/render/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "files": [
     "dist",
     "hook.d.ts"

--- a/packages/server/bff-core/CHANGELOG.md
+++ b/packages/server/bff-core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/bff-core
 
+## 3.0.0-alpha.2
+
+### Minor Changes
+
+- ecd247c: feat: esm runtime
+
+### Patch Changes
+
+- @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/server/bff-core/package.json
+++ b/packages/server/bff-core/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
   "exports": {

--- a/packages/server/bff-runtime/CHANGELOG.md
+++ b/packages/server/bff-runtime/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/bff-runtime
 
+## 3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ## 3.0.0-alpha.0

--- a/packages/server/bff-runtime/package.json
+++ b/packages/server/bff-runtime/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "exports": {

--- a/packages/server/core/CHANGELOG.md
+++ b/packages/server/core/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @modern-js/server-plugin
 
+## 3.0.0-alpha.2
+
+### Patch Changes
+
+- 96b5424: fix: dev hono context error
+  fix: 修复 dev 环境 hono context
+- eecb927: fix: should read html templates only in getHtmlTemplates function
+  fix: 在 getHtmlTemplates 函数中读取 html 模板
+- 952f6fe: perf: server monitor add more tags for timing/counter event
+  perf: server monitor 为 timing/couter 事件添加更多的 tags
+- 79f0efd: fix: MPA should apply csrRender function for every single page
+  fix: MPA 项目一个为每个单页面应用不同的 csrRender 逻辑
+- Updated dependencies [ecd247c]
+  - @modern-js/runtime-utils@3.0.0-alpha.2
+  - @modern-js/plugin@3.0.0-alpha.2
+  - @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "exports": {

--- a/packages/server/create-request/CHANGELOG.md
+++ b/packages/server/create-request/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/create-request
 
+## 3.0.0-alpha.2
+
+### Minor Changes
+
+- e21ac60: feat: use node native fetch
+
+### Patch Changes
+
+- Updated dependencies [ecd247c]
+  - @modern-js/runtime-utils@3.0.0-alpha.2
+  - @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/server/create-request/package.json
+++ b/packages/server/create-request/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "modern:source": "./src/node.ts",
   "types": "./src/browser.ts",
   "main": "./dist/cjs/node.js",

--- a/packages/server/plugin-polyfill/CHANGELOG.md
+++ b/packages/server/plugin-polyfill/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/plugin-polyfill
 
+## 3.0.0-alpha.2
+
+### Patch Changes
+
+- @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/server/plugin-polyfill/package.json
+++ b/packages/server/plugin-polyfill/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/cli.ts",
   "main": "./dist/cjs/cli.js",
   "exports": {

--- a/packages/server/prod-server/CHANGELOG.md
+++ b/packages/server/prod-server/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @modern-js/prod-server
 
+## 3.0.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies [96b5424]
+- Updated dependencies [eecb927]
+- Updated dependencies [ecd247c]
+- Updated dependencies [952f6fe]
+- Updated dependencies [79f0efd]
+  - @modern-js/server-core@3.0.0-alpha.2
+  - @modern-js/runtime-utils@3.0.0-alpha.2
+  - @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/server/prod-server/package.json
+++ b/packages/server/prod-server/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "scripts": {

--- a/packages/server/server-runtime/CHANGELOG.md
+++ b/packages/server/server-runtime/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @modern-js/server-runtime
 
+## 3.0.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies [96b5424]
+- Updated dependencies [eecb927]
+- Updated dependencies [ecd247c]
+- Updated dependencies [952f6fe]
+- Updated dependencies [79f0efd]
+  - @modern-js/server-core@3.0.0-alpha.2
+  - @modern-js/runtime-utils@3.0.0-alpha.2
+  - @modern-js/types@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/server/server-runtime/package.json
+++ b/packages/server/server-runtime/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "exports": {

--- a/packages/server/server/CHANGELOG.md
+++ b/packages/server/server/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @modern-js/server
 
+## 3.0.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies [96b5424]
+- Updated dependencies [eecb927]
+- Updated dependencies [ecd247c]
+- Updated dependencies [952f6fe]
+- Updated dependencies [79f0efd]
+  - @modern-js/server-core@3.0.0-alpha.2
+  - @modern-js/runtime-utils@3.0.0-alpha.2
+  - @modern-js/types@3.0.0-alpha.2
+  - @modern-js/server-utils@3.0.0-alpha.2
+  - @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "exports": {

--- a/packages/server/utils/CHANGELOG.md
+++ b/packages/server/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/server-utils
 
+## 3.0.0-alpha.2
+
+### Patch Changes
+
+- @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "exports": {

--- a/packages/solutions/app-tools/CHANGELOG.md
+++ b/packages/solutions/app-tools/CHANGELOG.md
@@ -1,5 +1,37 @@
 # @modern-js/app-tools
 
+## 3.0.0-alpha.2
+
+### Major Changes
+
+- ef4288c: feat: release Modern.js 3.0
+
+  feat: 发布 Modern.js 3.0
+
+### Minor Changes
+
+- ecd247c: feat: esm runtime
+
+### Patch Changes
+
+- 76d0fc2: feat(app-tools): add info command to display project entries information
+  feat(app-tools): 新增 info 命令，用于展示项目的 entries 信息
+- Updated dependencies [96b5424]
+- Updated dependencies [eecb927]
+- Updated dependencies [ecd247c]
+- Updated dependencies [952f6fe]
+- Updated dependencies [79f0efd]
+  - @modern-js/server-core@3.0.0-alpha.2
+  - @modern-js/i18n-utils@3.0.0-alpha.2
+  - @modern-js/types@3.0.0-alpha.2
+  - @modern-js/plugin-data-loader@3.0.0-alpha.2
+  - @modern-js/prod-server@3.0.0-alpha.2
+  - @modern-js/server@3.0.0-alpha.2
+  - @modern-js/server-utils@3.0.0-alpha.2
+  - @modern-js/plugin@3.0.0-alpha.2
+  - @modern-js/builder@3.0.0-alpha.2
+  - @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Major Changes

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "exports": {

--- a/packages/toolkit/create/CHANGELOG.md
+++ b/packages/toolkit/create/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/create
 
+## 3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ## 3.0.0-alpha.0

--- a/packages/toolkit/create/package.json
+++ b/packages/toolkit/create/package.json
@@ -19,7 +19,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/toolkit/i18n-utils/package.json
+++ b/packages/toolkit/i18n-utils/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "typesVersions": {

--- a/packages/toolkit/plugin/CHANGELOG.md
+++ b/packages/toolkit/plugin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/plugin-v2
 
+## 3.0.0-alpha.2
+
+### Patch Changes
+
+- Updated dependencies [ecd247c]
+- Updated dependencies [952f6fe]
+  - @modern-js/runtime-utils@3.0.0-alpha.2
+  - @modern-js/types@3.0.0-alpha.2
+  - @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/toolkit/plugin/package.json
+++ b/packages/toolkit/plugin/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "exports": {

--- a/packages/toolkit/runtime-utils/CHANGELOG.md
+++ b/packages/toolkit/runtime-utils/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @modern-js/runtime-utils
 
+## 3.0.0-alpha.2
+
+### Minor Changes
+
+- ecd247c: feat: esm runtime
+
+### Patch Changes
+
+- Updated dependencies [952f6fe]
+  - @modern-js/types@3.0.0-alpha.2
+  - @modern-js/utils@3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/toolkit/runtime-utils/package.json
+++ b/packages/toolkit/runtime-utils/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "_comment": "Provide ESM and CJS exports, ESM is used by runtime package, for treeshaking",
   "exports": {
     "./router": {

--- a/packages/toolkit/sandpack-react/CHANGELOG.md
+++ b/packages/toolkit/sandpack-react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/sandpack-react
 
+## 3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ## 3.0.0-alpha.0

--- a/packages/toolkit/sandpack-react/package.json
+++ b/packages/toolkit/sandpack-react/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",

--- a/packages/toolkit/types/CHANGELOG.md
+++ b/packages/toolkit/types/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/types
 
+## 3.0.0-alpha.2
+
+### Patch Changes
+
+- 952f6fe: perf: server monitor add more tags for timing/counter event
+  perf: server monitor 为 timing/couter 事件添加更多的 tags
+
 ## 3.0.0-alpha.1
 
 ### Patch Changes

--- a/packages/toolkit/types/package.json
+++ b/packages/toolkit/types/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./index.d.ts",
   "exports": {
     ".": {

--- a/packages/toolkit/utils/CHANGELOG.md
+++ b/packages/toolkit/utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/utils
 
+## 3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ## 3.0.0-alpha.0

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -15,7 +15,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",

--- a/packages/tsconfig/CHANGELOG.md
+++ b/packages/tsconfig/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/tsconfig
 
+## 3.0.0-alpha.2
+
 ## 3.0.0-alpha.1
 
 ## 3.0.0-alpha.0

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js/tsconfig",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "description": "A Progressive React Framework for modern web development.",
   "homepage": "https://modernjs.dev",
   "bugs": "https://github.com/web-infra-dev/modern.js/issues",


### PR DESCRIPTION
## What's Changed

### Performance Improvements ⚡

- perf: server monitor add more tags for timing/counter event by @GiveMe-A-Name in https://github.com/web-infra-dev/modern.js/pull/7967
### New Features 🎉

- feat: release Modern.js 3.0 by @caohuilin in https://github.com/web-infra-dev/modern.js/pull/7953
- feat: esm runtime by @sylingd in https://github.com/web-infra-dev/modern.js/pull/8227
- feat: use node native fetch by @sylingd in https://github.com/web-infra-dev/modern.js/pull/8273
- feat(app-tools): add info command to display project entries information by @zllkjc in https://github.com/web-infra-dev/modern.js/pull/8239
### Bug Fixes 🐞

- fix: dev hono context error by @keepview in https://github.com/web-infra-dev/modern.js/pull/8255
- fix: should read html templates only in getHtmlTemplates function by @yimingjfe in https://github.com/web-infra-dev/modern.js/pull/7963
- fix: MPA should apply csrRender function for every single page by @GiveMe-A-Name in https://github.com/web-infra-dev/modern.js/pull/8090
### Other Changes ✨

- refactor: update rsc, streaming ssr runtime code by @GiveMe-A-Name in https://github.com/web-infra-dev/modern.js/pull/8086
### Rsbuild Update 📦

- Upgrade @rsbuild/core from v1.7.1 to v2.0.0-beta.0. See [v2.0.0-beta.0](https://github.com/web-infra-dev/rsbuild/releases/tag/v2.0.0-beta.0) for details.


## 更新内容

### 性能优化 ⚡

- perf: server monitor 为 timing/couter 事件添加更多的 tags 由 @GiveMe-A-Name 实现， 详情可查看 https://github.com/web-infra-dev/modern.js/pull/7967
### 新特性 🎉

- feat: 发布 Modern.js 3.0 由 @caohuilin 实现， 详情可查看 https://github.com/web-infra-dev/modern.js/pull/7953
- feat(app-tools): 新增 info 命令，用于展示项目的 entries 信息 由 @zllkjc 实现， 详情可查看 https://github.com/web-infra-dev/modern.js/pull/8239
### Bug 修复 🐞

- fix: 修复 dev 环境 hono context 由 @keepview 实现， 详情可查看 https://github.com/web-infra-dev/modern.js/pull/8255
- fix: 在 getHtmlTemplates 函数中读取 html 模板 由 @yimingjfe 实现， 详情可查看 https://github.com/web-infra-dev/modern.js/pull/7963
- fix: MPA 项目一个为每个单页面应用不同的 csrRender 逻辑 由 @GiveMe-A-Name 实现， 详情可查看 https://github.com/web-infra-dev/modern.js/pull/8090
### 其他变更 ✨

- refactor: 更新 rsc, streeaming ssr 运行时代码 由 @GiveMe-A-Name 实现， 详情可查看 https://github.com/web-infra-dev/modern.js/pull/8086
### Rsbuild 更新 📦

- 升级 @rsbuild/core 从 v1.7.1 到 v2.0.0-beta.0，查看 [v2.0.0-beta.0](https://github.com/web-infra-dev/rsbuild/releases/tag/v2.0.0-beta.0) 了解详情。