### PR TITLE
feat(server-core): update flatted -> 3.4.2

### DIFF
--- a/.changeset/mighty-rice-hear.md
+++ b/.changeset/mighty-rice-hear.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/server-core': patch
+---
+
+Update to address flatted crit cve https://security.snyk.io/vuln/SNYK-JS-FLATTED-15700433

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -77,7 +77,7 @@
     "@web-std/file": "^3.0.3",
     "@web-std/stream": "^1.0.3",
     "cloneable-readable": "^3.0.0",
-    "flatted": "^3.4.0",
+    "flatted": "^3.4.2",
     "hono": "^4.11.7",
     "ts-deepmerge": "7.0.3"
   },

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -105,7 +105,7 @@
     "esbuild": "0.25.5",
     "esbuild-register": "^3.6.0",
     "import-meta-resolve": "^4.2.0",
-    "flatted": "^3.4.0",
+    "flatted": "^3.4.2",
     "mlly": "^1.8.0",
     "ndepe": "^0.1.13",
     "pkg-types": "^1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -930,7 +930,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       flatted:
-        specifier: ^3.4.0
+        specifier: ^3.4.2
         version: 3.4.2
       hono:
         specifier: ^4.11.7
@@ -1300,7 +1300,7 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0(esbuild@0.27.2)
       flatted:
-        specifier: ^3.4.0
+        specifier: ^3.4.2
         version: 3.4.2
       import-meta-resolve:
         specifier: ^4.2.0


### PR DESCRIPTION
This pull request updates the `flatted` dependency to version `3.4.2` in order to address a critical security vulnerability (CVE: SNYK-JS-FLATTED-15700433). The update is applied across relevant packages and reflected in the lockfile.

**Security update:**

* Updated the `flatted` package from version `3.4.0` to `3.4.2` in both `@modern-js/app-tools` and `@modern-js/server-core` to address a critical CVE. (`packages/solutions/app-tools/package.json`, `packages/server/core/package.json`, `.changeset/mighty-rice-hear.md`) [[1]](diffhunk://#diff-48f59b5651ff1f982a17a10d709daf19b68a669d2fa3d26644935ca6d922f255L108-R108) [[2]](diffhunk://#diff-72d64068cfac474c44045cd4355db420d3bd76a309883643e3af7f08638d0cafL80-R80) [[3]](diffhunk://#diff-45374a4497d4309d1fa19727537b1b235963a60225ed92c6c8ad3fadbef3b12dR1-R6)

**Dependency management:**

* Updated `flatted` version and specifier in `pnpm-lock.yaml` to ensure consistency and lock the secure version across the project. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL933-R933) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1303-R1303)