### PR TITLE
feat(app-tools): support tsconfig path aliases on Node 22+ without ts-node

### DIFF
--- a/packages/solutions/app-tools/src/esm/alias-resolver.mjs
+++ b/packages/solutions/app-tools/src/esm/alias-resolver.mjs
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+let absoluteBaseUrl;
+let tsPaths; // { pattern: string, prefix: string, replacements: string[] }[]
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+
+function tryResolveFile(filePath) {
+  // Try exact path
+  try {
+    if (fs.statSync(filePath).isFile()) {
+      return filePath;
+    }
+  } catch {}
+
+  // Try adding extensions
+  for (const ext of TS_EXTENSIONS) {
+    try {
+      const withExt = filePath + ext;
+      if (fs.statSync(withExt).isFile()) {
+        return withExt;
+      }
+    } catch {}
+  }
+
+  // Try index files
+  for (const ext of TS_EXTENSIONS) {
+    try {
+      const indexPath = path.join(filePath, `index${ext}`);
+      if (fs.statSync(indexPath).isFile()) {
+        return indexPath;
+      }
+    } catch {}
+  }
+
+  return null;
+}
+
+function matchAlias(specifier) {
+  if (!tsPaths) {
+    return null;
+  }
+
+  for (const { prefix, hasWildcard, replacements } of tsPaths) {
+    if (hasWildcard) {
+      if (specifier.startsWith(prefix)) {
+        const rest = specifier.slice(prefix.length);
+        for (const replacement of replacements) {
+          const resolved = path.resolve(absoluteBaseUrl, replacement + rest);
+          const file = tryResolveFile(resolved);
+          if (file) {
+            return file;
+          }
+        }
+      }
+    } else {
+      if (specifier === prefix) {
+        for (const replacement of replacements) {
+          const resolved = path.resolve(absoluteBaseUrl, replacement);
+          const file = tryResolveFile(resolved);
+          if (file) {
+            return file;
+          }
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+export function initialize(data) {
+  absoluteBaseUrl = data.absoluteBaseUrl;
+
+  // Convert paths config to lookup-friendly format
+  tsPaths = Object.entries(data.paths).map(([pattern, replacements]) => {
+    const hasWildcard = pattern.includes('*');
+    const prefix = hasWildcard ? pattern.replace('/*', '/') : pattern;
+    const processedReplacements = (
+      Array.isArray(replacements) ? replacements : [replacements]
+    ).map(r => (hasWildcard ? r.replace('/*', '/') : r));
+
+    return { prefix, hasWildcard, replacements: processedReplacements };
+  });
+}
+
+export function resolve(specifier, context, defaultResolve) {
+  // 1. Try tsconfig path aliases
+  const aliasMatch = matchAlias(specifier);
+  if (aliasMatch) {
+    return defaultResolve(pathToFileURL(aliasMatch).href, context);
+  }
+
+  // 2. Handle relative imports with missing extensions
+  if (specifier.startsWith('./') || specifier.startsWith('../')) {
+    const parentPath = context.parentURL
+      ? fileURLToPath(context.parentURL)
+      : undefined;
+
+    if (parentPath) {
+      const parentDir = path.dirname(parentPath);
+      const absolutePath = path.resolve(parentDir, specifier);
+      const resolved = tryResolveFile(absolutePath);
+      if (resolved) {
+        return defaultResolve(pathToFileURL(resolved).href, context);
+      }
+    }
+  }
+
+  return defaultResolve(specifier, context);
+}

--- a/packages/solutions/app-tools/src/esm/register-esm.mjs
+++ b/packages/solutions/app-tools/src/esm/register-esm.mjs
@@ -43,3 +43,18 @@ export const registerModuleHooks = async ({ appDir, distDir, alias }) => {
     },
   });
 };
+
+/**
+ * Register alias resolver hooks for Node.js 22+ native TypeScript support.
+ * Used when ts-node is not available but Node has native TypeScript strip-types.
+ * Handles tsconfig path aliases and extensionless imports.
+ */
+export const registerAliasResolver = async ({ absoluteBaseUrl, paths }) => {
+  const { register } = await import('node:module');
+  register('./alias-resolver.mjs', import.meta.url, {
+    data: {
+      absoluteBaseUrl,
+      paths,
+    },
+  });
+};

--- a/packages/solutions/app-tools/src/utils/register.ts
+++ b/packages/solutions/app-tools/src/utils/register.ts
@@ -19,8 +19,54 @@ const checkDepExist = (dep: string, appDir: string) => {
 };
 
 /**
+ * Check if Node.js has native TypeScript support (Node 22.6+ with strip-types).
+ */
+const hasNativeTypeScript = (): boolean => {
+  return Boolean((process as any).features?.typescript);
+};
+
+/**
+ * Compute tsconfig paths in a format suitable for alias resolution.
+ */
+const computeTsPaths = (
+  paths: Record<string, string | string[]>,
+  absoluteBaseUrl: string,
+) => {
+  return Object.keys(paths).reduce(
+    (o, key) => {
+      let tsPath = paths[key];
+      // Do some special handling for Modern.js's internal alias, we can drop it in the next version
+      if (
+        typeof tsPath === 'string' &&
+        key.startsWith('@') &&
+        tsPath.startsWith('@')
+      ) {
+        try {
+          tsPath = require.resolve(tsPath, {
+            paths: [process.cwd(), ...module.paths],
+          });
+        } catch {}
+      }
+      if (typeof tsPath === 'string' && path.isAbsolute(tsPath)) {
+        tsPath = path.relative(absoluteBaseUrl, tsPath);
+      }
+      if (typeof tsPath === 'string') {
+        tsPath = [tsPath];
+      }
+      return {
+        ...o,
+        [`${key}`]: tsPath,
+      };
+    },
+    {} as Record<string, string[]>,
+  );
+};
+
+/**
  * Setup TypeScript runtime support.
  * Register ts-node for compilation and tsconfig-paths for path alias resolution.
+ * On Node 22+ with native TypeScript support, falls back to alias-only resolution
+ * when ts-node is not available.
  */
 export const setupTsRuntime = async (
   appDir: string,
@@ -30,63 +76,53 @@ export const setupTsRuntime = async (
   const TS_CONFIG_FILENAME = `tsconfig.json`;
   const tsconfigPath = path.resolve(appDir, TS_CONFIG_FILENAME);
   const isTsProject = await fs.pathExists(tsconfigPath);
-  const hasTsNode = checkDepExist('ts-node', appDir);
 
-  if (!isTsProject || !hasTsNode) {
+  if (!isTsProject) {
     return;
   }
+
+  const hasTsNode = checkDepExist('ts-node', appDir);
 
   const aliasConfig = getAliasConfig(alias, {
     appDirectory: appDir,
     tsconfigPath,
   });
   const { paths = {}, absoluteBaseUrl = './' } = aliasConfig;
+  const tsPaths = computeTsPaths(paths, absoluteBaseUrl);
 
-  const tsPaths = Object.keys(paths).reduce((o, key) => {
-    let tsPath = paths[key];
-    // Do some special handling for Modern.js's internal alias, we can drop it in the next version
-    if (
-      typeof tsPath === 'string' &&
-      key.startsWith('@') &&
-      tsPath.startsWith('@')
-    ) {
-      try {
-        tsPath = require.resolve(tsPath, {
-          paths: [process.cwd(), ...module.paths],
-        });
-      } catch {}
-    }
-    if (typeof tsPath === 'string' && path.isAbsolute(tsPath)) {
-      tsPath = path.relative(absoluteBaseUrl, tsPath);
-    }
-    if (typeof tsPath === 'string') {
-      tsPath = [tsPath];
-    }
-    return {
-      ...o,
-      [`${key}`]: tsPath,
-    };
-  }, {});
+  if (hasTsNode) {
+    // ts-node available: use ts-node for compilation + tsconfig-paths for aliases
+    const tsConfig = readTsConfigByFile(tsconfigPath);
+    const tsNode = await loadFromProject('ts-node', appDir);
+    const tsNodeOptions = tsConfig['ts-node'];
+    tsNode.register({
+      project: tsconfigPath,
+      scope: true,
+      // for env.d.ts, https://www.npmjs.com/package/ts-node#missing-types
+      files: true,
+      transpileOnly: true,
+      ignore: [
+        '(?:^|/)node_modules/',
+        `(?:^|/)${path.relative(appDir, distDir)}/`,
+      ],
+      ...tsNodeOptions,
+    });
 
-  const tsConfig = readTsConfigByFile(tsconfigPath);
-  const tsNode = await loadFromProject('ts-node', appDir);
-  const tsNodeOptions = tsConfig['ts-node'];
-  tsNode.register({
-    project: tsconfigPath,
-    scope: true,
-    // for env.d.ts, https://www.npmjs.com/package/ts-node#missing-types
-    files: true,
-    transpileOnly: true,
-    ignore: [
-      '(?:^|/)node_modules/',
-      `(?:^|/)${path.relative(appDir, distDir)}/`,
-    ],
-    ...tsNodeOptions,
-  });
-
-  const { register } = await import('@modern-js/utils/tsconfig-paths');
-  register({
-    baseUrl: absoluteBaseUrl || './',
-    paths: tsPaths,
-  });
+    const { register } = await import('@modern-js/utils/tsconfig-paths');
+    register({
+      baseUrl: absoluteBaseUrl || './',
+      paths: tsPaths,
+    });
+  } else if (hasNativeTypeScript()) {
+    // Node 22+ with native TypeScript support but no ts-node:
+    // Register ESM resolve hooks for tsconfig path aliases and extensionless imports.
+    // Node handles TypeScript compilation natively via strip-types.
+    const { registerAliasResolver } = await import(
+      '../esm/register-esm.mjs' as string
+    );
+    await registerAliasResolver({
+      absoluteBaseUrl,
+      paths: tsPaths,
+    });
+  }
 };

--- a/tests/integration/server-config/server/modern.server.ts
+++ b/tests/integration/server-config/server/modern.server.ts
@@ -2,6 +2,7 @@ import {
   type MiddlewareHandler,
   defineServerConfig,
 } from '@modern-js/server-runtime';
+import { value } from '@shared/repro';
 import plugin1 from './plugins/serverPlugin';
 
 const timing: MiddlewareHandler = async (c, next) => {
@@ -34,7 +35,7 @@ export default defineServerConfig({
     {
       name: 'set-message',
       handler: async (c, next) => {
-        c.set('message', 'hi');
+        c.set('message', value || 'hi');
         await next();
       },
     },

--- a/tests/integration/server-config/shared/repro.ts
+++ b/tests/integration/server-config/shared/repro.ts
@@ -1,0 +1,1 @@
+export const value = 'alias test';

--- a/tests/integration/server-config/tests/index.test.ts
+++ b/tests/integration/server-config/tests/index.test.ts
@@ -50,7 +50,7 @@ const supportServerMiddleware = async ({
 
   const { headers } = res;
   expect(headers.get('X-Middleware')).toMatch('request');
-  expect(headers.get('x-message')).toMatch('hi');
+  expect(headers.get('x-message')).toMatch('alias test');
 };
 
 const supportServerPlugin = async ({


### PR DESCRIPTION
 Node 22.15+ enables native TypeScript strip-types by default, making it possible to run `.ts` files without `ts-node`.       
 
However, setupTsRuntime() previously returned early when ts-node (optional dep) was not found, skipping `tsconfig-paths` registration as well. This meant tsconfig path aliases (@shared/*, @/*) and extensionless relative imports in `server/modern.server.ts` would fail with ERR_MODULE_NOT_FOUND.

This PR adds a lightweight ESM resolve hook (alias-resolver.mjs) registered via node:module register API when ts-node is unavailable but Node has native TypeScript support. Existing behavior with ts-node is unchanged.



