### PR TITLE
feat: include server directory in tsconfig.json from @modernjs/create template

### DIFF
--- a/packages/document/docs/en/guides/advanced-features/web-server.mdx
+++ b/packages/document/docs/en/guides/advanced-features/web-server.mdx
@@ -48,6 +48,18 @@ export default defineServerConfig({
 
 After creating the file, you can write custom logic in this file.
 
+3. Include `server` directory in `tsconfig.json`
+
+```json5
+{
+  // ...
+  "include": [
+    // ...
+    "server"
+  ]
+}
+```
+
 ## Capabilities of the Custom Web Server
 
 Modern.js's Web Server is based on Hono, and in the latest version of the Custom Web Server, we expose Hono's middleware capabilities, you can refer to [Hono API](https://hono.dev/docs/api/context) for more usage.

--- a/packages/document/docs/zh/guides/advanced-features/web-server.mdx
+++ b/packages/document/docs/zh/guides/advanced-features/web-server.mdx
@@ -48,6 +48,18 @@ export default defineServerConfig({
 
 创建文件后，可以在这个文件中编写自定义逻辑。
 
+3. 你可以将 `server` 目录包含在 `tsconfig.json` 中
+
+```json5
+{
+  // ...
+  "include": [
+    // ...
+    "server"
+  ]
+}
+```
+
 ## 自定义 Web Server 能力
 
 Modern.js 的服务器基于 Hono 实现，在最新版本的自定义 Web Server 中，我们向用户暴露了 Hono 的中间件能力，你可以参考 [Hono 文档](https://hono.dev/docs/api/context) 了解更多用法。

--- a/packages/toolkit/create/template/tsconfig.json
+++ b/packages/toolkit/create/template/tsconfig.json
@@ -9,6 +9,6 @@
       "@shared/*": ["./shared/*"]
     }
   },
-  "include": ["src", "shared", "config", "modern.config.ts"],
+  "include": ["src", "shared", "config", "modern.config.ts", "server"],
   "exclude": ["**/node_modules"]
 }


### PR DESCRIPTION
## Summary
`modern/modern.server.ts` is ignored if the folder isn't included in `tsconfig.json`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
