### PR TITLE
fix: normalize chunk IDs in loadable-stats.json for Rspack 2.0 compat…

### DIFF
--- a/.changeset/flat-eels-occur.md
+++ b/.changeset/flat-eels-occur.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: normalize chunk IDs in loadable-stats.json for Rspack 2.0 compatibility
+fix: 修复 Rspack 2.0 下的 chunk ID 问题

--- a/packages/runtime/plugin-runtime/src/cli/ssr/loadable-bundler-plugin.ts
+++ b/packages/runtime/plugin-runtime/src/cli/ssr/loadable-bundler-plugin.ts
@@ -27,6 +27,16 @@ type Compiler = Rspack.Compiler;
 
 type Compilation = Rspack.Compilation;
 
+const normalizeChunkId = (id: string | number | null | undefined) =>
+  typeof id === 'string' && /^\d+$/.test(id) ? Number(id) : id;
+
+const normalizeChunkGroup = (
+  group: Record<string, any>,
+): Record<string, any> => ({
+  ...group,
+  chunks: (group.chunks || []).map(normalizeChunkId),
+});
+
 class LoadablePlugin {
   opts: LoadablePluginOptions;
 
@@ -99,12 +109,26 @@ class LoadablePlugin {
       publicPath: true,
     } as any);
 
+    const namedChunkGroups: Record<string, any> = {};
+    for (const [name, group] of Object.entries(
+      (stats as any).namedChunkGroups || {},
+    )) {
+      namedChunkGroups[name] = normalizeChunkGroup(group as any);
+    }
+
+    const entrypoints: Record<string, any> = {};
+    for (const [name, ep] of Object.entries((stats as any).entrypoints || {})) {
+      entrypoints[name] = normalizeChunkGroup(ep as any);
+    }
+
     const output = {
       ...stats,
+      namedChunkGroups,
+      entrypoints,
       generator: 'loadable-components',
       chunks: [...(stats.chunks || [])].map(chunk => {
         return {
-          id: chunk.id,
+          id: normalizeChunkId(chunk.id),
           files: [...(chunk.files || [])],
         };
       }),


### PR DESCRIPTION
…ibility

## Summary
- fix normalize chunk IDs in loadable-stats.json for Rspack 2.0 compatibility

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
