### PR TITLE
fix(app-tools): avoid resolving ts paths from non-file parents

### DIFF
--- a/packages/solutions/app-tools/src/esm/ts-paths-loader.mjs
+++ b/packages/solutions/app-tools/src/esm/ts-paths-loader.mjs
@@ -53,7 +53,14 @@ export async function initialize({ appDir: currentAppDir, baseUrl, paths }) {
 }
 
 export function resolve(specifier, context, defaultResolve) {
-  const parentPath = context.parentURL
+  const hasParentURL = Boolean(context.parentURL);
+  const isFileParentURL = context.parentURL?.startsWith('file:');
+
+  if (hasParentURL && !isFileParentURL) {
+    return defaultResolve(specifier, context, defaultResolve);
+  }
+
+  const parentPath = isFileParentURL
     ? path.dirname(fileURLToPath(context.parentURL))
     : process.cwd();
   const relativeFromApp = appDir ? path.relative(appDir, parentPath) : '';
@@ -84,6 +91,10 @@ export function resolve(specifier, context, defaultResolve) {
   }
 
   if (!matchPath) {
+    return defaultResolve(specifier, context, defaultResolve);
+  }
+
+  if (!isAppFile) {
     return defaultResolve(specifier, context, defaultResolve);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4575,6 +4575,30 @@ importers:
         specifier: ^4.1.18
         version: 4.1.18
 
+  tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig:
+    dependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../../../packages/solutions/app-tools
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../../../packages/runtime/plugin-runtime
+      '@tailwindcss/postcss':
+        specifier: ^4.1.18
+        version: 4.1.18
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.8
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.1.18
+
   tests/integration/temp-dir:
     dependencies:
       '@modern-js/runtime':
@@ -20362,12 +20386,16 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
+  css-declaration-sorter@7.3.0(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+
   css-minimizer-webpack-plugin@7.0.2(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.17))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      cssnano: 7.1.2(postcss@8.5.6)
+      cssnano: 7.1.2(postcss@8.5.8)
       jest-worker: 29.7.0
-      postcss: 8.5.6
+      postcss: 8.5.8
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       webpack: 5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.17))
@@ -20445,47 +20473,47 @@ snapshots:
       postcss-svgo: 6.0.3(postcss@8.5.6)
       postcss-unique-selectors: 6.0.4(postcss@8.5.6)
 
-  cssnano-preset-default@7.0.10(postcss@8.5.6):
+  cssnano-preset-default@7.0.10(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.2
-      css-declaration-sorter: 7.3.0(postcss@8.5.6)
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-calc: 10.1.1(postcss@8.5.6)
-      postcss-colormin: 7.0.5(postcss@8.5.6)
-      postcss-convert-values: 7.0.8(postcss@8.5.6)
-      postcss-discard-comments: 7.0.5(postcss@8.5.6)
-      postcss-discard-duplicates: 7.0.2(postcss@8.5.6)
-      postcss-discard-empty: 7.0.1(postcss@8.5.6)
-      postcss-discard-overridden: 7.0.1(postcss@8.5.6)
-      postcss-merge-longhand: 7.0.5(postcss@8.5.6)
-      postcss-merge-rules: 7.0.7(postcss@8.5.6)
-      postcss-minify-font-values: 7.0.1(postcss@8.5.6)
-      postcss-minify-gradients: 7.0.1(postcss@8.5.6)
-      postcss-minify-params: 7.0.5(postcss@8.5.6)
-      postcss-minify-selectors: 7.0.5(postcss@8.5.6)
-      postcss-normalize-charset: 7.0.1(postcss@8.5.6)
-      postcss-normalize-display-values: 7.0.1(postcss@8.5.6)
-      postcss-normalize-positions: 7.0.1(postcss@8.5.6)
-      postcss-normalize-repeat-style: 7.0.1(postcss@8.5.6)
-      postcss-normalize-string: 7.0.1(postcss@8.5.6)
-      postcss-normalize-timing-functions: 7.0.1(postcss@8.5.6)
-      postcss-normalize-unicode: 7.0.5(postcss@8.5.6)
-      postcss-normalize-url: 7.0.1(postcss@8.5.6)
-      postcss-normalize-whitespace: 7.0.1(postcss@8.5.6)
-      postcss-ordered-values: 7.0.2(postcss@8.5.6)
-      postcss-reduce-initial: 7.0.5(postcss@8.5.6)
-      postcss-reduce-transforms: 7.0.1(postcss@8.5.6)
-      postcss-svgo: 7.1.0(postcss@8.5.6)
-      postcss-unique-selectors: 7.0.4(postcss@8.5.6)
+      css-declaration-sorter: 7.3.0(postcss@8.5.8)
+      cssnano-utils: 5.0.1(postcss@8.5.8)
+      postcss: 8.5.8
+      postcss-calc: 10.1.1(postcss@8.5.8)
+      postcss-colormin: 7.0.5(postcss@8.5.8)
+      postcss-convert-values: 7.0.8(postcss@8.5.8)
+      postcss-discard-comments: 7.0.5(postcss@8.5.8)
+      postcss-discard-duplicates: 7.0.2(postcss@8.5.8)
+      postcss-discard-empty: 7.0.1(postcss@8.5.8)
+      postcss-discard-overridden: 7.0.1(postcss@8.5.8)
+      postcss-merge-longhand: 7.0.5(postcss@8.5.8)
+      postcss-merge-rules: 7.0.7(postcss@8.5.8)
+      postcss-minify-font-values: 7.0.1(postcss@8.5.8)
+      postcss-minify-gradients: 7.0.1(postcss@8.5.8)
+      postcss-minify-params: 7.0.5(postcss@8.5.8)
+      postcss-minify-selectors: 7.0.5(postcss@8.5.8)
+      postcss-normalize-charset: 7.0.1(postcss@8.5.8)
+      postcss-normalize-display-values: 7.0.1(postcss@8.5.8)
+      postcss-normalize-positions: 7.0.1(postcss@8.5.8)
+      postcss-normalize-repeat-style: 7.0.1(postcss@8.5.8)
+      postcss-normalize-string: 7.0.1(postcss@8.5.8)
+      postcss-normalize-timing-functions: 7.0.1(postcss@8.5.8)
+      postcss-normalize-unicode: 7.0.5(postcss@8.5.8)
+      postcss-normalize-url: 7.0.1(postcss@8.5.8)
+      postcss-normalize-whitespace: 7.0.1(postcss@8.5.8)
+      postcss-ordered-values: 7.0.2(postcss@8.5.8)
+      postcss-reduce-initial: 7.0.5(postcss@8.5.8)
+      postcss-reduce-transforms: 7.0.1(postcss@8.5.8)
+      postcss-svgo: 7.1.0(postcss@8.5.8)
+      postcss-unique-selectors: 7.0.4(postcss@8.5.8)
 
   cssnano-utils@4.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  cssnano-utils@5.0.1(postcss@8.5.6):
+  cssnano-utils@5.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
   cssnano@6.1.2(postcss@8.5.6):
     dependencies:
@@ -20493,11 +20521,11 @@ snapshots:
       lilconfig: 3.1.3
       postcss: 8.5.6
 
-  cssnano@7.1.2(postcss@8.5.6):
+  cssnano@7.1.2(postcss@8.5.8):
     dependencies:
-      cssnano-preset-default: 7.0.10(postcss@8.5.6)
+      cssnano-preset-default: 7.0.10(postcss@8.5.8)
       lilconfig: 3.1.3
-      postcss: 8.5.6
+      postcss: 8.5.8
 
   csso@5.0.5:
     dependencies:
@@ -24205,9 +24233,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-calc@10.1.1(postcss@8.5.6):
+  postcss-calc@10.1.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
@@ -24225,12 +24253,12 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@7.0.5(postcss@8.5.6):
+  postcss-colormin@7.0.5(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-convert-values@6.1.0(postcss@8.5.6):
@@ -24239,10 +24267,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@7.0.8(postcss@8.5.6):
+  postcss-convert-values@7.0.8(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-custom-properties@13.3.12(postcss@8.5.6):
@@ -24258,34 +24286,34 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  postcss-discard-comments@7.0.5(postcss@8.5.6):
+  postcss-discard-comments@7.0.5(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-selector-parser: 7.1.1
 
   postcss-discard-duplicates@6.0.3(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-discard-duplicates@7.0.2(postcss@8.5.6):
+  postcss-discard-duplicates@7.0.2(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
   postcss-discard-empty@6.0.3(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-discard-empty@7.0.1(postcss@8.5.6):
+  postcss-discard-empty@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
   postcss-discard-overridden@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-discard-overridden@7.0.1(postcss@8.5.6):
+  postcss-discard-overridden@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
   postcss-flexbugs-fixes@5.0.2(postcss@8.5.6):
     dependencies:
@@ -24309,7 +24337,7 @@ snapshots:
   postcss-js@3.0.3:
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.6
+      postcss: 8.5.8
 
   postcss-js@4.1.0(postcss@8.5.6):
     dependencies:
@@ -24343,11 +24371,11 @@ snapshots:
       postcss-value-parser: 4.2.0
       stylehacks: 6.1.1(postcss@8.5.6)
 
-  postcss-merge-longhand@7.0.5(postcss@8.5.6):
+  postcss-merge-longhand@7.0.5(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
-      stylehacks: 7.0.7(postcss@8.5.6)
+      stylehacks: 7.0.7(postcss@8.5.8)
 
   postcss-merge-rules@6.1.1(postcss@8.5.6):
     dependencies:
@@ -24357,12 +24385,12 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  postcss-merge-rules@7.0.7(postcss@8.5.6):
+  postcss-merge-rules@7.0.7(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.8)
+      postcss: 8.5.8
       postcss-selector-parser: 7.1.1
 
   postcss-minify-font-values@6.1.0(postcss@8.5.6):
@@ -24370,9 +24398,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-minify-font-values@7.0.1(postcss@8.5.6):
+  postcss-minify-font-values@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-minify-gradients@6.0.3(postcss@8.5.6):
@@ -24382,11 +24410,11 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@7.0.1(postcss@8.5.6):
+  postcss-minify-gradients@7.0.1(postcss@8.5.8):
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.8)
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-minify-params@6.1.0(postcss@8.5.6):
@@ -24396,11 +24424,11 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@7.0.5(postcss@8.5.6):
+  postcss-minify-params@7.0.5(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.2
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.8)
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-minify-selectors@6.0.4(postcss@8.5.6):
@@ -24408,10 +24436,10 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  postcss-minify-selectors@7.0.5(postcss@8.5.6):
+  postcss-minify-selectors@7.0.5(postcss@8.5.8):
     dependencies:
       cssesc: 3.0.0
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-selector-parser: 7.1.1
 
   postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
@@ -24468,18 +24496,18 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  postcss-normalize-charset@7.0.1(postcss@8.5.6):
+  postcss-normalize-charset@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
 
   postcss-normalize-display-values@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-display-values@7.0.1(postcss@8.5.6):
+  postcss-normalize-display-values@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-normalize-positions@6.0.2(postcss@8.5.6):
@@ -24487,9 +24515,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@7.0.1(postcss@8.5.6):
+  postcss-normalize-positions@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-normalize-repeat-style@6.0.2(postcss@8.5.6):
@@ -24497,9 +24525,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@7.0.1(postcss@8.5.6):
+  postcss-normalize-repeat-style@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-normalize-string@6.0.2(postcss@8.5.6):
@@ -24507,9 +24535,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@7.0.1(postcss@8.5.6):
+  postcss-normalize-string@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-normalize-timing-functions@6.0.2(postcss@8.5.6):
@@ -24517,9 +24545,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@7.0.1(postcss@8.5.6):
+  postcss-normalize-timing-functions@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@6.1.0(postcss@8.5.6):
@@ -24528,10 +24556,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@7.0.5(postcss@8.5.6):
+  postcss-normalize-unicode@7.0.5(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-normalize-url@6.0.2(postcss@8.5.6):
@@ -24539,9 +24567,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@7.0.1(postcss@8.5.6):
+  postcss-normalize-url@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-normalize-whitespace@6.0.2(postcss@8.5.6):
@@ -24549,9 +24577,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@7.0.1(postcss@8.5.6):
+  postcss-normalize-whitespace@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-ordered-values@6.0.2(postcss@8.5.6):
@@ -24560,10 +24588,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-ordered-values@7.0.2(postcss@8.5.6):
+  postcss-ordered-values@7.0.2(postcss@8.5.8):
     dependencies:
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.8)
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-page-break@3.0.4(postcss@8.5.6):
@@ -24576,20 +24604,20 @@ snapshots:
       caniuse-api: 3.0.0
       postcss: 8.5.6
 
-  postcss-reduce-initial@7.0.5(postcss@8.5.6):
+  postcss-reduce-initial@7.0.5(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      postcss: 8.5.6
+      postcss: 8.5.8
 
   postcss-reduce-transforms@6.0.2(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-transforms@7.0.1(postcss@8.5.6):
+  postcss-reduce-transforms@7.0.1(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
   postcss-selector-parser@6.1.2:
@@ -24608,9 +24636,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 3.3.2
 
-  postcss-svgo@7.1.0(postcss@8.5.6):
+  postcss-svgo@7.1.0(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-value-parser: 4.2.0
       svgo: 4.0.0
 
@@ -24619,9 +24647,9 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  postcss-unique-selectors@7.0.4(postcss@8.5.6):
+  postcss-unique-selectors@7.0.4(postcss@8.5.8):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-selector-parser: 7.1.1
 
   postcss-value-parser@3.3.1: {}
@@ -24766,7 +24794,7 @@ snapshots:
     dependencies:
       commander: 8.3.0
       glob: 7.2.3
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-selector-parser: 6.1.2
 
   qs@6.14.1:
@@ -26226,10 +26254,10 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  stylehacks@7.0.7(postcss@8.5.6):
+  stylehacks@7.0.7(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.6
+      postcss: 8.5.8
       postcss-selector-parser: 7.1.1
 
   stylis@4.3.6: {}

--- a/tests/integration/alias-set/runtime/entry.mjs
+++ b/tests/integration/alias-set/runtime/entry.mjs
@@ -1,0 +1,3 @@
+import runtimeValue from '@common/runtime-value.mjs';
+
+export default runtimeValue;

--- a/tests/integration/alias-set/src/common/runtime-value.mjs
+++ b/tests/integration/alias-set/src/common/runtime-value.mjs
@@ -1,0 +1,3 @@
+const runtimeValue = 'alias runtime ok';
+
+export default runtimeValue;

--- a/tests/integration/alias-set/tests/index.test.ts
+++ b/tests/integration/alias-set/tests/index.test.ts
@@ -1,5 +1,7 @@
-import fs from 'fs';
-import path from 'path';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import puppeteer from 'puppeteer';
 import {
   getPort,
@@ -10,6 +12,11 @@ import {
 } from '../../../utils/modernTestUtils';
 
 const appDir = path.resolve(__dirname, '../');
+const runtimeEntryFile = path.join(appDir, 'runtime/entry.mjs');
+const loaderFile = path.resolve(
+  __dirname,
+  '../../../../packages/solutions/app-tools/src/esm/ts-paths-loader.mjs',
+);
 
 function existsSync(filePath: string) {
   return fs.existsSync(path.join(appDir, 'dist', filePath));
@@ -21,6 +28,84 @@ describe('alias set build', () => {
     expect(buildRes.code === 0).toBe(true);
     expect(existsSync('route.json')).toBe(true);
     expect(existsSync('html/index/index.html')).toBe(true);
+  });
+
+  test('should resolve runtime alias with node loader under file parent url', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        `
+          import { register } from 'node:module';
+          import { pathToFileURL } from 'node:url';
+
+          const appDir = ${JSON.stringify(appDir)};
+          register(pathToFileURL(${JSON.stringify(loaderFile)}).href, import.meta.url, {
+            data: {
+              appDir,
+              baseUrl: appDir,
+              paths: {
+                '@common/*': ['src/common/*'],
+              },
+            },
+          });
+
+          const mod = await import(pathToFileURL(${JSON.stringify(runtimeEntryFile)}).href);
+          process.stdout.write(String(mod.default));
+        `,
+      ],
+      {
+        cwd: appDir,
+        encoding: 'utf8',
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('alias runtime ok');
+    expect(result.stderr.trim()).toBe('');
+  });
+
+  test('should not resolve runtime alias for file parent outside app dir', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'modern-alias-set-'));
+    const tempEntryFile = path.join(tempDir, 'entry.mjs');
+
+    fs.writeFileSync(
+      tempEntryFile,
+      `import value from '@common/runtime-value.mjs';\nexport default value;\n`,
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        `
+          import { register } from 'node:module';
+          import { pathToFileURL } from 'node:url';
+
+          const appDir = ${JSON.stringify(appDir)};
+          register(pathToFileURL(${JSON.stringify(loaderFile)}).href, import.meta.url, {
+            data: {
+              appDir,
+              baseUrl: appDir,
+              paths: {
+                '@common/*': ['src/common/*'],
+              },
+            },
+          });
+
+          await import(pathToFileURL(${JSON.stringify(tempEntryFile)}).href);
+        `,
+      ],
+      {
+        cwd: appDir,
+        encoding: 'utf8',
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('@common/runtime-value.mjs');
   });
 });
 

--- a/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/modern.config.ts
+++ b/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/modern.config.ts
@@ -1,0 +1,5 @@
+import { applyBaseConfig } from '../../../../utils/applyBaseConfig';
+
+export default applyBaseConfig({
+  plugins: [],
+});

--- a/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/package.json
+++ b/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/package.json
@@ -1,0 +1,21 @@
+{
+  "private": true,
+  "type": "module",
+  "name": "integration-tailwindcss-v4-tsconfig",
+  "version": "2.66.0",
+  "scripts": {
+    "dev": "modern dev",
+    "build": "modern build",
+    "serve": "modern serve",
+    "new": "modern new"
+  },
+  "dependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/runtime": "workspace:*",
+    "postcss": "^8.5.6",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "@tailwindcss/postcss": "^4.1.18",
+    "tailwindcss": "^4.1.18"
+  }
+}

--- a/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/postcss.config.mjs
+++ b/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': true,
+  },
+};

--- a/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/src/App.jsx
+++ b/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/src/App.jsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import './index.css';
+import { primaryColorClass } from '@/theme';
+
+const App = () => {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    if (isDarkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [isDarkMode]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-6 transition-colors duration-300">
+      <button
+        onClick={() => setIsDarkMode(value => !value)}
+        className="px-4 py-2 bg-blue-500 text-white rounded-md"
+      >
+        Toggle
+      </button>
+      <div
+        className={`mt-6 w-12 h-12 rounded-full ${primaryColorClass} dark:bg-dark-primary`}
+      />
+    </div>
+  );
+};
+
+export default App;

--- a/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/src/index.css
+++ b/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/src/index.css
@@ -1,0 +1,3 @@
+@import 'tailwindcss';
+
+@config '../tailwind.config.js';

--- a/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/src/theme.js
+++ b/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/src/theme.js
@@ -1,0 +1,1 @@
+export const primaryColorClass = 'bg-primary';

--- a/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/tailwind.config.js
+++ b/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/tailwind.config.js
@@ -1,0 +1,16 @@
+export default {
+  darkMode: 'class',
+
+  theme: {
+    extend: {
+      colors: {
+        primary: 'blue',
+        secondary: 'yellow',
+        dark: {
+          primary: 'sky',
+          secondary: 'light-yellow',
+        },
+      },
+    },
+  },
+};

--- a/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/tsconfig.json
+++ b/tests/integration/tailwindcss/fixtures/tailwindcss-v4-tsconfig/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": ["src", "shared", "config", "modern.config.ts"],
+  "exclude": ["**/node_modules"]
+}

--- a/tests/integration/tailwindcss/tests/tailwindcss-v4.test.ts
+++ b/tests/integration/tailwindcss/tests/tailwindcss-v4.test.ts
@@ -1,12 +1,45 @@
 import path from 'path';
+import { modernBuild } from '../../../utils/modernTestUtils';
 import { fixtures, launchAppWithPage } from './utils';
 
 rstest.setConfig({ testTimeout: 180_000, hookTimeout: 180_000 });
 
 describe('use tailwindcss v4', () => {
-  test(`should show style by use tailwindcss theme`, async () => {
+  test('should build successfully with tailwindcss v4 baseline fixture', async () => {
     const appDir = path.resolve(fixtures, 'tailwindcss-v4');
+
+    const buildResult = await modernBuild(appDir, [], {});
+
+    expect(buildResult.code).toBe(0);
+  });
+
+  test('should serve successfully with tailwindcss v4 baseline fixture', async () => {
+    const appDir = path.resolve(fixtures, 'tailwindcss-v4');
+
     const { page, clear } = await launchAppWithPage(appDir);
+
+    try {
+      const primaryColorElement = await page.waitForSelector('.bg-primary');
+      const backgroundColor = await page.evaluate(element => {
+        const style = window.getComputedStyle(element);
+        return style.backgroundColor;
+      }, primaryColorElement);
+
+      expect(backgroundColor).toMatch(/rgb\(0, 0, 255\)|#0000ff|blue/i);
+    } finally {
+      await clear();
+    }
+  });
+
+  test('should build and serve successfully with tailwindcss v4 tsconfig paths', async () => {
+    const appDir = path.resolve(fixtures, 'tailwindcss-v4-tsconfig');
+
+    const buildResult = await modernBuild(appDir, [], {});
+
+    expect(buildResult.code).toBe(0);
+
+    const { page, clear } = await launchAppWithPage(appDir);
+
     try {
       const primaryColorElement = await page.waitForSelector('.bg-primary');
       const backgroundColor = await page.evaluate(element => {

--- a/tests/integration/tailwindcss/tests/utils.ts
+++ b/tests/integration/tailwindcss/tests/utils.ts
@@ -10,7 +10,7 @@ import {
 
 export const fixtures = path.resolve(__dirname, '../fixtures');
 
-const { readdirSync, readFileSync, copySync } = fs;
+const { readFileSync, readdirSync } = fs;
 
 export const getCssFiles = (appDir: string) =>
   readdirSync(path.resolve(appDir, 'dist/static/css')).filter(filepath =>
@@ -19,13 +19,6 @@ export const getCssFiles = (appDir: string) =>
 
 export const readCssFile = (appDir: string, filename: string) =>
   readFileSync(path.resolve(appDir, `dist/static/css/${filename}`), 'utf8');
-
-export const copyModules = (appDir: string) => {
-  copySync(
-    path.resolve(appDir, '_node_modules'),
-    path.resolve(appDir, 'node_modules'),
-  );
-};
 
 export const getCssMaps = (appDir: string) =>
   readdirSync(path.resolve(appDir, 'dist/static/css')).filter(filepath =>


### PR DESCRIPTION
## Summary
- avoid running the ts paths loader against non-`file:` parent URLs, which can be introduced by PostCSS/rsbuild virtual modules when loading `postcss.config.mjs`
- keep runtime alias resolution scoped to app files so the loader only participates where tsconfig path aliases are expected to apply
- add regression coverage for the Tailwind v4 + `postcss.config.mjs` + `tsconfig.json` crash and preserve the alias runtime boundary checks

## Validation
- `pnpm --filter @modern-js/app-tools build`
- `pnpm --dir tests exec rstest integration/tailwindcss/tests/tailwindcss-v4.test.ts`
- `pnpm --dir tests exec rstest integration/alias-set/tests/index.test.ts`
- verified the external repro from issue #8516 no longer crashes on `pnpm dev` after consuming the patched `@modern-js/app-tools`

Closes #8516