### PR TITLE
fix(app-tools): align async pre-entry test with v2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7937,11 +7937,11 @@ importers:
         specifier: workspace:*
         version: link:../../../../../packages/runtime/plugin-runtime
       react:
-        specifier: ^19.2.4
-        version: 19.2.6
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: ^19.2.4
-        version: 19.2.6(react@19.2.6)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@modern-js/app-tools':
         specifier: workspace:*
@@ -7950,11 +7950,11 @@ importers:
         specifier: workspace:*
         version: link:../../../../../packages/tsconfig
       '@types/react':
-        specifier: ^19.2.14
-        version: 19.2.14
+        specifier: ^18.3.11
+        version: 18.3.18
       '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.14)
+        specifier: ^18.3.1
+        version: 18.3.5(@types/react@18.3.18)
       typescript:
         specifier: ^5
         version: 5.6.3
@@ -35032,10 +35032,6 @@ snapshots:
     dependencies:
       '@types/react': 18.3.18
     optional: true
-
-  '@types/react-dom@19.2.3(@types/react@19.2.14)':
-    dependencies:
-      '@types/react': 19.2.14
 
   '@types/react-loadable@5.5.11':
     dependencies:

--- a/tests/integration/ssr/fixtures/base-async-pre-entry/package.json
+++ b/tests/integration/ssr/fixtures/base-async-pre-entry/package.json
@@ -7,14 +7,14 @@
   },
   "dependencies": {
     "@modern-js/runtime": "workspace:*",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@modern-js/app-tools": "workspace:*",
     "@modern-js/tsconfig": "workspace:*",
-    "@types/react": "^19.2.14",
-    "@types/react-dom": "^19.2.3",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.1",
     "typescript": "^5"
   }
 }

--- a/tests/integration/ssr/tests/base-async-pre-entry.test.ts
+++ b/tests/integration/ssr/tests/base-async-pre-entry.test.ts
@@ -1,6 +1,6 @@
 import dns from 'node:dns';
 import path, { join } from 'path';
-import { fs } from '@modern-js/utils';
+import { fs, MAIN_ENTRY_NAME } from '@modern-js/utils';
 import puppeteer, { type Browser, type Page } from 'puppeteer';
 import {
   getPort,
@@ -39,7 +39,11 @@ describe('enableAsyncPreEntry', () => {
   });
 
   test('should inject preEntry into index.jsx (not bootstrap.jsx)', () => {
-    const internalDir = path.join(appDir, 'node_modules/.modern-js/index');
+    const internalDir = path.join(
+      appDir,
+      'node_modules/.modern-js',
+      MAIN_ENTRY_NAME,
+    );
     const indexFile = path.join(internalDir, 'index.jsx');
     const bootstrapFile = path.join(internalDir, 'bootstrap.jsx');
 
@@ -53,7 +57,7 @@ describe('enableAsyncPreEntry', () => {
     // bootstrap.jsx should remain an async boundary only
     expect(bootstrapCode).not.toContain('pre.ts');
     expect(bootstrapCode).toContain(
-      'import(/* webpackChunkName: "async-index" */ \'./index\');',
+      `import(/* webpackChunkName: "async-${MAIN_ENTRY_NAME}" */ './index');`,
     );
   });
 


### PR DESCRIPTION
## Summary

Fix the v2 async pre-entry SSR integration test after the cherry-pick.

The test was still assuming the v3 generated entry name, so CI could not find the generated file on Linux and Windows. The fixture also used React 19 versions, while this v2 branch uses React 18.

## Changes

- Use the configured main entry name in the SSR async pre-entry test.
- Align the async pre-entry fixture React dependencies with v2.
- Update the lockfile for the fixture dependency change.

## Validation

* Integration Test(Linux) : https://github.com/web-infra-dev/modern.js/actions/runs/25839742896
* Integration Test(Windows) : https://github.com/web-infra-dev/modern.js/actions/runs/25839733729


- `pnpm --dir tests exec jest -c jest.config.js integration/ssr/tests/base-async-pre-entry.test.ts --runInBand`
- Commit hook passed `biome check` and `pnpm check-dependencies`.