### PR TITLE
fix(create): add @rsbuild/core/types reference to modern-app-env.d.ts template

### DIFF
--- a/.changeset/little-cars-cough.md
+++ b/.changeset/little-cars-cough.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/create': patch
+---
+
+add @rsbuild/core/types reference to modern-app-env.d.ts template

--- a/.changeset/little-cars-cough.md
+++ b/.changeset/little-cars-cough.md
@@ -1,5 +1,5 @@
 ---
-'@modern-js/create': patch
+'@modern-js/app-tools': patch
 ---
 
-add @rsbuild/core/types reference to modern-app-env.d.ts template
+add @rsbuild/core/types reference to app-tools types

--- a/packages/solutions/app-tools/lib/types.d.ts
+++ b/packages/solutions/app-tools/lib/types.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 /// <reference types="react" />
 /// <reference types="react-dom" />
+/// <reference types="@rsbuild/core/types" />
 /// <reference path="../dist/types/index.d.ts" />
 
 declare namespace NodeJS {

--- a/packages/solutions/app-tools/tests/types.test.ts
+++ b/packages/solutions/app-tools/tests/types.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repoRoot = join(__dirname, '../../../..');
+
+describe('app-tools types', () => {
+  it('includes Rsbuild client types from the shared app-tools type reference', () => {
+    const appToolsTypes = readFileSync(
+      join(repoRoot, 'packages/solutions/app-tools/lib/types.d.ts'),
+      'utf-8',
+    );
+    const appEnvTemplate = readFileSync(
+      join(
+        repoRoot,
+        'packages/toolkit/create/template/src/modern-app-env.d.ts',
+      ),
+      'utf-8',
+    );
+
+    expect(appToolsTypes).toContain(
+      '/// <reference types="@rsbuild/core/types" />',
+    );
+    expect(appEnvTemplate).toBe(
+      "/// <reference types='@modern-js/app-tools/types' />\n",
+    );
+  });
+});

--- a/packages/solutions/app-tools/tests/types.test.ts
+++ b/packages/solutions/app-tools/tests/types.test.ts
@@ -20,8 +20,9 @@ describe('app-tools types', () => {
     expect(appToolsTypes).toContain(
       '/// <reference types="@rsbuild/core/types" />',
     );
-    expect(appEnvTemplate).toBe(
-      "/// <reference types='@modern-js/app-tools/types' />\n",
+    expect(appEnvTemplate).toContain(
+      "/// <reference types='@modern-js/app-tools/types' />",
     );
+    expect(appEnvTemplate).not.toContain('@rsbuild/core/types');
   });
 });

--- a/packages/toolkit/create/template/src/modern-app-env.d.ts
+++ b/packages/toolkit/create/template/src/modern-app-env.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="@rsbuild/core/types" />
 /// <reference types='@modern-js/app-tools/types' />

--- a/packages/toolkit/create/template/src/modern-app-env.d.ts
+++ b/packages/toolkit/create/template/src/modern-app-env.d.ts
@@ -1,2 +1,1 @@
-/// <reference types="@rsbuild/core/types" />
 /// <reference types='@modern-js/app-tools/types' />


### PR DESCRIPTION
## Summary

The following type reference is missing in the default modern-app-env.d.ts, which causes import.meta.xxx to result in a type error.

## Related Links

#8522 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
