### PR TITLE
docs: update react-server-dom-rspack version to 0.0.1-beta.1

### DIFF
--- a/packages/document/docs/en/configure/app/server/rsc.mdx
+++ b/packages/document/docs/en/configure/app/server/rsc.mdx
@@ -22,7 +22,7 @@ export default defineConfig({
 :::tip Prerequisites
 Before enabling RSC, ensure:
 1. React and React DOM are upgraded to version 19 (recommended 19.2.4 or above)
-2. Install the `react-server-dom-rspack@0.0.1-beta.0` dependency
+2. Install the `react-server-dom-rspack@0.0.1-beta.1` dependency
 
 :::
 

--- a/packages/document/docs/en/guides/basic-features/render/rsc.mdx
+++ b/packages/document/docs/en/guides/basic-features/render/rsc.mdx
@@ -23,10 +23,10 @@ Before starting, we recommend reading React's official [Server Components docume
 
 1. **Ensure React and React DOM are upgraded to version 19** (recommended version 19.2.4 or above)
 
-2. **Install the `react-server-dom-rspack@0.0.1-beta.0` dependency**
+2. **Install the `react-server-dom-rspack@0.0.1-beta.1` dependency**
 
 ```bash
-npm install react-server-dom-rspack@0.0.1-beta.0
+npm install react-server-dom-rspack@0.0.1-beta.1
 ```
 
 :::warning Notes

--- a/packages/document/docs/zh/configure/app/server/rsc.mdx
+++ b/packages/document/docs/zh/configure/app/server/rsc.mdx
@@ -22,7 +22,7 @@ export default defineConfig({
 :::tip 前置条件
 在启用 RSC 之前，请确保：
 1. React 和 React DOM 已升级到 19 版本（建议 19.2.4 以上版本）
-2. 已安装 `react-server-dom-rspack@0.0.1-beta.0` 依赖
+2. 已安装 `react-server-dom-rspack@0.0.1-beta.1` 依赖
 
 :::
 

--- a/packages/document/docs/zh/guides/basic-features/render/rsc.mdx
+++ b/packages/document/docs/zh/guides/basic-features/render/rsc.mdx
@@ -23,10 +23,10 @@ React Server Components (RSC) 是一种新的组件类型，允许在服务端�
 
 1. **确保 React 和 React DOM 升级到 19 版本**（建议 19.2.4 以上版本）
 
-2. **安装 `react-server-dom-rspack@0.0.1-beta.0` 依赖**
+2. **安装 `react-server-dom-rspack@0.0.1-beta.1` 依赖**
 
 ```bash
-npm install react-server-dom-rspack@0.0.1-beta.0
+npm install react-server-dom-rspack@0.0.1-beta.1
 ```
 
 :::warning 注意事项


### PR DESCRIPTION
## Summary
- Update `react-server-dom-rspack` version references in documentation from `0.0.1-beta.0` to `0.0.1-beta.1`
- Follow-up to #8384 which upgraded the actual dependencies

## Changed files
- `packages/document/docs/en/configure/app/server/rsc.mdx`
- `packages/document/docs/en/guides/basic-features/render/rsc.mdx`
- `packages/document/docs/zh/configure/app/server/rsc.mdx`
- `packages/document/docs/zh/guides/basic-features/render/rsc.mdx`

## Test plan
- [ ] CI passes
- [ ] Documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)