### PR TITLE
fix: disable the `o` shortcut key

### DIFF
--- a/.changeset/rare-readers-allow.md
+++ b/.changeset/rare-readers-allow.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: temporarily disable the `o` shortcut key, as it opens the wrong URL (/html/main => 404).
+
+fix: 临时禁用 `o` 快捷键，因为它会打开错误的网址（/html/main => 404）。

--- a/packages/solutions/app-tools/src/config/default.ts
+++ b/packages/solutions/app-tools/src/config/default.ts
@@ -11,8 +11,11 @@ export function createDefaultConfig(
     cliShortcuts: {
       help: false,
       // does not support restart server and print urls yet
+      // temporarily disable the `o` shortcut key, as it opens the wrong URL (/html/main => 404).
       custom: (shortcuts = []) =>
-        shortcuts.filter(({ key }) => key !== 'r' && key !== 'u'),
+        shortcuts.filter(
+          ({ key }) => key !== 'r' && key !== 'u' && key !== 'o',
+        ),
     },
   };
 


### PR DESCRIPTION
## Summary

Temporarily disable the `o` shortcut key, as it opens the wrong URL (`/html/main` => 404).


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
