### PR TITLE
chore(renovate): enable dependency dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,9 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":disableDependencyDashboard"],
+  "extends": ["config:recommended"],
   "baseBranch": ["main", "v2"],
- "rangeStrategy": "bump",
- "updateLockFiles": true,
+  "rangeStrategy": "bump",
+  "updateLockFiles": true,
   "schedule": ["every weekend"],
   "ignorePaths": ["**/node_modules/**", "packages/toolkit/utils/tests/fixtures/plugin"],
   "lockFileMaintenance": {


### PR DESCRIPTION
## Summary

Remove ":disableDependencyDashboard" from extends array to restore the dependency dashboard functionality in Renovate

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
