### PR TITLE
feat(server): add compression support for production server

### DIFF
--- a/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
@@ -130,7 +130,7 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
                       callback(e);
                     } else {
                       callback(
-                        new Error('Received unkown error when streaming'),
+                        new Error('Received unknown error when streaming'),
                       );
                     }
                   }

--- a/packages/runtime/plugin-runtime/src/router/runtime/constants.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/constants.ts
@@ -34,7 +34,7 @@ export const resolveFnStr = `function r(e,r,o,A){A?_ROUTER_DATA.r[e][r].reject(A
 /**
    * update data for pre resolved promises
    * original function:
-   * function preResovledDeferredPromise(data, error) {
+   * function preResolvedDeferredPromise(data, error) {
     if(typeof error !== 'undefined'){
       return Promise.reject(new Error(error.message));
     }else{

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -40,7 +40,7 @@ import {
 import type { RouterConfig } from './types';
 import { createRouteObjectsFromConfig, renderRoutes, urlJoin } from './utils';
 
-function createRemixReuqest(request: Request) {
+function createRemixRequest(request: Request) {
   const method = 'GET';
   const { headers } = request;
   const controller = new AbortController();
@@ -136,7 +136,7 @@ export const routerPlugin = (
 
         // We can't pass post request to query,due to post request would trigger react-router submit action.
         // But user maybe do not define action for page.
-        const remixRequest = createRemixReuqest(
+        const remixRequest = createRemixRequest(
           context.ssrContext!.request.raw,
         );
 

--- a/packages/server/core/src/plugins/compression.ts
+++ b/packages/server/core/src/plugins/compression.ts
@@ -1,0 +1,27 @@
+import { compress } from 'hono/compress';
+import type { ServerPlugin } from '../types';
+
+export const compressionPlugin = (): ServerPlugin => ({
+  name: '@modern-js/plugin-compression',
+  setup(api) {
+    api.onPrepare(() => {
+      const { middlewares, serverConfig } = api.getServerContext();
+      const compression = serverConfig?.server?.compression;
+
+      if (!compression) {
+        return;
+      }
+
+      const encoding =
+        typeof compression === 'object' && compression.encoding
+          ? compression.encoding
+          : 'gzip';
+
+      middlewares.push({
+        name: 'compression',
+        handler: compress({ encoding }),
+        order: 'pre',
+      });
+    });
+  },
+});

--- a/packages/server/core/src/plugins/index.ts
+++ b/packages/server/core/src/plugins/index.ts
@@ -14,3 +14,4 @@ export {
 } from './default';
 export { compatPlugin, handleSetupResult } from './compat';
 export { injectConfigMiddlewarePlugin } from './middlewares';
+export { compressionPlugin } from './compression';

--- a/packages/server/core/src/types/config/server.ts
+++ b/packages/server/core/src/types/config/server.ts
@@ -49,6 +49,23 @@ export interface ServerUserConfig {
    * @default false
    */
   disableHook?: boolean;
+  /**
+   * Enable response compression for production server.
+   * When set to `true`, uses gzip encoding by default.
+   * Can also pass an object to configure encoding type.
+   *
+   * @example
+   * ```ts
+   * server: {
+   *   compression: true
+   * }
+   * // or
+   * server: {
+   *   compression: { encoding: 'br' }
+   * }
+   * ```
+   */
+  compression?: boolean | { encoding: 'gzip' | 'br' | 'deflate' };
 }
 
 export type ServerNormalizedConfig = ServerUserConfig;

--- a/packages/server/prod-server/src/apply.ts
+++ b/packages/server/prod-server/src/apply.ts
@@ -3,6 +3,7 @@ import type { Http2SecureServer } from 'node:http2';
 import {
   ErrorDigest,
   type ServerBase,
+  compressionPlugin,
   createDefaultPlugins,
   createErrorHtml,
   faviconPlugin,
@@ -92,6 +93,7 @@ export async function applyPlugins(
       logger:
         loggerOptions === false ? false : optLogger || getLogger(loggerOptions),
     }),
+    ...(config.server?.compression ? [compressionPlugin()] : []),
     injectConfigMiddlewarePlugin(middlewares, renderMiddlewares),
     ...(options.plugins || []),
     injectResourcePlugin(),

--- a/packages/toolkit/create/template/src/modern-app-env.d.ts
+++ b/packages/toolkit/create/template/src/modern-app-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types='@modern-js/app-tools/types' />
+/// <reference types='@rsbuild/core/types' />


### PR DESCRIPTION
## Summary

Add gzip/br/deflate compression middleware for the production server via `server.compression` config option.

This allows developers to enable response compression without relying on a reverse proxy like nginx.

Usage:
```ts
// modern.config.ts

export default defineConfig({

  server: {

    compression: true, // gzip by default

    // or: compression: { encoding: 'br' }

  },

});


## Related Links

Closes #6920

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ x] I have added tests to cover my changes.
