### PR TITLE
test(server-config): add ts-node devDependency for integration test

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3911,6 +3911,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.19))(@types/node@20.19.27)(typescript@5.9.3)
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -17600,7 +17603,7 @@ snapshots:
       '@modern-js/types': 3.0.5
       '@modern-js/utils': 3.0.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@rsbuild/core': 2.0.0-beta.4(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-      '@swc/helpers': 0.5.18
+      '@swc/helpers': 0.5.19
       jiti: 2.6.1
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -17661,7 +17664,7 @@ snapshots:
     dependencies:
       '@modern-js/types': 3.0.5
       '@modern-js/utils': 3.0.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@swc/helpers': 0.5.18
+      '@swc/helpers': 0.5.19
       lru-cache: 10.4.3
       react-router: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       serialize-javascript: 6.0.2
@@ -17720,8 +17723,8 @@ snapshots:
 
   '@modern-js/utils@3.0.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@swc/helpers': 0.5.18
-      caniuse-lite: 1.0.30001766
+      '@swc/helpers': 0.5.19
+      caniuse-lite: 1.0.30001779
       import-meta-resolve: 4.2.0
       lodash: 4.17.23
       lodash-es: 4.17.23

--- a/tests/integration/server-config/package.json
+++ b/tests/integration/server-config/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
+    "ts-node": "^10.9.2",
     "@modern-js/app-tools": "workspace:*",
     "@modern-js/server-core": "workspace:*",
     "@modern-js/utils": "workspace:*",


### PR DESCRIPTION
## Summary

- Add `ts-node` to `tests/integration/server-config` devDependencies
- This ensures the integration test environment has `ts-node` installed, so the detection logic introduced in #8455 (checking `ts-node` in `package.json`) can be properly exercised

## Test plan

- [x] Run `tests/integration/server-config` integration tests and verify ts-node detection works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)