### PR TITLE
test(app-tools): isolate ts-node-loader fixture config

### DIFF
--- a/packages/solutions/app-tools/tests/utils/ts-node-loader.test.ts
+++ b/packages/solutions/app-tools/tests/utils/ts-node-loader.test.ts
@@ -10,6 +10,7 @@ describe('ts-node-loader', () => {
     const appDir = path.join(rootDir, 'app');
     const serviceDir = path.join(rootDir, 'service');
     const serviceFile = path.join(serviceDir, 'user.ts');
+    const tsconfigPath = path.join(rootDir, 'tsconfig.json');
     const loaderPath = path.resolve(
       __dirname,
       '../../src/esm/ts-node-loader.mjs',
@@ -18,6 +19,17 @@ describe('ts-node-loader', () => {
     fs.mkdirSync(appDir, { recursive: true });
     fs.mkdirSync(serviceDir, { recursive: true });
     fs.writeFileSync(serviceFile, 'export const user = 1;\n');
+    // Keep ts-node isolated from workspace-level tsconfig files in CI.
+    fs.writeFileSync(
+      tsconfigPath,
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ES2020',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+        },
+      }),
+    );
 
     try {
       const output = childProcess.execFileSync(
@@ -55,8 +67,12 @@ describe('ts-node-loader', () => {
           `,
         ],
         {
-          cwd: process.cwd(),
+          cwd: rootDir,
           encoding: 'utf8',
+          env: {
+            ...process.env,
+            TS_NODE_PROJECT: tsconfigPath,
+          },
         },
       );
 


### PR DESCRIPTION
## Summary

This PR fixes a eco-CI-only failure in `ts-node-loader.test.ts` where `ts-node` could pick up a workspace-level `tsconfig` with unsupported `moduleResolution` values in eco-ci. The test now uses an isolated temporary `tsconfig` and runs the child process from the fixture root so resolution stays deterministic across environments.

## Related Links

fix: https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/24324272940/job/71016372656

test ci: https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/24329567135

## Checklist

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
