### PR TITLE
fix(plugin-i18n): expose i18n runtime context type

### DIFF
--- a/.changeset/fiery-keys-draw.md
+++ b/.changeset/fiery-keys-draw.md
@@ -3,3 +3,5 @@
 ---
 
 fix(plugin-i18n): expose i18n fields on runtime context type
+
+fix(plugin-i18n): 将 i18n 字段暴露到运行时上下文类型上

--- a/.changeset/fiery-keys-draw.md
+++ b/.changeset/fiery-keys-draw.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-i18n': patch
+---
+
+fix(plugin-i18n): expose i18n fields on runtime context type

--- a/packages/runtime/plugin-i18n/src/runtime/types.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/types.ts
@@ -10,7 +10,7 @@ declare module '@modern-js/runtime' {
     };
   }
 
-  interface TInternalRuntimeContext {
+  interface TRuntimeContext {
     i18nInstance?: I18nInstance;
     changeLanguage?: (lang: string) => Promise<void>;
   }


### PR DESCRIPTION
## Summary
- augment the public TRuntimeContext with plugin-i18n runtime fields
- add a bilingual patch changeset for @modern-js/plugin-i18n

## Test
- pnpm exec biome check packages/runtime/plugin-i18n/src/runtime/types.ts
- pnpm --filter @modern-js/plugin-i18n build