### PR TITLE
feat(server-core): add server fallback hook context

### DIFF
--- a/.changeset/fresh-fallback-context.md
+++ b/.changeset/fresh-fallback-context.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/server-core': patch
+---
+
+feat(server-core): pass request and monitors context to server plugin fallback hooks
+
+feat(server-core): 为 server 插件 fallback hook 传递 request 和 monitors 上下文

--- a/packages/server/core/src/plugins/render/inject.ts
+++ b/packages/server/core/src/plugins/render/inject.ts
@@ -29,11 +29,12 @@ export const injectRenderHandlerPlugin = ({
         return;
       }
 
-      const onFallback: OnFallback = async (reason, error) => {
+      const onFallback: OnFallback = async (reason, error, context) => {
         // For other framework can report ssr fallback reason & error.
         await hooks.fallback.call({
           reason,
           error,
+          context,
         });
       };
 

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -6,6 +6,7 @@ import { TrieRouter } from 'hono/router/trie-router';
 import { X_MODERNJS_RENDER } from '../../constants';
 import type {
   CacheConfig,
+  FallbackContext,
   FallbackReason,
   OnFallback,
   UserConfig,
@@ -150,10 +151,14 @@ export async function createRender({
     const framework = cutNameByHyphen(metaName || 'modern-js');
     const fallbackHeader = `x-${framework}-ssr-fallback`;
     let fallbackReason = null;
+    const fallbackContext: FallbackContext = {
+      request: req,
+      monitors,
+    };
 
     const fallbackWrapper: FallbackWrapper = async (reason, error?) => {
       fallbackReason = reason;
-      return onFallback?.(reason, error);
+      return onFallback?.(reason, error, fallbackContext);
     };
 
     if (!routeInfo) {

--- a/packages/server/core/src/types/plugins/base.ts
+++ b/packages/server/core/src/types/plugins/base.ts
@@ -5,6 +5,7 @@ import type {
   Logger,
   Metrics,
   MiddlewareContext,
+  Monitors,
   Reporter,
   ServerRoute,
 } from '@modern-js/types';
@@ -16,14 +17,21 @@ import type { ServerPlugin } from './plugin';
 export type { FileChangeEvent, ResetEvent } from '@modern-js/plugin';
 export type FallbackReason = 'error' | 'header' | 'query' | `header,${string}`;
 
+export type FallbackContext = {
+  request: Request;
+  monitors?: Monitors;
+};
+
 export type FallbackInput = {
   reason: FallbackReason;
   error: unknown;
+  context?: FallbackContext;
 };
 
 export type OnFallback = (
   reason: FallbackReason,
   error?: unknown,
+  context?: FallbackContext,
 ) => Promise<void>;
 
 export type APIServerStartInput = {

--- a/packages/server/core/src/types/plugins/index.ts
+++ b/packages/server/core/src/types/plugins/index.ts
@@ -4,6 +4,7 @@ export type {
   CacheConfig,
   OnFallback,
   FallbackReason,
+  FallbackContext,
   GetRenderHandlerOptions,
   FileChangeEvent,
   FallbackInput,

--- a/packages/server/core/tests/plugins/render.test.ts
+++ b/packages/server/core/tests/plugins/render.test.ts
@@ -3,7 +3,11 @@ import type { Logger, ServerRoute } from '@modern-js/types';
 import { injectResourcePlugin } from '../../src/adapters/node/plugins';
 import { createDefaultPlugins, renderPlugin } from '../../src/plugins';
 import { createServerBase } from '../../src/serverBase';
-import type { ServerUserConfig } from '../../src/types';
+import type {
+  FallbackInput,
+  ServerPlugin,
+  ServerUserConfig,
+} from '../../src/types';
 import { getDefaultAppContext, getDefaultConfig } from '../helpers';
 
 const logger: Logger = {
@@ -24,6 +28,7 @@ const logger: Logger = {
 async function createSSRServer(
   pwd: string,
   serverConfig: ServerUserConfig = { ssr: true },
+  extraPlugins: ServerPlugin[] = [],
 ) {
   const config = getDefaultConfig();
 
@@ -42,6 +47,7 @@ async function createSSRServer(
     ...createDefaultPlugins({
       logger,
     }),
+    ...extraPlugins,
     injectResourcePlugin(),
     renderPlugin(),
   ]);
@@ -49,6 +55,18 @@ async function createSSRServer(
   await server.init();
 
   return server;
+}
+
+function createFallbackCapturePlugin(inputs: FallbackInput[]): ServerPlugin {
+  return {
+    name: 'fallback-capture',
+    setup(api) {
+      api.fallback(async input => {
+        inputs.push(input);
+        return input;
+      });
+    },
+  };
 }
 
 describe('should render html correctly', () => {
@@ -174,6 +192,47 @@ describe('should render html correctly', () => {
     expect(html4).toMatch(/Hello Modern/);
   });
 
+  it('should pass request and monitors when forcing csr fallback', async () => {
+    const ssrPwd = path.join(pwd, 'ssr');
+    const fallbackInputs: FallbackInput[] = [];
+    const server = await createSSRServer(
+      ssrPwd,
+      {
+        ssr: {
+          forceCSR: true,
+        },
+      },
+      [createFallbackCapturePlugin(fallbackInputs)],
+    );
+
+    let fallbackHeader;
+    const html = await Promise.resolve(server.request('/?csr=1', {}, {})).then(
+      res => {
+        fallbackHeader = res.headers.get('x-modern-ssr-fallback');
+        return res.text();
+      },
+    );
+
+    expect(html).toMatch(/Hello Modern/);
+    expect(fallbackHeader).toBe('1;reason=query');
+    expect(
+      html.includes(
+        `<script id="__modern_ssr_fallback_reason__" type="application/json">{"reason":"query"}</script>`,
+      ),
+    ).toBe(true);
+    expect(fallbackInputs).toHaveLength(1);
+    const fallbackInput = fallbackInputs[0]!;
+    expect(fallbackInput.reason).toBe('query');
+    expect(fallbackInput.context?.request).toBeInstanceOf(Request);
+    expect(fallbackInput.context?.request.url).toContain('/?csr=1');
+    expect(fallbackInput.context?.monitors?.counter).toEqual(
+      expect.any(Function),
+    );
+    expect(fallbackInput.context?.monitors?.error).toEqual(
+      expect.any(Function),
+    );
+  });
+
   it('support serve data', async () => {
     const ssrPwd = path.join(pwd, 'ssr');
 
@@ -218,5 +277,54 @@ describe('should render html correctly', () => {
         `<script id="__modern_ssr_fallback_reason__" type="application/json">{"reason":"error"}</script>`,
       ),
     ).toBe(true);
+  });
+
+  it('should pass request and monitors when render error fallback', async () => {
+    const ssrPwd = path.join(pwd, 'ssr');
+    const fallbackInputs: FallbackInput[] = [];
+    const server = await createSSRServer(
+      ssrPwd,
+      {
+        ssr: {
+          forceCSR: true,
+        },
+      },
+      [createFallbackCapturePlugin(fallbackInputs)],
+    );
+
+    let fallbackHeader;
+    const html = await Promise.resolve(
+      server.request(
+        '/',
+        {
+          headers: new Headers({
+            'x-render-error': '1',
+          }),
+        },
+        {},
+      ),
+    ).then(res => {
+      fallbackHeader = res.headers.get('x-modern-ssr-fallback');
+      return res.text();
+    });
+
+    expect(fallbackHeader).toBe('1;reason=error');
+    expect(
+      html.includes(
+        `<script id="__modern_ssr_fallback_reason__" type="application/json">{"reason":"error"}</script>`,
+      ),
+    ).toBe(true);
+    expect(fallbackInputs).toHaveLength(1);
+    const fallbackInput = fallbackInputs[0]!;
+    expect(fallbackInput.reason).toBe('error');
+    expect(fallbackInput.error).toBeInstanceOf(Error);
+    expect(fallbackInput.context?.request).toBeInstanceOf(Request);
+    expect(fallbackInput.context?.request.url).toContain('/');
+    expect(fallbackInput.context?.monitors?.counter).toEqual(
+      expect.any(Function),
+    );
+    expect(fallbackInput.context?.monitors?.error).toEqual(
+      expect.any(Function),
+    );
   });
 });


### PR DESCRIPTION
## Summary

### English
- Add optional `context` to server plugin fallback hook payload with the current `Request` and request-scoped `Monitors`.
- Thread the context through active CSR fallback and SSR render error fallback without changing existing fallback headers or HTML reason injection.
- Add focused server-core tests and a changeset.

### 中文
- 为 server 插件 fallback hook 入参增加可选 `context`，包含当前 `Request` 和请求级 `Monitors`。
- 在主动 CSR fallback 和 SSR 渲染错误 fallback 链路中传递 context，同时保持现有 fallback header 和 HTML reason 注入行为不变。
- 补充 server-core 聚焦测试和 changeset。

## Tests

- `pnpm --filter @modern-js/server-core test -- tests/plugins/render.test.ts`
- `pnpm --filter @modern-js/server-core build`
- `pnpm biome check --files-ignore-unknown=true packages/server/core/src/plugins/render/inject.ts packages/server/core/src/plugins/render/render.ts packages/server/core/src/types/plugins/base.ts packages/server/core/src/types/plugins/index.ts packages/server/core/tests/plugins/render.test.ts`