### PR TITLE
docs: add breaking change for node_modules resolution removal in v3

### DIFF
--- a/packages/document/docs/en/guides/upgrade/other.mdx
+++ b/packages/document/docs/en/guides/upgrade/other.mdx
@@ -170,6 +170,14 @@ antd v5 uses a CSS-in-JS solution and natively supports on-demand loading, so `s
 For more details, refer to [Rsbuild - source.transformImport](https://v2.rsbuild.rs/config/source/transform-import).
 :::
 
+## `node_modules` Resolution Behavior Removed
+
+In Modern.js v1, there was an internal workaround that redirected `node_modules` module resolution to the project root directory. This behavior has been removed in Modern.js 3.0.
+
+This workaround was not a standard practice and could lead to unpredictable dependency resolution — for example, packages not explicitly declared in a project's `package.json` might still resolve successfully, masking missing dependency declarations.
+
+If your project relied on this behavior, ensure that all required dependencies are explicitly declared in your `package.json` and installed locally.
+
 ## ESLint Rule Sets
 
 Modern.js previously provided complete ESLint rule sets, covering @modern-js (Lint rules for Node.js projects) and @modern-js-app (Lint rules for frontend projects). In [v2.60.0](https://github.com/web-infra-dev/modern.js/releases/tag/v2.60.0), we officially removed these rule sets. We encourage developers to choose appropriate code specification tools according to their needs, directly use ESLint combined with community-recommended rules, or use Biome to improve code formatting performance.

--- a/packages/document/docs/zh/guides/upgrade/other.md
+++ b/packages/document/docs/zh/guides/upgrade/other.md
@@ -171,6 +171,14 @@ antd v5 使用了 CSS-in-JS 方案，已原生支持按需加载，无需配置 
 更多用法请参考 [Rsbuild - source.transformImport](https://v2.rsbuild.rs/config/source/transform-import)。
 :::
 
+## 移除 `node_modules` 解析重定向行为
+
+在 Modern.js v1 版本中，框架内部存在一个 hack，会将 `node_modules` 的模块解析路径强制指向项目根目录。在 Modern.js 3.0 中，我们移除了这一行为。
+
+这一做法并非标准实践，可能导致不可预期的依赖解析问题——例如，未在 `package.json` 中显式声明的依赖包可能仍能被解析，从而掩盖了缺失的依赖声明。
+
+如果你的项目依赖了这一行为，请确保所有需要的依赖都已在 `package.json` 中显式声明并安装到本地。
+
 ## Eslint 规则集
 
 Modern.js 之前提供了 ESLint 的完整规则集，涵盖了 @modern-js（针对 Node.js 项目的 Lint 规则）和 @modern-js-app（针对前端项目的 Lint 规则）。在 [v2.60.0](https://github.com/web-infra-dev/modern.js/releases/tag/v2.60.0) 版本中，我们正式移除了这些规则集。我们鼓励开发者根据自身需求选择合适的代码规范工具，直接使用 ESLint 并结合社区推荐的规则，或使用 Biome 以提升代码格式化的性能。


### PR DESCRIPTION
## Summary

- Documents the removal of an internal v1 hack that redirected `node_modules` module resolution to the project root directory
- This behavior was removed in Modern.js 3.0 as it is not a standard practice and can lead to unpredictable dependency resolution
- Added the new section to both the English (`other.mdx`) and Chinese (`other.md`) upgrade guides under "Other Important Changes"

## Changes

- `packages/document/docs/en/guides/upgrade/other.mdx`: Added "node_modules Resolution Behavior Removed" section
- `packages/document/docs/zh/guides/upgrade/other.md`: Added "移除 node_modules 解析重定向行为" section

## Test plan

- [ ] Verify the new section renders correctly in the docs site
- [ ] Check that links and formatting are correct in both EN and ZH versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)