### PR TITLE
feat:  support tsconfig.server.json for server-side TypeScript

### DIFF
--- a/.changeset/beige-rivers-itch.md
+++ b/.changeset/beige-rivers-itch.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/plugin-bff': patch
+'@modern-js/utils': patch
+---
+
+feat: support tsconfig.server.json for server-side TypeScript
+feat: 支持单独配置服务端 tsconfig 配置

--- a/packages/cli/plugin-bff/src/cli.ts
+++ b/packages/cli/plugin-bff/src/cli.ts
@@ -12,13 +12,13 @@ import {
   DEFAULT_API_PREFIX,
   SHARED_DIR,
   normalizeOutputPath,
+  resolveServerTsconfig,
 } from '@modern-js/utils';
 import type { ConfigChain } from '@rsbuild/core';
 import clientGenerator from './utils/clientGenerator';
 import pluginGenerator from './utils/pluginGenerator';
 import runtimeGenerator from './utils/runtimeGenerator';
 
-const TS_CONFIG_FILENAME = 'tsconfig.json';
 const RUNTIME_CREATE_REQUEST = '@modern-js/plugin-bff/client';
 
 export const bffPlugin = (): CliPlugin<AppTools> => ({
@@ -38,7 +38,10 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
       const apiDir = apiDirectory || path.resolve(appDirectory, API_DIR);
       const sharedDir =
         sharedDirectory || path.resolve(appDirectory, SHARED_DIR);
-      const tsconfigPath = path.resolve(appDirectory, TS_CONFIG_FILENAME);
+      const tsconfigPath = resolveServerTsconfig(
+        appDirectory,
+        modernConfig?.server?.tsconfigPath,
+      );
 
       const sourceDirs = [];
       if (await fs.pathExists(apiDir)) {

--- a/packages/document/docs/en/configure/app/server/tsconfig-path.mdx
+++ b/packages/document/docs/en/configure/app/server/tsconfig-path.mdx
@@ -1,0 +1,63 @@
+---
+title: tsconfigPath
+---
+
+# server.tsconfigPath
+
+- **Type:** `string`
+- **Default:** `<appDirectory>/tsconfig.json`
+
+Specifies the tsconfig file used by server-side TypeScript processes.
+
+This option affects:
+
+- BFF / API compilation (`@modern-js/plugin-bff`)
+- Custom server compilation (`*.ts` files under `server/`)
+- Runtime ts-node registration, such as SSR, `modern.config.ts`, and `.ts` files under `config/`
+
+When this option is not set, `<appDirectory>/tsconfig.json` is used by default.
+
+## When to use
+
+Use this option when frontend and server-side code need different TypeScript configurations.
+
+For example, the frontend can use `moduleResolution: "Bundler"`, while the server side uses `moduleResolution: "NodeNext"` for type resolution of conditional exports or subpath exports.
+
+## Example
+
+The example below uses `tsconfig.server.json` as the file name. You can use another name in your project.
+
+Add `<appDirectory>/tsconfig.server.json`:
+
+```jsonc title="tsconfig.server.json"
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "lib": ["ESNext"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["api", "shared", "server", "config", "modern.config.ts"]
+}
+```
+
+Specify this file in `modern.config.ts`:
+
+```ts title="modern.config.ts"
+export default defineConfig({
+  server: {
+    tsconfigPath: './tsconfig.server.json',
+  },
+});
+```
+
+## Notes
+
+- `tsconfigPath` is resolved relative to `appDirectory`. Absolute paths are also supported.
+- It is recommended to inherit shared options such as `paths` from the root tsconfig through `extends`, instead of maintaining them in multiple files.
+- If the configured file does not exist, TypeScript / ts-node will throw an error at startup.

--- a/packages/document/docs/zh/configure/app/server/tsconfig-path.mdx
+++ b/packages/document/docs/zh/configure/app/server/tsconfig-path.mdx
@@ -1,0 +1,63 @@
+---
+title: tsconfigPath
+---
+
+# server.tsconfigPath
+
+- **类型：** `string`
+- **默认值：** `<appDirectory>/tsconfig.json`
+
+指定服务端 TypeScript 相关流程使用的 tsconfig 文件。
+
+该配置会影响：
+
+- BFF / API 编译（`@modern-js/plugin-bff`）
+- 自定义 Server 编译（`server/` 目录下的 `*.ts` 文件）
+- 运行时 ts-node 注册（如 SSR、`modern.config.ts`、`config/` 目录下的 `.ts` 文件）
+
+未配置时，默认使用 `<appDirectory>/tsconfig.json`。
+
+## 使用场景
+
+当前端和服务端需要不同的 TypeScript 配置时，可以通过该选项为服务端单独指定 tsconfig。
+
+例如前端使用 `moduleResolution: "Bundler"`，服务端需要使用 `moduleResolution: "NodeNext"` 来适配 conditional exports 或 subpath exports 的类型解析。
+
+## 配置示例
+
+下面以 `tsconfig.server.json` 为例，你也可以根据项目情况使用其他文件名。
+
+新增 `<appDirectory>/tsconfig.server.json`：
+
+```jsonc title="tsconfig.server.json"
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "lib": ["ESNext"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["api", "shared", "server", "config", "modern.config.ts"]
+}
+```
+
+在 `modern.config.ts` 中指定该文件：
+
+```ts title="modern.config.ts"
+export default defineConfig({
+  server: {
+    tsconfigPath: './tsconfig.server.json',
+  },
+});
+```
+
+## 注意事项
+
+- `tsconfigPath` 相对 `appDirectory` 解析，也支持绝对路径。
+- 建议通过 `extends` 继承根 tsconfig 中的 `paths` 等公共配置，避免重复维护。
+- 如果配置的文件不存在，TypeScript / ts-node 会在启动时抛出错误。

--- a/packages/server/core/src/types/config/server.ts
+++ b/packages/server/core/src/types/config/server.ts
@@ -49,6 +49,14 @@ export interface ServerUserConfig {
    * @default false
    */
   disableHook?: boolean;
+  /**
+   * Path to the tsconfig used by all server-side TypeScript stages:
+   * BFF/api compile, custom server compile, runtime ts-node register,
+   * and downstream runtimes.
+   *
+   * @default <appDirectory>/tsconfig.json
+   */
+  tsconfigPath?: string;
 }
 
 export type ServerNormalizedConfig = ServerUserConfig;

--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -72,6 +72,7 @@ export const build = async (
     combinedAlias,
     {
       moduleType: appContext.moduleType,
+      tsconfigPath: resolvedConfig?.server?.tsconfigPath,
     },
   );
 

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -50,6 +50,7 @@ export const dev = async (
     combinedAlias,
     {
       moduleType: appContext.moduleType,
+      tsconfigPath: normalizedConfig?.server?.tsconfigPath,
     },
   );
 

--- a/packages/solutions/app-tools/src/plugins/serverBuild.ts
+++ b/packages/solutions/app-tools/src/plugins/serverBuild.ts
@@ -1,10 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import { compile } from '@modern-js/server-utils';
-import { SERVER_DIR, SHARED_DIR, getMeta } from '@modern-js/utils';
+import {
+  SERVER_DIR,
+  SHARED_DIR,
+  getMeta,
+  resolveServerTsconfig,
+} from '@modern-js/utils';
 import type { AppTools, CliPlugin } from '../types';
-
-const TS_CONFIG_FILENAME = 'tsconfig.json';
 
 function checkHasCache(appDir: string) {
   const tsFilepath = path.resolve(appDir, SERVER_DIR, 'cache.ts');
@@ -39,7 +42,10 @@ export default (): CliPlugin<AppTools> => ({
       const distDir = path.resolve(distDirectory);
       const serverDir = path.resolve(appDirectory, SERVER_DIR);
       const sharedDir = path.resolve(appDirectory, SHARED_DIR);
-      const tsconfigPath = path.resolve(appDirectory, TS_CONFIG_FILENAME);
+      const tsconfigPath = resolveServerTsconfig(
+        appDirectory,
+        modernConfig?.server?.tsconfigPath,
+      );
 
       const sourceDirs = [];
       if (fs.existsSync(serverDir)) {

--- a/packages/solutions/app-tools/src/utils/register.ts
+++ b/packages/solutions/app-tools/src/utils/register.ts
@@ -7,6 +7,7 @@ import {
   loadFromProject,
   mergeAlias,
   readTsConfigByFile,
+  resolveServerTsconfig,
 } from '@modern-js/utils';
 import type { ConfigChain } from '@rsbuild/core';
 
@@ -14,6 +15,12 @@ type TsRuntimeRegisterMode = 'ts-node' | 'node-loader' | 'unsupported';
 
 interface TsRuntimeSetupOptions {
   moduleType?: string;
+  /**
+   * User-configured `server.tsconfigPath`. Forwarded into the shared
+   * resolveServerTsconfig helper. Resolved relative to appDir when not
+   * absolute. Falls back to `<appDir>/tsconfig.json` when unset.
+   */
+  tsconfigPath?: string;
 }
 
 const normalizePathValue = ({
@@ -155,8 +162,7 @@ export const setupTsRuntime = async (
   alias?: ConfigChain<Alias>,
   options: TsRuntimeSetupOptions = {},
 ) => {
-  const TS_CONFIG_FILENAME = `tsconfig.json`;
-  const tsconfigPath = path.resolve(appDir, TS_CONFIG_FILENAME);
+  const tsconfigPath = resolveServerTsconfig(appDir, options.tsconfigPath);
   const isTsProject = await fs.pathExists(tsconfigPath);
   const hasTsNode = isDepExists(appDir, 'ts-node');
 

--- a/packages/toolkit/utils/src/cli/constants.ts
+++ b/packages/toolkit/utils/src/cli/constants.ts
@@ -43,6 +43,11 @@ export const SERVER_DIR = 'server';
 export const SHARED_DIR = 'shared';
 
 /**
+ * Project root tsconfig filename.
+ */
+export const TS_CONFIG_FILENAME = 'tsconfig.json';
+
+/**
  * Modern.config.ts cached dir
  */
 export const CONFIG_CACHE_DIR = './node_modules/.cache/bundle-require';

--- a/packages/toolkit/utils/src/cli/index.ts
+++ b/packages/toolkit/utils/src/cli/index.ts
@@ -20,3 +20,4 @@ export * from './config';
 export * from './version';
 export * from './route';
 export * from './modulePath';
+export * from './tsconfig';

--- a/packages/toolkit/utils/src/cli/tsconfig.ts
+++ b/packages/toolkit/utils/src/cli/tsconfig.ts
@@ -1,0 +1,14 @@
+import path from 'path';
+import { TS_CONFIG_FILENAME } from './constants';
+
+export const resolveServerTsconfig = (
+  appDirectory: string,
+  configuredPath?: string,
+): string => {
+  if (configuredPath) {
+    return path.isAbsolute(configuredPath)
+      ? configuredPath
+      : path.resolve(appDirectory, configuredPath);
+  }
+  return path.resolve(appDirectory, TS_CONFIG_FILENAME);
+};

--- a/tests/integration/bff-hono/modern.config.ts
+++ b/tests/integration/bff-hono/modern.config.ts
@@ -6,6 +6,7 @@ export default applyBaseConfig({
     ssr: {
       mode: 'stream',
     },
+    tsconfigPath: 'tsconfig.server.json',
   },
   bff: {
     prefix: '/bff-api',

--- a/tests/integration/bff-hono/tsconfig.server.json
+++ b/tests/integration/bff-hono/tsconfig.server.json
@@ -11,5 +11,5 @@
     },
     "types": ["@rstest/core/globals"]
   },
-  "include": ["src", "shared", "config", "modern.config.ts"]
+  "include": ["shared", "server", "api"]
 }


### PR DESCRIPTION
## Summary
  ### Why     
  BFF/serverBuild/setupTsRuntime hardcode `<appDir>/tsconfig.json`. Projects
  needing `moduleResolution: "NodeNext"` for server code (e.g. subpath-export                                                  
  deps) must flip the *root* tsconfig to NodeNext, breaking frontend                                                           
  type-checking in `src/` (lodash-es ESM imports, dynamic `import()` without                                                   
  `.js`).                                                                                                                      
                                                                                                                               
  ### What                                                                                                                      
  File-presence convention: prefer `tsconfig.server.json` if present, else                                                     
  `tsconfig.json`. Centralized in `@modern-js/utils.resolveServerTsconfig`                                                     
  and called from 3 server-side stages.  

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
