### PR TITLE
Fix/html genearate with uniq verify

### DIFF
--- a/.changeset/remove-unused-vercel-code.md
+++ b/.changeset/remove-unused-vercel-code.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/app-tools": patch
+---
+
+docs: remove unused code in vercel deployment plugin

--- a/.changeset/remove-unused-vercel-code.md
+++ b/.changeset/remove-unused-vercel-code.md
@@ -3,3 +3,4 @@
 ---
 
 docs: remove unused code in vercel deployment plugin
+docs: 移除 Vercel 部署插件中未使用的代码

--- a/packages/runtime/plugin-runtime/src/document/Html.tsx
+++ b/packages/runtime/plugin-runtime/src/document/Html.tsx
@@ -3,7 +3,9 @@ import React, { type ReactElement } from 'react';
 import { Body } from './Body';
 import { DocumentStructureContext } from './DocumentStructureContext';
 import { Head } from './Head';
+import { Links } from './Links';
 import { Root } from './Root';
+import { Scripts } from './Scripts';
 
 /**
  * get the directly son element by name
@@ -90,10 +92,16 @@ export function Html(
     findTargetChildByComponent(Head, children) ||
       findTargetChildByName('Head', children),
   );
-  const hasSetScripts = Boolean(findTargetElement('Scripts', children));
-  const hasSetLinks = Boolean(findTargetElement('Links', children));
+  const hasSetScripts = Boolean(
+    findTargetElementByComponent(Scripts, children) ||
+      findTargetChildByName('Scripts', children),
+  );
+  const hasSetLinks = Boolean(
+    findTargetElementByComponent(Links, children) ||
+      findTargetChildByName('Links', children),
+  );
   const hasSetBody = Boolean(
-    findTargetChildByComponent(Body, children) ||
+    findTargetElementByComponent(Body, children) ||
       findTargetChildByName('Body', children),
   );
   const hasSetRoot = Boolean(

--- a/packages/solutions/app-tools/src/plugins/deploy/platforms/vercel.ts
+++ b/packages/solutions/app-tools/src/plugins/deploy/platforms/vercel.ts
@@ -2,8 +2,8 @@ import path from 'node:path';
 import { fs as fse, removeModuleSyncFromExports } from '@modern-js/utils';
 import { nodeDepEmit as handleDependencies } from 'ndepe';
 import { isMainEntry } from '../../../utils/routes';
-import { getTemplatePath, readTemplate, resolveESMDependency } from '../utils';
-import { type PluginItem, generateHandler } from '../utils/generator';
+import { readTemplate, resolveESMDependency } from '../utils';
+import { generateHandler } from '../utils/generator';
 import type { CreatePreset } from './platform';
 
 export const createVercelPreset: CreatePreset = ({


### PR DESCRIPTION
## Summary

  清理 @modern-js/app-tools 包中 Vercel
  部署平台插件的冗余代码。移除了未使用的 getTemplatePath 和 PluginItem
  导入，以保持代码整洁。

  - @modern-js/app-tools:
    - 在 packages/solutions/app-tools/src/plugins/deploy/platforms/verc
      el.ts 中移除未使用的辅助函数 getTemplatePath 导入。
    - 移除 ../utils/generator 中未使用的类型 PluginItem 导入。

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
