### PR TITLE
fix(plugin-i18n): import runtime types from cli

### DIFF
--- a/packages/runtime/plugin-i18n/src/cli/index.ts
+++ b/packages/runtime/plugin-i18n/src/cli/index.ts
@@ -5,6 +5,7 @@ import { getPublicDirRoutePrefixes } from '@modern-js/server-core';
 import type { Entrypoint } from '@modern-js/types';
 import type { BackendOptions, LocaleDetectionOptions } from '../shared/type';
 import { getBackendOptions, getLocaleDetectionOptions } from '../shared/utils';
+import '../runtime/types';
 
 export type TransformRuntimeConfigFn = (
   extendedConfig: Record<string, any>,


### PR DESCRIPTION
## Summary

- Import plugin-i18n runtime type augmentations from the CLI entry.
- Ensure the CLI package type entry includes the runtime context types exposed by the plugin.

## Related Links

N/A

## Checklist

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.

## Verification

- `git diff --check`
- `pnpm --filter @modern-js/plugin-i18n build`