### PR TITLE
fix(app-tools): restore bff-hono dev runtime selection

### DIFF
--- a/packages/solutions/app-tools/src/utils/register.ts
+++ b/packages/solutions/app-tools/src/utils/register.ts
@@ -58,7 +58,11 @@ export const setupTsRuntime = async (
     return;
   }
 
-  const registerMode = resolveTsRuntimeRegisterMode(hasTsNode);
+  const preferredRegisterMode = resolveTsRuntimeRegisterMode(hasTsNode);
+  const registerMode =
+    options.preferTsNodeForServerRuntime && hasTsNode
+      ? 'ts-node'
+      : preferredRegisterMode;
 
   const aliasConfig = getAliasConfig(alias, {
     appDirectory: appDir,


### PR DESCRIPTION
## Summary
- restore bff-hono dev runtime register mode selection
- prefer ts-node for server runtime when available to avoid dev instability

## Verification
- cd tests
- npm run test:framework bff-hono