### PR TITLE
docs: remove webpack references from docs

### DIFF
--- a/packages/document/docs/en/components/rspackPrecautions.mdx
+++ b/packages/document/docs/en/components/rspackPrecautions.mdx
@@ -1,6 +1,0 @@
-## Precautions
-
-Before using Rspack, you need to be aware of the following:
-
-- Rspack is compatible with most webpack plugins and almost all loaders, but there are still a few webpack plugins that cannot be used for now. For more details, see [Plugin Compatibility](https://rspack.rs/guide/compatibility/plugin).
-- Rspack uses [SWC](https://rspack.rs/guide/features/builtin-swc-loader) by default for code transformation and compression. In rare cases, you may encounter bugs in SWC in edge cases. You can provide feedback via [SWC issues](https://github.com/swc-project/swc/issues).

--- a/packages/document/docs/en/configure/app/tools/dev-server.mdx
+++ b/packages/document/docs/en/configure/app/tools/dev-server.mdx
@@ -9,10 +9,6 @@ title: devServer
 
 The config of DevServer can be modified through `tools.devServer`.
 
-:::tip
-Modern.js does not directly use [webpack-dev-server](https://webpack.js.org/api/webpack-dev-server/) or [@rspack/dev-server](https://rspack.rs/guide/dev-server.html), but implement DevServer based on [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware).
-:::
-
 ### Options
 
 #### compress

--- a/packages/document/docs/en/guides/basic-features/alias.mdx
+++ b/packages/document/docs/en/guides/basic-features/alias.mdx
@@ -37,7 +37,7 @@ You can refer to the [TypeScript - paths](https://www.typescriptlang.org/tsconfi
 
 ## Use `source.alias` Configuration
 
-Modern.js provides the [source.alias](/configure/app/source/alias) configuration option, which corresponds to the webpack/Rspack native [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) configuration. You can configure this option using an object or a function.
+Modern.js provides the [source.alias](/configure/app/source/alias) configuration option. You can configure this option using an object or a function.
 
 ### Use Cases
 

--- a/packages/document/docs/en/guides/basic-features/html.mdx
+++ b/packages/document/docs/en/guides/basic-features/html.mdx
@@ -190,7 +190,7 @@ Under the application root directory, create the `config/html/` directory, which
   <head>
     <%= topTemplate %>
     <%= headTemplate %>
-    {/* webpack inject css  */}
+    {/* rspack inject css  */}
   </head>
   <body>
     <noscript>
@@ -199,7 +199,7 @@ Under the application root directory, create the `config/html/` directory, which
     </noscript>
     <div id="<%= mountId %>"></div>
     <%= bodyTemplate %>
-    {/* webpack inject js  */}
+    {/* rspack inject js  */}
     {/* <?- bottomTemplate ?> */}
   </body>
 </html>

--- a/packages/document/docs/en/guides/basic-features/static-assets.mdx
+++ b/packages/document/docs/en/guides/basic-features/static-assets.mdx
@@ -123,7 +123,7 @@ After adding the type declaration, if the type error still exists, you can try t
 
 ## Extend Asset Types
 
-If the built-in asset types in Modern.js cannot meet your requirements, you can modify the built-in webpack/Rspack configuration and extend the asset types you need using [tools.bundlerChain](/configure/app/tools/bundler-chain).
+If the built-in asset types in Modern.js cannot meet your requirements, you can modify the built-in Rspack configuration and extend the asset types you need using [tools.bundlerChain](/configure/app/tools/bundler-chain).
 
 For example, if you want to treat `*.pdf` files as assets and directly output them to the dist directory, you can add the following configuration:
 
@@ -151,7 +151,6 @@ console.log(myFile); // "/static/myFile.6c12aba3.pdf"
 For more information about asset modules, please refer to:
 
 - [Rspack Documentation - Asset modules](https://rspack.rs/guide/asset-module.html#asset-modules)
-- [webpack Documentation - Asset modules](https://webpack.js.org/guides/asset-modules/)
 
 ## Image Format
 

--- a/packages/document/docs/en/guides/concept/entries.mdx
+++ b/packages/document/docs/en/guides/concept/entries.mdx
@@ -273,13 +273,13 @@ export default defineConfig({
 
 ## In-Depth
 
-The concept of page entry is derived from the concept of [Entrypoint](https://webpack.js.org/concepts/entry-points/) in webpack. It is mainly used to configure JavaScript or other modules to be executed during application startup. webpack's [best practice](https://webpack.docschina.org/concepts/entry-points/#multi-page-application) for web applications usually corresponds entries to HTML output files, meaning each additional entry will eventually generate a corresponding HTML file in the output. The modules imported by the entry will be compiled and packaged into multiple Chunk outputs. For example, JavaScript modules may ultimately generate several file outputs similar to `dist/static/js/index.ea39u8.js`.
+Pages usually correspond to HTML output files, meaning each additional entry will eventually generate a corresponding HTML file in the output. The modules imported by the entry will be compiled and packaged into multiple Chunk outputs. For example, JavaScript modules may ultimately generate several file outputs similar to `dist/static/js/index.ea39u8.js`.
 
 It's important to distinguish the relationships between concepts such as entry and route:
 
 - **Entry**: Contains multiple modules used for startup execution.
 - **Client Router**: In Modern.js, it is usually implemented by `react-router`, using the History API to determine which React component to load and display based on the browser's current URL.
-- **Server Router**: The server can mimic [devServer behavior](https://webpack.docschina.org/configuration/dev-server/#devserverhistoryapifallback), returning the index.html page instead of all 404 responses to implement client-side routing, or it can implement any routing logic as needed.
+- **Server Router**: Determines what content the server returns based on the request URL. For traditional multi-page applications, different URLs usually return different HTML pages directly. For single-page applications that use client-side routing, the server generally falls back non-static asset requests to the entry HTML, and then the frontend takes over subsequent route matching and page rendering.
 
 Their corresponding relationships are as follows:
 

--- a/packages/document/docs/zh/components/rspackPrecautions.mdx
+++ b/packages/document/docs/zh/components/rspackPrecautions.mdx
@@ -1,6 +1,0 @@
-## 注意事项
-
-在使用 Rspack 前，你需要了解以下事项：
-
-- Rspack 能够兼容大部分 webpack 插件和几乎所有的 loaders，但仍有少数 webpack 插件暂时无法使用，详见 [Plugin 兼容](https://rspack.rs/zh/guide/compatibility/plugin)。
-- Rspack 默认基于 [SWC](https://rspack.rs/zh/guide/features/builtin-swc-loader) 进行代码编译和压缩，在个别情况下，你可能会遇到 SWC 在边界场景的 bug，可以通过 [SWC 的 issue](https://github.com/swc-project/swc/issues) 反馈。

--- a/packages/document/docs/zh/configure/app/tools/dev-server.mdx
+++ b/packages/document/docs/zh/configure/app/tools/dev-server.mdx
@@ -9,10 +9,6 @@ title: devServer
 
 通过 `tools.devServer` 可以修改开发环境服务器的配置。
 
-:::tip
-Modern.js 中并没有直接使用 [webpack-dev-server](https://webpack.js.org/api/webpack-dev-server/) 或 [@rspack/dev-server](https://rspack.rs/guide/dev-server.html), 而是基于 [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) 实现 DevServer。
-:::
-
 ### 选项
 
 #### compress

--- a/packages/document/docs/zh/guides/basic-features/alias.mdx
+++ b/packages/document/docs/zh/guides/basic-features/alias.mdx
@@ -35,7 +35,7 @@ sidebar_position: 4
 
 ## 通过 `source.alias` 配置
 
-Modern.js 提供了 [source.alias](/configure/app/source/alias) 配置项，对应 webpack / Rspack 原生的 [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) 配置，你可以通过对象或者函数的方式来配置这个选项。
+Modern.js 提供了 [source.alias](/configure/app/source/alias) 配置项，你可以通过对象或者函数的方式来配置这个选项。
 
 ### 使用场景
 

--- a/packages/document/docs/zh/guides/basic-features/html.mdx
+++ b/packages/document/docs/zh/guides/basic-features/html.mdx
@@ -193,7 +193,7 @@ Modern.js 也支持通过 HTML(EJS) 语法来生成 HTML 文件。
   <head>
     <%= topTemplate %>
     <%= headTemplate %>
-    {/* webpack inject css  */}
+    {/* rspack inject css  */}
   </head>
   <body>
     <noscript>
@@ -202,7 +202,7 @@ Modern.js 也支持通过 HTML(EJS) 语法来生成 HTML 文件。
     </noscript>
     <div id="<%= mountId %>"></div>
     <%= bodyTemplate %>
-    {/* webpack inject js  */}
+    {/* rspack inject js  */}
     {/* <?- bottomTemplate ?> */}
   </body>
 </html>

--- a/packages/document/docs/zh/guides/basic-features/static-assets.mdx
+++ b/packages/document/docs/zh/guides/basic-features/static-assets.mdx
@@ -119,7 +119,7 @@ declare module '*.png' {
 
 ## 扩展静态资源类型
 
-如果 Modern.js 内置的静态资源类型不能满足你的需求，那么你可以通过 [tools.bundlerChain](/configure/app/tools/bundler-chain) 来修改内置的 webpack / Rspack 配置，并扩展你需要的静态资源类型。
+如果 Modern.js 内置的静态资源类型不能满足你的需求，那么你可以通过 [tools.bundlerChain](/configure/app/tools/bundler-chain) 来修改内置的 Rspack 配置，并扩展你需要的静态资源类型。
 
 比如，你需要把 `*.pdf` 文件当做静态资源直接输出到产物目录，可以添加以下配置：
 
@@ -147,7 +147,6 @@ console.log(myFile); // "/static/myFile.6c12aba3.pdf"
 关于以上配置的更多介绍，请参考：
 
 - [Rspack 文档 - Asset modules](https://rspack.rs/guide/asset-module.html#asset-modules)
-- [webpack 文档 - Asset modules](https://webpack.js.org/guides/asset-modules/)
 
 ## 图片格式
 

--- a/packages/document/docs/zh/guides/concept/entries.mdx
+++ b/packages/document/docs/zh/guides/concept/entries.mdx
@@ -273,13 +273,13 @@ export default defineConfig({
 
 ## 深入了解
 
-页面入口的概念衍生自 webpack 的入口（Entrypoint）概念，其主要用于配置 JavaScript 或其他模块在应用启动时加载和执行。webpack 对于网页应用的 [最佳实践](https://webpack.docschina.org/concepts/entry-points/#multi-page-application) 通常将入口与 HTML 产物对应，即每增加一个入口最终就会在产物中生成一份对应的 HTML 文件。入口引入的模块会在编译打包后生成多个 Chunk 产物，例如对于 JavaScript 模块最终可能会生成数个类似 `dist/static/js/index.ea39u8.js` 的文件产物。
+页面通常与 HTML 产物对应，即每增加一个入口最终就会在产物中生成一份对应的 HTML 文件。入口引入的模块会在编译打包后生成多个 Chunk 产物，例如对于 JavaScript 模块最终可能会生成数个类似 `dist/static/js/index.ea39u8.js` 的文件产物。
 
 需要注意区分入口、路由等概念之间的关系：
 
 - **入口**：包含多个用于启动时执行的模块。
 - **客户端路由**：在 Modern.js 中通常由 `react-router` 实现，通过 History API 判断浏览器当前 URL 决定加载和显示哪个 React 组件。
-- **服务端路由**：服务端可以模仿 [devServer 的行为](https://webpack.docschina.org/configuration/dev-server/#devserverhistoryapifallback)，将 index.html 页面代替所有 404 响应被返回以实现客户端路由，也可以自行实现任何路由逻辑。
+- **服务端路由**：由服务器根据请求 URL 决定返回什么内容。对于传统多页应用，不同 URL 通常会直接返回不同的 HTML 页面。对于使用客户端路由的单页应用，服务器一般会将非静态资源请求统一回退到入口 HTML，再由前端接管后续路由匹配与页面渲染
 
 它们的对应关系如下：
 


### PR DESCRIPTION
## Summary
- remove the Rspack precautions component docs in both English and Chinese
- remove outdated webpack-related wording and links from related docs
- sync English docs with the latest Chinese documentation changes

## Validation
- git diff --check