### PR TITLE
fix: correct use browser mode and polish docs

### DIFF
--- a/packages/cli/adapter-rstest/package.json
+++ b/packages/cli/adapter-rstest/package.json
@@ -26,7 +26,7 @@
     "test": "rstest"
   },
   "dependencies": {
-    "@rstest/adapter-rsbuild": "^0.2.1",
+    "@rstest/adapter-rsbuild": "^0.2.2",
     "@modern-js/app-tools": "workspace:*"
   },
   "devDependencies": {

--- a/packages/document/docs/en/guides/basic-features/testing/rstest.mdx
+++ b/packages/document/docs/en/guides/basic-features/testing/rstest.mdx
@@ -1,49 +1,18 @@
 # Rstest
 
-[Rstest](https://rstest.rs) is a testing framework developed by the Rspack team, built on Rspack with extremely fast test execution.
+[Rstest](https://rstest.rs) is a testing framework developed by the Rspack team and built on top of Rspack for fast test execution.
 
-This guide explains how to integrate Rstest with Modern.js for seamless testing in your Modern.js project.
+This guide explains how to integrate Rstest with Modern.js for web app testing.
 
 ## Quick Start
 
-To use Rstest in Modern.js, you need to install dependencies first by running the following command:
+Install the base dependencies first:
 
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs
-  command={{
-    npm: 'npm install -D @rstest/core @modern-js/adapter-rstest happy-dom @testing-library/react @testing-library/dom',
-    yarn: 'yarn add -D @rstest/core @modern-js/adapter-rstest happy-dom @testing-library/react @testing-library/dom',
-    pnpm: 'pnpm install -D @rstest/core @modern-js/adapter-rstest happy-dom @testing-library/react @testing-library/dom',
-    bun: 'bun add -D @rstest/core @modern-js/adapter-rstest happy-dom @testing-library/react @testing-library/dom',
-  }}
-/>
+<PackageManagerTabs command="add @rstest/core @modern-js/adapter-rstest -D" />
 
-Next, you need to create a Rstest configuration file `rstest.config.ts` with the following content:
-
-```ts title="rstest.config.ts"
-import { defineConfig } from '@rstest/core';
-
-export default defineConfig({
-  testEnvironment: 'happy-dom',
-});
-```
-
-For more information about Rstest configuration, refer to the [Rstest configuration documentation](https://rstest.rs/config).
-
-You can run test cases with the `npx rstest` command. You can also add the `rstest` command to `package.json`:
-
-```json title="package.json"
-{
-  "scripts": {
-    "test": "rstest"
-  }
-}
-```
-
-## Using Modern.js Configuration
-
-`@modern-js/adapter-rstest` is an official adapter that allows Rstest to automatically inherit configuration from your existing Modern.js config files. This ensures your test environment matches your build configuration without duplicate setup.
+Then create `rstest.config.ts`:
 
 ```ts title="rstest.config.ts"
 import { defineConfig } from '@rstest/core';
@@ -54,33 +23,113 @@ export default defineConfig({
 });
 ```
 
-:::tip
-Currently, the `@modern-js/adapter-rstest` adapter only supports web tests in Modern.js projects and other types (such as `bff`) should use Rstest configuration directly.
-:::
+`@modern-js/adapter-rstest` lets Rstest inherit your existing Modern.js config so your test setup stays aligned with your app.
 
-## Creating Unit Tests
+For more configuration details, refer to the [Rstest configuration documentation](https://rstest.rs/config).
+
+You can run tests with `npx rstest`, or add a script in `package.json`:
+
+```json title="package.json"
+{
+  "scripts": {
+    "test": "rstest"
+  }
+}
+```
+
+## Testing Web UI
+
+For web UI tests in Modern.js, there are two common approaches:
+
+- Use Rstest browser mode, which runs tests in a real browser. This is the recommended option in most cases, although it is currently experimental.
+- Use a simulated DOM environment with `happy-dom` and Testing Library. This matches the default web test environment provided by `@modern-js/adapter-rstest`.
+
+We generally recommend browser mode because it uses real browser APIs and behavior, supports cases that simulated DOM environments cannot fully cover, and offers a better debugging experience when UI behavior does not match expectations.
+
+### Browser mode (experimental)
+
+If you want to test in a real browser instead of a simulated DOM, install the browser mode dependencies:
+
+<PackageManagerTabs command="add @rstest/browser @rstest/browser-react playwright -D" />
+
+Then enable browser mode in `rstest.config.ts`:
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { withModernConfig } from '@modern-js/adapter-rstest';
+
+export default defineConfig({
+  extends: withModernConfig(),
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+  },
+});
+```
+
+Example test:
+
+```tsx title="__tests__/page.browser.test.tsx"
+import { BrowserRouter as Router } from '@modern-js/runtime/router';
+import { page } from '@rstest/browser';
+import { render } from '@rstest/browser-react';
+import { expect, test } from '@rstest/core';
+import Page from '../routes/page';
+
+test('Page', async () => {
+  await render(
+    <Router>
+      <Page />
+    </Router>,
+  );
+
+  await expect.element(
+    page.getByRole('heading', { level: 1, name: 'Home' }),
+  ).toBeVisible();
+});
+```
+
+For more browser mode setup, Locator APIs, and assertions, refer to the [Rstest documentation](https://rstest.rs/guide/browser-testing/).
+
+### DOM simulation with `happy-dom`
+
+Install the DOM testing dependencies:
+
+<PackageManagerTabs command="add happy-dom @testing-library/react @testing-library/dom -D" />
+
+Update `rstest.config.ts` to use `happy-dom`:
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { withModernConfig } from '@modern-js/adapter-rstest';
+
+export default defineConfig({
+  extends: withModernConfig(),
+  testEnvironment: 'happy-dom',
+});
+```
 
 First, create a simple page for testing:
 
 ```tsx title="routes/page.tsx"
 import { Link } from '@modern-js/runtime/router';
 
-const Index = () => (
+const Page = () => (
   <div>
     <h1>Home</h1>
     <Link to="/about">About</Link>
   </div>
 );
 
-export default Index;
+export default Page;
 ```
 
-Add a test case to check if the page contains the expected text:
+Then add a test case:
 
 ```tsx title="__tests__/page.test.tsx"
+import { BrowserRouter as Router } from '@modern-js/runtime/router';
 import { expect, test } from '@rstest/core';
 import { render, screen } from '@testing-library/react';
-import { BrowserRouter as Router } from '@modern-js/runtime/router';
 import Page from '../routes/page';
 
 test('Page', () => {
@@ -89,13 +138,14 @@ test('Page', () => {
       <Page />
     </Router>,
   );
+
   expect(screen.getByRole('heading', { level: 1, name: 'Home' })).toBeDefined();
 });
 ```
 
 ## Running Test Cases
 
-Execute the `test` command above to run the test cases:
+Execute the `test` command above to run your tests:
 
 ```bash
 ✓ __tests__/page.test.tsx (1)
@@ -105,3 +155,9 @@ Execute the `test` command above to run the test cases:
       Tests 1 passed
    Duration 510ms (build 145ms, tests 365ms)
 ```
+
+## Node Mode
+
+If you need node mode tests for server-side logic such as `bff`, refer to the [Rstest documentation](https://rstest.rs) directly.
+
+Modern.js mainly targets web apps, so this guide focuses on web UI testing and browser mode.

--- a/packages/document/docs/zh/guides/basic-features/testing/rstest.mdx
+++ b/packages/document/docs/zh/guides/basic-features/testing/rstest.mdx
@@ -1,49 +1,18 @@
 # Rstest
 
-[Rstest](https://rstest.rs) 是由 Rspack 团队开发的测试框架，基于 Rspack 构建，具有极快的测试执行速度。
+[Rstest](https://rstest.rs) 是由 Rspack 团队开发的测试框架，基于 Rspack 构建，具备很快的测试执行速度。
 
-本指南介绍了如何将 Rstest 与 Modern.js 集成，以便在你的 Modern.js 项目中进行无缝测试。
+本指南介绍如何在 Modern.js 中集成 Rstest，并用于 web app 测试。
 
 ## 快速开始
 
-在 Modern.js 中使用 Rstest 需要先安装依赖，可以执行以下命令：
+先安装基础依赖：
 
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs
-  command={{
-    npm: 'npm install -D @rstest/core @modern-js/adapter-rstest happy-dom @testing-library/react @testing-library/dom',
-    yarn: 'yarn add -D @rstest/core @modern-js/adapter-rstest happy-dom @testing-library/react @testing-library/dom',
-    pnpm: 'pnpm install -D @rstest/core @modern-js/adapter-rstest happy-dom @testing-library/react @testing-library/dom',
-    bun: 'bun add -D @rstest/core @modern-js/adapter-rstest happy-dom @testing-library/react @testing-library/dom',
-  }}
-/>
+<PackageManagerTabs command="add @rstest/core @modern-js/adapter-rstest -D" />
 
-接下来，你需要创建一个 Rstest 配置文件 `rstest.config.ts`，内容如下：
-
-```ts title="rstest.config.ts"
-import { defineConfig } from '@rstest/core';
-
-export default defineConfig({
-  testEnvironment: 'happy-dom',
-});
-```
-
-更多关于 Rstest 配置的信息，可以参考 [Rstest 配置文档](https://rstest.rs/config)。
-
-你可以通过 `npx rstest` 命令来运行测试用例，也可以将 `rstest` 命令添加到 `package.json` 中：
-
-```json title="package.json"
-{
-  "scripts": {
-    "test": "rstest"
-  }
-}
-```
-
-## 使用 Modern.js 配置
-
-`@modern-js/adapter-rstest` 是一个官方适配器，它允许 Rstest 自动从你现有的 Modern.js 配置文件中继承配置。这可以确保你的测试环境与构建配置相匹配，而无需重复配置。
+然后创建 `rstest.config.ts`：
 
 ```ts title="rstest.config.ts"
 import { defineConfig } from '@rstest/core';
@@ -54,33 +23,113 @@ export default defineConfig({
 });
 ```
 
-:::tip
-目前 `@modern-js/adapter-rstest` 适配器仅适用于 Modern.js 项目中的 web 测试，其他类型(如 `bff`) 测试请直接使用 Rstest 配置。
-:::
+`@modern-js/adapter-rstest` 可以让 Rstest 继承你现有的 Modern.js 配置，使测试环境和应用配置保持一致。
 
-## 创建单元测试
+更多配置项可以参考 [Rstest 配置文档](https://rstest.rs/config)。
 
-首先，创建一个简单的页面用于测试：
+你可以通过 `npx rstest` 运行测试，也可以在 `package.json` 中添加脚本：
+
+```json title="package.json"
+{
+  "scripts": {
+    "test": "rstest"
+  }
+}
+```
+
+## 测试 Web UI
+
+在 Modern.js 中测试 Web UI，通常有两种方案：
+
+- 使用 Rstest 的 browser mode，直接在真实浏览器中运行测试。大多数场景更推荐这种方式，但目前仍处于实验性阶段。
+- 使用 `happy-dom` 和 Testing Library 提供一个模拟 DOM 环境，这种方式也符合 `@modern-js/adapter-rstest` 默认的 web 测试环境。
+
+我们整体更推荐 browser mode，因为它使用的是真实浏览器 API 和行为，能覆盖模拟 DOM 难以完整支持的场景，同时在排查 UI 行为问题时也更容易调试。
+
+### Browser mode（实验性）
+
+如果你希望直接在真实浏览器中测试，而不是使用模拟 DOM，可以安装 browser mode 相关依赖：
+
+<PackageManagerTabs command="add @rstest/browser @rstest/browser-react playwright -D" />
+
+然后在 `rstest.config.ts` 中启用 browser mode：
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { withModernConfig } from '@modern-js/adapter-rstest';
+
+export default defineConfig({
+  extends: withModernConfig(),
+  browser: {
+    enabled: true,
+    provider: 'playwright',
+  },
+});
+```
+
+示例测试如下：
+
+```tsx title="__tests__/page.browser.test.tsx"
+import { BrowserRouter as Router } from '@modern-js/runtime/router';
+import { page } from '@rstest/browser';
+import { render } from '@rstest/browser-react';
+import { expect, test } from '@rstest/core';
+import Page from '../routes/page';
+
+test('Page', async () => {
+  await render(
+    <Router>
+      <Page />
+    </Router>,
+  );
+
+  await expect.element(
+    page.getByRole('heading', { level: 1, name: 'Home' }),
+  ).toBeVisible();
+});
+```
+
+关于 browser mode 的更多配置、Locator API 和断言能力，可以直接参考 [Rstest 文档](https://rstest.rs/guide/browser-testing/)。
+
+### 使用 `happy-dom` 模拟 DOM
+
+先安装 DOM 测试相关依赖：
+
+<PackageManagerTabs command="add happy-dom @testing-library/react @testing-library/dom -D" />
+
+然后在 `rstest.config.ts` 中启用 `happy-dom`：
+
+```ts title="rstest.config.ts"
+import { defineConfig } from '@rstest/core';
+import { withModernConfig } from '@modern-js/adapter-rstest';
+
+export default defineConfig({
+  extends: withModernConfig(),
+  testEnvironment: 'happy-dom',
+});
+```
+
+先创建一个简单页面用于测试：
 
 ```tsx title="routes/page.tsx"
 import { Link } from '@modern-js/runtime/router';
 
-const Index = () => (
+const Page = () => (
   <div>
     <h1>Home</h1>
     <Link to="/about">About</Link>
   </div>
 );
 
-export default Index;
+export default Page;
 ```
 
-添加测试用例，检测页面中是否有预期的文本：
+然后添加测试用例：
 
 ```tsx title="__tests__/page.test.tsx"
+import { BrowserRouter as Router } from '@modern-js/runtime/router';
 import { expect, test } from '@rstest/core';
 import { render, screen } from '@testing-library/react';
-import { BrowserRouter as Router } from '@modern-js/runtime/router';
 import Page from '../routes/page';
 
 test('Page', () => {
@@ -89,13 +138,14 @@ test('Page', () => {
       <Page />
     </Router>,
   );
+
   expect(screen.getByRole('heading', { level: 1, name: 'Home' })).toBeDefined();
 });
 ```
 
 ## 运行测试用例
 
-执行上述 `test` 命令，运行测试用例：
+执行上面的 `test` 命令即可运行测试：
 
 ```bash
 ✓ __tests__/page.test.tsx (1)
@@ -105,3 +155,9 @@ test('Page', () => {
       Tests 1 passed
    Duration 510ms (build 145ms, tests 365ms)
 ```
+
+## Node Mode
+
+如果你需要测试 `bff` 等 server-side logic，建议直接参考 [Rstest 文档](https://rstest.rs) 中关于 node mode 的说明。
+
+Modern.js 主要面向 web app，因此这里重点介绍的是 Web UI 测试，以及更贴近真实运行环境的 browser mode。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,8 +125,8 @@ importers:
         specifier: workspace:*
         version: link:../../solutions/app-tools
       '@rstest/adapter-rsbuild':
-        specifier: ^0.2.1
-        version: 0.2.1(@rsbuild/core@2.0.0-beta.4(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rstest/core@0.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
+        specifier: ^0.2.2
+        version: 0.2.2(@rsbuild/core@2.0.0-beta.4(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rstest/core@0.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
     devDependencies:
       '@modern-js/rslib':
         specifier: workspace:*
@@ -3697,6 +3697,9 @@ importers:
       '@modern-js/plugin-bff':
         specifier: workspace:*
         version: link:../../../../packages/cli/plugin-bff
+      '@rstest/core':
+        specifier: 0.9.0
+        version: 0.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -3738,17 +3741,14 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/solutions/app-tools
       '@rstest/browser':
-        specifier: ^0.9.0
+        specifier: 0.9.0
         version: 0.9.0(@rstest/core@0.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(playwright@1.58.2)(utf-8-validate@5.0.10)
       '@rstest/browser-react':
-        specifier: ^0.9.0
+        specifier: 0.9.0
         version: 0.9.0(@rstest/core@0.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@testing-library/jest-dom':
-        specifier: ^6.9.1
-        version: 6.9.1
-      '@testing-library/react':
-        specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rstest/core':
+        specifier: 0.9.0
+        version: 0.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@types/node':
         specifier: ^20
         version: 20.19.27
@@ -7179,8 +7179,8 @@ packages:
   '@rspress/shared@2.0.2':
     resolution: {integrity: sha512-9+QC8UL1gV2KpRZx4n55vAl6bE38y7eDnGJhdFSHdJkpFbUCiJDk9ZcR6jD/Rrtq7vlT0gfumUk640pxpi3IDQ==}
 
-  '@rstest/adapter-rsbuild@0.2.1':
-    resolution: {integrity: sha512-m/DBCERrFJr2hx6VlDM1o8oMJzWKABloW7a0+QKn61F/bQNM+PWlZdU+wtmQ6ljevmhRaJ+U9vHT6U4HZUS5Kg==}
+  '@rstest/adapter-rsbuild@0.2.2':
+    resolution: {integrity: sha512-Hv33JLQNN95wwCprGR51lDBqeUam9JR8gTdC0NvP5rcPmA/bFezAi1tERxnMci5FntGHgNicijZDfVhUm8v/Vg==}
     peerDependencies:
       '@rsbuild/core': '*'
       '@rstest/core': '>=0.7.7'
@@ -16807,7 +16807,7 @@ snapshots:
       '@changesets/read': 0.6.6
       '@modern-js/plugin-i18n': 2.70.4
       '@modern-js/utils': 2.70.4
-      '@swc/helpers': 0.5.18
+      '@swc/helpers': 0.5.19
       axios: 1.13.6(debug@4.4.3)
       resolve-from: 5.0.0
     transitivePeerDependencies:
@@ -16817,7 +16817,7 @@ snapshots:
   '@modern-js/plugin-i18n@2.70.4':
     dependencies:
       '@modern-js/utils': 2.70.4
-      '@swc/helpers': 0.5.18
+      '@swc/helpers': 0.5.19
 
   '@modern-js/plugin@2.70.4':
     dependencies:
@@ -18171,7 +18171,7 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rstest/adapter-rsbuild@0.2.1(@rsbuild/core@2.0.0-beta.4(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rstest/core@0.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)))':
+  '@rstest/adapter-rsbuild@0.2.2(@rsbuild/core@2.0.0-beta.4(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rstest/core@0.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)))':
     dependencies:
       '@rsbuild/core': 2.0.0-beta.4(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
       '@rstest/core': 0.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))

--- a/tests/integration/rstest/basic-app-rstest-browser/package.json
+++ b/tests/integration/rstest/basic-app-rstest-browser/package.json
@@ -18,10 +18,9 @@
   "devDependencies": {
     "@modern-js/app-tools": "workspace:*",
     "@modern-js/adapter-rstest": "workspace:*",
-    "@testing-library/react": "^16.3.2",
-    "@testing-library/jest-dom": "^6.9.1",
-    "@rstest/browser": "^0.9.0",
-    "@rstest/browser-react": "^0.9.0",
+    "@rstest/browser": "0.9.0",
+    "@rstest/browser-react": "0.9.0",
+    "@rstest/core": "0.9.0",
     "@types/node": "^20",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/tests/integration/rstest/basic-app-rstest-browser/rstest.config.ts
+++ b/tests/integration/rstest/basic-app-rstest-browser/rstest.config.ts
@@ -7,9 +7,12 @@ export default defineConfig({
   extends: withModernConfig({
     cwd: __dirname,
   }),
+  // Add setupFiles when you need global browser test setup, such as
+  // custom matchers, mocks, or polyfills.
+  // Docs: https://rstest.rs/config/
+  // setupFiles: ['./tests/rstest.setup.ts'],
   browser: {
     enabled: true,
     provider: 'playwright',
   },
-  setupFiles: ['./tests/rstest.setup.ts'],
 });

--- a/tests/integration/rstest/basic-app-rstest-browser/tests/App.test.tsx
+++ b/tests/integration/rstest/basic-app-rstest-browser/tests/App.test.tsx
@@ -1,14 +1,18 @@
 import { BrowserRouter as Router } from '@modern-js/runtime/router';
+import { page } from '@rstest/browser';
+import { render } from '@rstest/browser-react';
 import { expect, test } from '@rstest/core';
-import { render, screen } from '@testing-library/react';
 import App from '../src/App';
 
-test('renders the main page', () => {
+test('renders the main page', async () => {
   const testMessage = 'Powered by Modern.js';
-  render(
+  await render(
     <Router>
       <App />
     </Router>,
   );
-  expect(screen.getByText(testMessage)).toBeInTheDocument();
+
+  await expect
+    .element(page.getByRole('link', { name: testMessage }))
+    .toBeVisible();
 });

--- a/tests/integration/rstest/basic-app-rstest-browser/tests/rstest.setup.ts
+++ b/tests/integration/rstest/basic-app-rstest-browser/tests/rstest.setup.ts
@@ -1,4 +1,0 @@
-import { expect } from '@rstest/core';
-import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
-
-expect.extend(jestDomMatchers);

--- a/tests/integration/rstest/basic-app-rstest-browser/tests/tsconfig.json
+++ b/tests/integration/rstest/basic-app-rstest-browser/tests/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "types": ["@testing-library/jest-dom"]
-  },
   "include": ["./"]
 }

--- a/tests/integration/rstest/basic-app-rstest/package.json
+++ b/tests/integration/rstest/basic-app-rstest/package.json
@@ -19,6 +19,7 @@
     "@modern-js/app-tools": "workspace:*",
     "@modern-js/plugin-bff": "workspace:*",
     "@modern-js/adapter-rstest": "workspace:*",
+    "@rstest/core": "0.9.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/jest-dom": "^6.9.1",
     "happy-dom": "^20.7.0",


### PR DESCRIPTION
## Summary

- correct use browser mode with native Locator API
- add browser mode to Rstest docs

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
