### PR TITLE
fix(runtime): split streaming SSR chunk at SHELL_STREAM_END_MARK

### DIFF
--- a/.changeset/thirty-bees-rescue.md
+++ b/.changeset/thirty-bees-rescue.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(runtime): split streaming SSR chunk at SHELL_STREAM_END_MARK so suspense boundary content is not swallowed before shellAfter
+
+fix(runtime): 流式 SSR 在 SHELL_STREAM_END_MARK 位置切分 chunk，避免 suspense 兑现内容被夹在 shellAfter 之前

--- a/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
@@ -94,26 +94,38 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
                     if (shellChunkStatus !== ShellChunkStatus.FINISH) {
                       chunkVec.push(
                         Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
-                      ); /**
+                      );
+                      /**
                        * The shell content of App may be splitted by multiple chunks to transform,
                        * when any node value's size is larger than the React limitation, refer to:
                        * https://github.com/facebook/react/blob/v18.2.0/packages/react-server/src/ReactServerStreamConfigNode.js#L53.
                        * So we use the `SHELL_STREAM_END_MARK` to mark the shell content' tail.
+                       *
+                       * The marker can also land in the middle of a chunk that already carries
+                       * suspense-boundary content emitted right after the shell (React's chunk
+                       * boundaries are byte-driven, not render-phase-driven). Concat first so
+                       * we also catch markers that straddle two chunks, then split the buffered
+                       * content at the marker: everything before goes between shellBefore and
+                       * shellAfter; everything after goes out as-is so it lands past the
+                       * closing `</html>` instead of being swallowed inside it.
                        */
-                      const chunkStr = chunk.toString('utf-8');
-                      if (chunkStr.includes(ESCAPED_SHELL_STREAM_END_MARK)) {
-                        let concatedChunk = Buffer.concat(
-                          chunkVec as any,
-                        ).toString('utf-8');
-                        concatedChunk = concatedChunk.replace(
-                          ESCAPED_SHELL_STREAM_END_MARK,
-                          '',
+                      const concatedChunk = Buffer.concat(
+                        chunkVec as any,
+                      ).toString('utf-8');
+                      const markerIndex = concatedChunk.indexOf(
+                        ESCAPED_SHELL_STREAM_END_MARK,
+                      );
+                      if (markerIndex !== -1) {
+                        const beforeMark = concatedChunk.slice(0, markerIndex);
+                        const afterMark = concatedChunk.slice(
+                          markerIndex + ESCAPED_SHELL_STREAM_END_MARK.length,
                         );
 
                         shellChunkStatus = ShellChunkStatus.FINISH;
-                        this.push(
-                          `${shellBefore}${concatedChunk}${shellAfter}`,
-                        );
+                        this.push(`${shellBefore}${beforeMark}${shellAfter}`);
+                        if (afterMark) {
+                          this.push(afterMark);
+                        }
                         // Flush any pending <script> collected before shell finished
                         if (pendingScripts.length > 0) {
                           for (const s of pendingScripts) {

--- a/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.worker.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.worker.ts
@@ -142,16 +142,33 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
                 chunkVec.push(new TextDecoder().decode(value));
                 const concatedChunk = chunkVec.join('');
 
-                if (concatedChunk.includes(ESCAPED_SHELL_STREAM_END_MARK)) {
+                /**
+                 * React's chunk boundaries are byte-driven, so the marker can
+                 * land in the middle of a chunk that already carries
+                 * suspense-boundary content emitted right after the shell.
+                 * Split at the marker: content before goes between
+                 * shellBefore and shellAfter; content after is emitted as-is
+                 * so it lands past the closing `</html>` rather than being
+                 * swallowed inside it.
+                 */
+                const markerIndex = concatedChunk.indexOf(
+                  ESCAPED_SHELL_STREAM_END_MARK,
+                );
+                if (markerIndex !== -1) {
+                  const beforeMark = concatedChunk.slice(0, markerIndex);
+                  const afterMark = concatedChunk.slice(
+                    markerIndex + ESCAPED_SHELL_STREAM_END_MARK.length,
+                  );
+
                   shellChunkStatus = ShellChunkStatus.FINISH;
                   safeEnqueue(
                     encodeForWebStream(
-                      `${shellBefore}${concatedChunk.replace(
-                        ESCAPED_SHELL_STREAM_END_MARK,
-                        '',
-                      )}${shellAfter}`,
+                      `${shellBefore}${beforeMark}${shellAfter}`,
                     ),
                   );
+                  if (afterMark) {
+                    safeEnqueue(encodeForWebStream(afterMark));
+                  }
                   flushPendingScripts();
                 }
               } else {


### PR DESCRIPTION
## Summary

The streaming SSR transform in `plugin-runtime` treats `ESCAPED_SHELL_STREAM_END_MARK` as a signal to wrap *everything buffered so far* with `shellBefore` + `shellAfter`, push it as one chunk, then forward subsequent chunks as-is.

This only works if the marker happens to land at the very end of a React stream chunk. React's `renderToPipeableStream` chunks are byte-driven (highWaterMark, not render phase), so a single chunk can carry **shell content + the marker + the start of a deferred suspense boundary's payload**. When that happens:

- everything after the marker (start of `<div hidden id="S:N">…`) is swallowed *before* `shellAfter`
- `shellAfter`'s `</div>` ends up closing the suspense container instead of `<div id="root">`
- the remainder of the boundary (the rest of the payload + `$RC` swap script) is pushed after `</html>`

In our reproduction the cut sometimes landed inside an attribute value (a `<div class="…` or an SVG `<path d="…"`). The browser's HTML parser then ate `</div></body></html>` as part of that attribute and DOM structure went off the rails — and `$RC` could no longer find `id="S:N"` to swap, leaving the suspense boundary stuck in pending state.

This change makes the transform split the buffered content **at the marker position**, so post-marker bytes are emitted *after* `shellAfter` instead of being concatenated before it. While here, also switched the non-worker variant from `chunk.toString().includes(MARK)` to `concatedChunk.indexOf(MARK)` so a marker that straddles two chunks is detected (the worker variant already did this).

## 中文说明

`plugin-runtime` 的流式 SSR Transform 把 `ESCAPED_SHELL_STREAM_END_MARK` 当作"shell 结束信号"，做法是：把目前缓存的全部内容拼上 `shellBefore` + `shellAfter` 推出去，后续 chunk 直接转发。

这只在 marker 恰好落在某个 React stream chunk 末尾时正确。但 React `renderToPipeableStream` 的 chunk 边界是按字节走的（看 highWaterMark，不看渲染阶段），所以一个 chunk 完全可能同时携带 **shell 内容 + marker + 某个 deferred suspense boundary 兑现内容的开头**。一旦命中：

- marker 之后那段（`<div hidden id="S:N">…` 的开头）被错误地塞在 `shellAfter` **之前**
- `shellAfter` 的 `</div>` 关掉的是这个 suspense 容器，而不是 `<div id="root">`
- 兑现内容的剩余部分（form HTML 尾段 + `$RC` 切换脚本）被推到 `</html>` 之后

在我们的复现里，切口有时落在某个属性值半中间（`<div class="…` 或 SVG 的 `<path d="…"`）。浏览器 HTML parser 为了找属性的关闭 `"` 会把 `</div></body></html>` 都吞进属性值里，DOM 结构整个错乱——并且 `$RC` 在 DOM 里 `getElementById("S:N")` 取不到东西，suspense boundary 永远停在 pending 状态。

本 PR 让 Transform **在 marker 字节位置切分**缓存内容：marker 之前的部分继续夹在 `shellBefore` 与 `shellAfter` 之间，marker 之后的字节作为独立 chunk 推到 `shellAfter` 之后。顺带把 non-worker 变体里那个 `chunk.toString().includes(MARK)` 改成 `concatedChunk.indexOf(MARK)`——避免 marker 横跨两个 chunk 时漏检（worker 变体原本就是这么做的）。

## Related Links

N/A

## Checklist

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.

Verified against the existing streaming integration suite (`tests/integration/ssr/tests/streaming.test.ts` — basic / deferred / navigation / error / fallback-order) plus base / partial / rsc-closing-tags — all green.