### PR TITLE
fix(builder): inlineScripts:false doesn't work

### DIFF
--- a/.changeset/sunny-years-lie.md
+++ b/.changeset/sunny-years-lie.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder': patch
+---
+
+fix: inlineScripts should not takes the default value when set to false
+fix: inlineScripts 设置为false时不应取默认值

--- a/packages/cli/builder/src/plugins/runtimeChunk.ts
+++ b/packages/cli/builder/src/plugins/runtimeChunk.ts
@@ -33,7 +33,7 @@ export const pluginRuntimeChunk = (
         return;
       }
 
-      if (!config.output.inlineScripts) {
+      if (config.output.inlineScripts === undefined) {
         config.output.inlineScripts = RUNTIME_CHUNK_REGEX;
       }
     });


### PR DESCRIPTION
## Summary

inlineScripts always take their default value, even though I set it to false.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation. - bugfix, no need
- [x] I have added tests to cover my changes. - my be latter
