### PR TITLE
fix: RSC routes pattern and head exports

### DIFF
--- a/packages/cli/builder/src/plugins/rscConfig.ts
+++ b/packages/cli/builder/src/plugins/rscConfig.ts
@@ -62,7 +62,7 @@ export function pluginRscConfig(): RsbuildPlugin {
             //         $.tsx, $.ts, $.jsx, $.js
             // Use [/\\] before filename so both Unix (/) and Windows (\) paths match
             const routeFilePattern =
-              /routes[/\\].*[/\\](layout|page|\$)\.[tj]sx?$/;
+              /[/\\]routes[/\\](?:.*[/\\])?(?:layout|page|\$)\.[tj]sx?$/;
 
             // Pattern 2: Match App.[tj]sx files anywhere (self-controlled routing)
             // Matches: App.tsx, App.ts, App.jsx, App.js in any directory

--- a/packages/runtime/plugin-runtime/src/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/cli/index.ts
@@ -86,6 +86,11 @@ export const runtimePlugin = (params?: {
           globalVars: {
             'process.env.IS_REACT18': process.env.IS_REACT18,
           },
+          include: [
+            new RegExp(
+              `[\\\\/]node_modules[\\\\/]@${metaName}[\\\\/]runtime[\\\\/].*[\\\\/]head\\.[jt]sx?$`,
+            ),
+          ],
         },
         tools: {
           bundlerChain: chain => {

--- a/packages/runtime/plugin-runtime/src/exports/head.ts
+++ b/packages/runtime/plugin-runtime/src/exports/head.ts
@@ -1,5 +1,15 @@
+'use client';
 import head from 'react-helmet';
 
 export default head;
 
-export * from 'react-helmet';
+export { Helmet } from 'react-helmet';
+export type {
+  HelmetTags,
+  HelmetProps,
+  HelmetPropsToState,
+  HelmetData,
+  HelmetDatum,
+  HelmetHTMLBodyDatum,
+  HelmetHTMLElementDatum,
+} from 'react-helmet';


### PR DESCRIPTION
## Summary
- Refine RSC routes file regex to correctly match layout/page/$ files under routes directory
- Ensure runtime head plugin includes @runtime/head entry files and exposes typed Helmet exports
