### PR TITLE
fix: isolate sdk resource events between i18n instances

### DIFF
--- a/.changeset/shy-paths-teach.md
+++ b/.changeset/shy-paths-teach.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-i18n': patch
+---
+
+fix: isolate sdk resource events between i18n instances
+
+fix: 隔离多 i18n 实例之间的 sdk 资源事件串扰

--- a/packages/runtime/plugin-i18n/src/runtime/hooks.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/hooks.ts
@@ -3,6 +3,11 @@ import type { TRuntimeContext } from '@modern-js/runtime';
 import type React from 'react';
 import { useEffect, useRef } from 'react';
 import type { I18nInstance } from './i18n';
+import {
+  I18N_SDK_RESOURCES_LOADED_EVENT,
+  type I18nSdkResourcesLoadedEventDetail,
+  getI18nSdkBackendId,
+} from './i18n/backend/sdk-event';
 import { cacheUserLanguage } from './i18n/detection';
 import {
   buildLocalizedUrl,
@@ -59,12 +64,31 @@ export function useSdkResourcesLoader(
       return;
     }
 
+    const backendId =
+      getI18nSdkBackendId(i18nInstance.services?.resourceStore) ||
+      getI18nSdkBackendId(i18nInstance.services?.store) ||
+      getI18nSdkBackendId(i18nInstance.store);
+
+    if (!backendId) {
+      return;
+    }
+
     const handleSdkResourcesLoaded = (event: Event) => {
-      const customEvent = event as CustomEvent<{
-        language: string;
-        namespace: string;
-      }>;
-      const { language, namespace } = customEvent.detail;
+      const customEvent =
+        event as CustomEvent<I18nSdkResourcesLoadedEventDetail>;
+      const {
+        language,
+        namespace,
+        backendId: eventBackendId,
+      } = customEvent.detail || {};
+
+      if (!language || !namespace) {
+        return;
+      }
+
+      if (eventBackendId && eventBackendId !== backendId) {
+        return;
+      }
 
       const triggerUpdate = (retryCount = 0) => {
         const store = (i18nInstance as any).store;
@@ -110,13 +134,13 @@ export function useSdkResourcesLoader(
     };
 
     window.addEventListener(
-      'i18n-sdk-resources-loaded',
+      I18N_SDK_RESOURCES_LOADED_EVENT,
       handleSdkResourcesLoaded,
     );
 
     return () => {
       window.removeEventListener(
-        'i18n-sdk-resources-loaded',
+        I18N_SDK_RESOURCES_LOADED_EVENT,
         handleSdkResourcesLoaded,
       );
     };

--- a/packages/runtime/plugin-i18n/src/runtime/i18n/backend/sdk-backend.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/i18n/backend/sdk-backend.ts
@@ -1,5 +1,10 @@
 import type { I18nSdkLoadOptions, I18nSdkLoader } from '../../../shared/type';
 import type { Resources } from '../instance';
+import {
+  I18N_SDK_RESOURCES_LOADED_EVENT,
+  createI18nSdkBackendId,
+  setI18nSdkBackendId,
+} from './sdk-event';
 
 interface BackendOptions {
   sdk?: I18nSdkLoader;
@@ -29,6 +34,7 @@ export class SdkBackend {
   type = 'backend' as const;
   sdk?: I18nSdkLoader;
   private allResourcesCache: Resources | null = null;
+  private backendId = createI18nSdkBackendId();
   private loadingPromises = new Map<string, Promise<unknown>>();
   private services?: I18nextServices;
 
@@ -45,6 +51,10 @@ export class SdkBackend {
     this.services = services;
     void _i18nextOptions;
     this.sdk = backendOptions?.sdk;
+    setI18nSdkBackendId(
+      services.resourceStore || services.store,
+      this.backendId,
+    );
     if (!this.sdk) {
       throw new Error(
         'SdkBackend requires an SDK function to be provided in backend options',
@@ -283,8 +293,12 @@ export class SdkBackend {
 
   private triggerI18nextUpdate(language: string, namespace: string): void {
     if (typeof window !== 'undefined') {
-      const event = new CustomEvent('i18n-sdk-resources-loaded', {
-        detail: { language, namespace },
+      const event = new CustomEvent(I18N_SDK_RESOURCES_LOADED_EVENT, {
+        detail: {
+          language,
+          namespace,
+          backendId: this.backendId,
+        },
       });
       window.dispatchEvent(event);
     }

--- a/packages/runtime/plugin-i18n/src/runtime/i18n/backend/sdk-event.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/i18n/backend/sdk-event.ts
@@ -1,0 +1,39 @@
+export const I18N_SDK_RESOURCES_LOADED_EVENT = 'i18n-sdk-resources-loaded';
+
+const I18N_SDK_BACKEND_ID_KEY = '__modern_i18n_sdk_backend_id__';
+
+let sdkBackendInstanceCount = 0;
+
+export interface I18nSdkResourcesLoadedEventDetail {
+  language: string;
+  namespace: string;
+  backendId?: string;
+}
+
+export function createI18nSdkBackendId(): string {
+  sdkBackendInstanceCount += 1;
+  return `modern-i18n-sdk-backend-${sdkBackendInstanceCount}`;
+}
+
+export function setI18nSdkBackendId(target: unknown, backendId: string): void {
+  if (!target || typeof target !== 'object') {
+    return;
+  }
+
+  Object.defineProperty(target, I18N_SDK_BACKEND_ID_KEY, {
+    configurable: true,
+    enumerable: false,
+    value: backendId,
+    writable: true,
+  });
+}
+
+export function getI18nSdkBackendId(target: unknown): string | undefined {
+  if (!target || typeof target !== 'object') {
+    return undefined;
+  }
+
+  return (target as Record<string, unknown>)[I18N_SDK_BACKEND_ID_KEY] as
+    | string
+    | undefined;
+}


### PR DESCRIPTION
## Summary
在使用 garfish 或者 vmok 等这种微前端框架时，i18n 插件现在的共享事件机制会造成跨应用状态更新，从而导致应用频繁 rerender，当前改动隔离了多 i18n 实例之间的 sdk 资源事件串扰，从而避免了这个问题

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
