### PR TITLE
fix: use react-server-dom-rspack fallback for SSR without RSC

### DIFF
--- a/packages/cli/builder/src/shared/rsc/rscClientBrowserFallback.ts
+++ b/packages/cli/builder/src/shared/rsc/rscClientBrowserFallback.ts
@@ -20,7 +20,7 @@ export function rscClientBrowserFallbackPlugin(): RsbuildPlugin {
         config.resolve ??= {};
         config.resolve.fallback ??= {};
         (config.resolve.fallback as Record<string, string | false>)[
-          'react-server-dom-webpack/client.browser'
+          'react-server-dom-rspack/client.browser'
         ] = emptyModulePath;
       });
     },

--- a/packages/cli/builder/src/shared/rsc/rscEmptyModule.ts
+++ b/packages/cli/builder/src/shared/rsc/rscEmptyModule.ts
@@ -1,2 +1,2 @@
-// Empty fallback module for react-server-dom-webpack when RSC is disabled
+// Empty fallback module for react-server-dom-rspack when RSC is disabled
 export default {};

--- a/packages/cli/builder/tests/__snapshots__/default.test.ts.snap
+++ b/packages/cli/builder/tests/__snapshots__/default.test.ts.snap
@@ -1191,7 +1191,7 @@ exports[`builder rspack > should generator rspack config correctly 1`] = `
       ".json",
     ],
     "fallback": {
-      "react-server-dom-webpack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
+      "react-server-dom-rspack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
     },
     "tsConfig": {
       "configFile": "<WORKSPACE>/packages/cli/builder/tsconfig.json",
@@ -2020,7 +2020,7 @@ exports[`builder rspack > should generator rspack config correctly when node 1`]
       ".json",
     ],
     "fallback": {
-      "react-server-dom-webpack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
+      "react-server-dom-rspack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
     },
     "tsConfig": {
       "configFile": "<WORKSPACE>/packages/cli/builder/tsconfig.json",
@@ -3234,7 +3234,7 @@ exports[`builder rspack > should generator rspack config correctly when prod 1`]
       ".json",
     ],
     "fallback": {
-      "react-server-dom-webpack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
+      "react-server-dom-rspack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
     },
     "tsConfig": {
       "configFile": "<WORKSPACE>/packages/cli/builder/tsconfig.json",
@@ -4055,7 +4055,7 @@ exports[`builder rspack > should generator rspack config correctly when service-
       ".json",
     ],
     "fallback": {
-      "react-server-dom-webpack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
+      "react-server-dom-rspack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
     },
     "tsConfig": {
       "configFile": "<WORKSPACE>/packages/cli/builder/tsconfig.json",

--- a/packages/cli/builder/tests/__snapshots__/environment.test.ts.snap
+++ b/packages/cli/builder/tests/__snapshots__/environment.test.ts.snap
@@ -1192,7 +1192,7 @@ exports[`builder environment compat > should generator environment config correc
         ".json",
       ],
       "fallback": {
-        "react-server-dom-webpack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
+        "react-server-dom-rspack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
       },
       "tsConfig": {
         "configFile": "<WORKSPACE>/packages/cli/builder/tsconfig.json",
@@ -1978,7 +1978,7 @@ exports[`builder environment compat > should generator environment config correc
         ".json",
       ],
       "fallback": {
-        "react-server-dom-webpack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
+        "react-server-dom-rspack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
       },
       "tsConfig": {
         "configFile": "<WORKSPACE>/packages/cli/builder/tsconfig.json",
@@ -2737,7 +2737,7 @@ exports[`builder environment compat > should generator environment config correc
         ".json",
       ],
       "fallback": {
-        "react-server-dom-webpack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
+        "react-server-dom-rspack/client.browser": "<WORKSPACE>/packages/cli/builder/src/shared/rsc/rscEmptyModule",
       },
       "tsConfig": {
         "configFile": "<WORKSPACE>/packages/cli/builder/tsconfig.json",


### PR DESCRIPTION
## Summary

Sync RSC client browser fallback from `react-server-dom-webpack/client.browser` to `react-server-dom-rspack/client.browser`, so that SSR-only apps (without RSC enabled) can resolve the import and build successfully.

## Related Links

- Fixes #8362
- Related to PR #8224 (which added fallback for react-server-dom-webpack; render package has since migrated to react-server-dom-rspack)

## Changes

- `rscClientBrowserFallback.ts`: fallback key updated to `react-server-dom-rspack/client.browser`
- `rscEmptyModule.ts`: comment updated
- Snapshot tests updated

Made with [Cursor](https://cursor.com)