### PR TITLE
fix(plugin-i18n): keep locale paths independent from assetPrefix

### DIFF
--- a/.changeset/quiet-locales-serve.md
+++ b/.changeset/quiet-locales-serve.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-i18n': patch
+---
+
+fix(plugin-i18n): keep browser backend locale paths independent from assetPrefix
+
+fix(plugin-i18n): 浏览器端 backend 加载本地语言资源时不再拼接 assetPrefix

--- a/.changeset/soft-i18n-hydration.md
+++ b/.changeset/soft-i18n-hydration.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-i18n': patch
+---
+
+fix(plugin-i18n): align SSR backend with detected public locales directory
+
+fix(plugin-i18n): SSR backend 跟随检测到的 public locales 目录，避免与根 locales 目录读取不一致

--- a/packages/runtime/plugin-i18n/src/cli/index.ts
+++ b/packages/runtime/plugin-i18n/src/cli/index.ts
@@ -1,85 +1,15 @@
-import fs from 'fs';
-import path from 'path';
 import type { AppTools, CliPlugin } from '@modern-js/app-tools';
 import { getPublicDirRoutePrefixes } from '@modern-js/server-core';
 import type { Entrypoint } from '@modern-js/types';
 import type { BackendOptions, LocaleDetectionOptions } from '../shared/type';
 import { getBackendOptions, getLocaleDetectionOptions } from '../shared/utils';
+import { applyDetectedBackendPaths, detectLocalesDirectory } from './locales';
 import '../runtime/types';
 
 export type TransformRuntimeConfigFn = (
   extendedConfig: Record<string, any>,
   entrypoint: Entrypoint,
 ) => Record<string, any>;
-
-/**
- * Check if a directory exists and contains JSON files
- */
-function hasJsonFiles(dirPath: string): boolean {
-  try {
-    if (!fs.existsSync(dirPath) || !fs.statSync(dirPath).isDirectory()) {
-      return false;
-    }
-    const entries = fs.readdirSync(dirPath);
-    // Check if there are any JSON files in the directory or subdirectories
-    for (const entry of entries) {
-      const entryPath = path.join(dirPath, entry);
-      const stat = fs.statSync(entryPath);
-      if (stat.isFile() && entry.endsWith('.json')) {
-        return true;
-      }
-      if (stat.isDirectory()) {
-        // Recursively check subdirectories (e.g., locales/en/, locales/zh/)
-        if (hasJsonFiles(entryPath)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Auto-detect if locales directory exists with JSON files
- * Checks both project root and config/public directory
- */
-function detectLocalesDirectory(
-  appDirectory: string,
-  normalizedConfig?: any,
-): boolean {
-  // Check project root directory
-  const rootLocalesPath = path.join(appDirectory, 'locales');
-  if (hasJsonFiles(rootLocalesPath)) {
-    return true;
-  }
-
-  // Check config/public directory
-  const configPublicPath = path.join(
-    appDirectory,
-    'config',
-    'public',
-    'locales',
-  );
-  if (hasJsonFiles(configPublicPath)) {
-    return true;
-  }
-
-  // Check publicDir if configured
-  const publicDir = normalizedConfig?.server?.publicDir;
-  if (publicDir) {
-    const publicDirPath = Array.isArray(publicDir) ? publicDir[0] : publicDir;
-    const localesPath = path.isAbsolute(publicDirPath)
-      ? path.join(publicDirPath, 'locales')
-      : path.join(appDirectory, publicDirPath, 'locales');
-    if (hasJsonFiles(localesPath)) {
-      return true;
-    }
-  }
-
-  return false;
-}
 
 export interface I18nPluginOptions {
   localeDetection?: LocaleDetectionOptions;
@@ -118,10 +48,14 @@ export const i18nPlugin = (
       // Auto-detect locales directory and enable backend if:
       // 1. User didn't explicitly set backend.enabled to false
       // 2. Locales directory exists with JSON files
-      // 3. If user configured loadPath or addPath, auto-enable backend without detection
+      // 3. If user configured loadPath or addPath, auto-enable backend
       let backendOptions: BackendOptions | undefined;
       const { appDirectory } = api.getAppContext();
       const normalizedConfig = api.getNormalizedConfig();
+      const detectedLocales = detectLocalesDirectory(
+        appDirectory,
+        normalizedConfig,
+      );
 
       if (backend) {
         const entryBackendOptions = getBackendOptions(
@@ -132,45 +66,35 @@ export const i18nPlugin = (
         if (entryBackendOptions?.enabled === false) {
           backendOptions = entryBackendOptions;
         } else {
-          // If user configured loadPath or addPath, auto-enable backend
-          // No need to detect locales directory since user has specified the path
-          if (entryBackendOptions?.loadPath || entryBackendOptions?.addPath) {
+          if (detectedLocales) {
+            backendOptions = applyDetectedBackendPaths(
+              entryBackendOptions,
+              detectedLocales,
+            );
+          } else if (
+            entryBackendOptions?.loadPath ||
+            entryBackendOptions?.addPath
+          ) {
+            // If user configured loadPath or addPath, auto-enable backend even
+            // when no local locales directory is detected.
             backendOptions = {
               ...entryBackendOptions,
               enabled: true,
             };
-          } else if (entryBackendOptions?.enabled !== true) {
-            // Auto-detect if enabled is not explicitly true and no loadPath/addPath configured
-            const hasLocales = detectLocalesDirectory(
-              appDirectory,
-              normalizedConfig,
-            );
-
-            if (hasLocales) {
-              // Auto-enable backend if locales directory is detected
-              backendOptions = {
-                ...entryBackendOptions,
-                enabled: true,
-              };
-            } else {
-              backendOptions = entryBackendOptions;
-            }
           } else {
             backendOptions = entryBackendOptions;
           }
         }
       } else {
         // No backend config provided, try auto-detection
-        const hasLocales = detectLocalesDirectory(
-          appDirectory,
-          normalizedConfig,
-        );
-
-        if (hasLocales) {
+        if (detectedLocales) {
           // Auto-enable backend if locales directory is detected
-          backendOptions = getBackendOptions(entrypoint.entryName, {
-            enabled: true,
-          });
+          backendOptions = applyDetectedBackendPaths(
+            getBackendOptions(entrypoint.entryName, {
+              enabled: true,
+            }),
+            detectedLocales,
+          );
         }
       }
 

--- a/packages/runtime/plugin-i18n/src/cli/locales.ts
+++ b/packages/runtime/plugin-i18n/src/cli/locales.ts
@@ -1,0 +1,186 @@
+import fs from 'fs';
+import path from 'path';
+import {
+  getPublicDirRoutePrefixes,
+  normalizePublicDir,
+  normalizePublicDirPath,
+} from '@modern-js/server-core';
+import type { BackendOptions } from '../shared/type';
+
+interface NormalizedConfigForLocales {
+  server?: {
+    publicDir?: string | string[];
+  };
+}
+
+export interface DetectedLocalesDirectory {
+  loadPath: string;
+  addPath: string;
+  serverLoadPath: string;
+  serverAddPath: string;
+  serverLoadPaths?: string[];
+  serverAddPaths?: string[];
+}
+
+const LOCALES_RESOURCE_PATTERN = '{{lng}}/{{ns}}.json';
+
+function hasJsonFiles(dirPath: string): boolean {
+  try {
+    if (!fs.existsSync(dirPath) || !fs.statSync(dirPath).isDirectory()) {
+      return false;
+    }
+    const entries = fs.readdirSync(dirPath);
+    for (const entry of entries) {
+      const entryPath = path.join(dirPath, entry);
+      const stat = fs.statSync(entryPath);
+      if (stat.isFile() && entry.endsWith('.json')) {
+        return true;
+      }
+      if (stat.isDirectory() && hasJsonFiles(entryPath)) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join(path.posix.sep);
+}
+
+function getPublicDirOutputPath(publicDir: string): string {
+  return normalizePublicDirPath(publicDir);
+}
+
+function buildDetectedLocalesDirectory(
+  clientBasePath: string,
+  serverBasePath: string,
+  serverBasePathCandidates: string[] = [serverBasePath],
+): DetectedLocalesDirectory {
+  const normalizedClientBasePath = clientBasePath.startsWith('/')
+    ? clientBasePath
+    : `/${clientBasePath}`;
+  const normalizedServerBasePath = toPosixPath(serverBasePath).replace(
+    /\/$/,
+    '',
+  );
+  const normalizedServerBasePathCandidates = Array.from(
+    new Set(
+      serverBasePathCandidates.map(candidate =>
+        toPosixPath(candidate).replace(/\/$/, ''),
+      ),
+    ),
+  );
+  const serverLoadPaths = normalizedServerBasePathCandidates.map(
+    candidate => `${candidate}/${LOCALES_RESOURCE_PATTERN}`,
+  );
+  const serverAddPaths = normalizedServerBasePathCandidates.map(
+    candidate => `${candidate}/${LOCALES_RESOURCE_PATTERN}`,
+  );
+
+  return {
+    loadPath: `${normalizedClientBasePath}/${LOCALES_RESOURCE_PATTERN}`,
+    addPath: `${normalizedClientBasePath}/${LOCALES_RESOURCE_PATTERN}`,
+    serverLoadPath: `${normalizedServerBasePath}/${LOCALES_RESOURCE_PATTERN}`,
+    serverAddPath: `${normalizedServerBasePath}/${LOCALES_RESOURCE_PATTERN}`,
+    serverLoadPaths,
+    serverAddPaths,
+  };
+}
+
+export function detectLocalesDirectory(
+  appDirectory: string,
+  normalizedConfig?: NormalizedConfigForLocales,
+): DetectedLocalesDirectory | undefined {
+  const publicDirs = normalizePublicDir(normalizedConfig?.server?.publicDir);
+  const publicDirPrefixes = getPublicDirRoutePrefixes(
+    normalizedConfig?.server?.publicDir,
+  );
+
+  for (let index = 0; index < publicDirs.length; index++) {
+    const publicDir = publicDirs[index];
+    if (path.isAbsolute(publicDir)) {
+      continue;
+    }
+
+    const publicDirPath = path.join(appDirectory, publicDir);
+    const publicDirPrefix =
+      publicDirPrefixes[index] || `/${normalizePublicDirPath(publicDir)}`;
+    const publicDirOutputPath = getPublicDirOutputPath(publicDir);
+
+    if (
+      path.basename(normalizePublicDirPath(publicDir)) === 'locales' &&
+      hasJsonFiles(publicDirPath)
+    ) {
+      return buildDetectedLocalesDirectory(
+        publicDirPrefix,
+        `./${publicDirOutputPath}`,
+      );
+    }
+
+    const localesPath = path.join(publicDirPath, 'locales');
+    if (hasJsonFiles(localesPath)) {
+      return buildDetectedLocalesDirectory(
+        `${publicDirPrefix}/locales`,
+        `./${publicDirOutputPath}/locales`,
+      );
+    }
+  }
+
+  const configPublicPath = path.join(
+    appDirectory,
+    'config',
+    'public',
+    'locales',
+  );
+  if (hasJsonFiles(configPublicPath)) {
+    return buildDetectedLocalesDirectory('/locales', './public/locales', [
+      './config/public/locales',
+      './public/locales',
+    ]);
+  }
+
+  const rootLocalesPath = path.join(appDirectory, 'locales');
+  if (hasJsonFiles(rootLocalesPath)) {
+    return buildDetectedLocalesDirectory('/locales', './locales');
+  }
+
+  return undefined;
+}
+
+export function applyDetectedBackendPaths(
+  backendOptions: BackendOptions,
+  detectedLocales: DetectedLocalesDirectory | undefined,
+): BackendOptions {
+  if (!detectedLocales) {
+    return backendOptions;
+  }
+
+  const backendWithDetectedPaths: BackendOptions & {
+    _detectedLoadPath: string;
+    _detectedAddPath: string;
+  } = {
+    ...backendOptions,
+    enabled: true,
+    loadPath: backendOptions.loadPath ?? detectedLocales.loadPath,
+    addPath: backendOptions.addPath ?? detectedLocales.addPath,
+    serverLoadPath:
+      backendOptions.serverLoadPath ?? detectedLocales.serverLoadPath,
+    serverLoadPaths:
+      backendOptions.serverLoadPath || backendOptions.serverLoadPaths
+        ? backendOptions.serverLoadPaths
+        : detectedLocales.serverLoadPaths,
+    serverAddPath:
+      backendOptions.serverAddPath ?? detectedLocales.serverAddPath,
+    serverAddPaths:
+      backendOptions.serverAddPath || backendOptions.serverAddPaths
+        ? backendOptions.serverAddPaths
+        : detectedLocales.serverAddPaths,
+    _detectedLoadPath: detectedLocales.loadPath,
+    _detectedAddPath: detectedLocales.addPath,
+  };
+
+  return backendWithDetectedPaths;
+}

--- a/packages/runtime/plugin-i18n/src/runtime/i18n/backend/defaults.node.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/i18n/backend/defaults.node.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+
 export const DEFAULT_I18NEXT_BACKEND_OPTIONS = {
   loadPath: './locales/{{lng}}/{{ns}}.json',
   addPath: './locales/{{lng}}/{{ns}}.json',
@@ -14,18 +16,85 @@ function convertPath(path: string | undefined): string | undefined {
   return path;
 }
 
-export function convertBackendOptions<
-  T extends { loadPath?: string; addPath?: string },
->(options: T): T {
+interface InternalBackendPathOptions {
+  loadPath?: string;
+  addPath?: string;
+  serverLoadPath?: string;
+  serverAddPath?: string;
+  serverLoadPaths?: string[];
+  serverAddPaths?: string[];
+  _detectedLoadPath?: string;
+  _detectedAddPath?: string;
+}
+
+function shouldUseServerPath(
+  currentPath: string | undefined,
+  detectedPath: string | undefined,
+): boolean {
+  return !detectedPath || currentPath === detectedPath;
+}
+
+function getResourceBasePath(resourcePath: string): string {
+  const markerIndex = resourcePath.indexOf('{{lng}}');
+  if (markerIndex < 0) {
+    return resourcePath;
+  }
+  return resourcePath.slice(0, markerIndex).replace(/[\\/]+$/, '');
+}
+
+function pathExists(resourcePath: string): boolean {
+  try {
+    return fs.existsSync(getResourceBasePath(resourcePath));
+  } catch {
+    return false;
+  }
+}
+
+function getServerPath(
+  pathCandidates: string[] | undefined,
+  fallbackPath: string | undefined,
+): string | undefined {
+  const candidates = Array.from(
+    new Set([...(pathCandidates || []), fallbackPath].filter(Boolean)),
+  ) as string[];
+
+  return candidates.find(pathExists) || candidates[0];
+}
+
+export function convertBackendOptions<T extends InternalBackendPathOptions>(
+  options: T,
+): T {
   if (!options) {
     return options;
   }
   const converted = { ...options };
-  if (converted.loadPath) {
+  if (
+    (converted.serverLoadPath || converted.serverLoadPaths) &&
+    shouldUseServerPath(converted.loadPath, converted._detectedLoadPath)
+  ) {
+    converted.loadPath = getServerPath(
+      converted.serverLoadPaths,
+      converted.serverLoadPath,
+    );
+  } else if (converted.loadPath) {
     converted.loadPath = convertPath(converted.loadPath);
   }
-  if (converted.addPath) {
+  if (
+    (converted.serverAddPath || converted.serverAddPaths) &&
+    shouldUseServerPath(converted.addPath, converted._detectedAddPath)
+  ) {
+    converted.addPath = getServerPath(
+      converted.serverAddPaths,
+      converted.serverAddPath,
+    );
+  } else if (converted.addPath) {
     converted.addPath = convertPath(converted.addPath);
   }
+  delete converted.serverLoadPath;
+  delete converted.serverAddPath;
+  delete converted.serverLoadPaths;
+  delete converted.serverAddPaths;
+  delete converted._detectedLoadPath;
+  delete converted._detectedAddPath;
   return converted;
 }

--- a/packages/runtime/plugin-i18n/src/runtime/i18n/backend/defaults.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/i18n/backend/defaults.ts
@@ -7,13 +7,30 @@ function convertPath(path: string | undefined): string | undefined {
   return path;
 }
 
-export function convertBackendOptions<
-  T extends { loadPath?: string; addPath?: string },
->(options: T): T {
+interface InternalBackendPathOptions {
+  loadPath?: string;
+  addPath?: string;
+  serverLoadPath?: string;
+  serverAddPath?: string;
+  serverLoadPaths?: string[];
+  serverAddPaths?: string[];
+  _detectedLoadPath?: string;
+  _detectedAddPath?: string;
+}
+
+export function convertBackendOptions<T extends InternalBackendPathOptions>(
+  options: T,
+): T {
   if (!options) {
     return options;
   }
   const converted = { ...options };
+  delete converted.serverLoadPath;
+  delete converted.serverAddPath;
+  delete converted.serverLoadPaths;
+  delete converted.serverAddPaths;
+  delete converted._detectedLoadPath;
+  delete converted._detectedAddPath;
   if (converted.loadPath) {
     converted.loadPath = convertPath(converted.loadPath);
   }

--- a/packages/runtime/plugin-i18n/src/runtime/i18n/backend/defaults.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/i18n/backend/defaults.ts
@@ -3,20 +3,7 @@ export const DEFAULT_I18NEXT_BACKEND_OPTIONS = {
   addPath: '/locales/{{lng}}/{{ns}}.json',
 };
 
-declare global {
-  interface Window {
-    __assetPrefix__?: string;
-  }
-}
-
 function convertPath(path: string | undefined): string | undefined {
-  if (!path) {
-    return path;
-  }
-  // If it's an absolute path (starts with /), convert to relative path
-  if (path.startsWith('/')) {
-    return `${window.__assetPrefix__ || ''}${path}`;
-  }
   return path;
 }
 

--- a/packages/runtime/plugin-i18n/src/shared/type.ts
+++ b/packages/runtime/plugin-i18n/src/shared/type.ts
@@ -72,6 +72,26 @@ export interface BaseBackendOptions {
   loadPath?: string;
   addPath?: string;
   /**
+   * Internal file-system path used by the Node.js FS backend.
+   * Browser HTTP backend keeps using `loadPath`.
+   */
+  serverLoadPath?: string;
+  /**
+   * Internal file-system path candidates used by the Node.js FS backend.
+   * The first existing path under current cwd will be used.
+   */
+  serverLoadPaths?: string[];
+  /**
+   * Internal file-system path used by the Node.js FS backend.
+   * Browser HTTP backend keeps using `addPath`.
+   */
+  serverAddPath?: string;
+  /**
+   * Internal file-system path candidates used by the Node.js FS backend.
+   * The first existing path under current cwd will be used.
+   */
+  serverAddPaths?: string[];
+  /**
    * Cache hit mode for chained backend (only effective when both `loadPath` and `sdk` are provided)
    *
    * - `'none'` (default): If the first backend returns resources, stop and don't try the next backend


### PR DESCRIPTION
### Background / Problem

When `@modern-js/plugin-i18n` auto-detects local `locales` files and enables the backend, CSR and SSR handled resource paths inconsistently:

1. Browser-side local locale requests could be affected by `assetPrefix`, causing public resource paths like `/locales/{{lng}}/{{ns}}.json` to be prefixed incorrectly.
2. SSR converted `/locales/...` to `./locales/...` by default, but when the actual files were under `config/public/locales` or a custom `server.publicDir`, the Node FS backend read from the wrong directory.
3. Auto-injected SSR backend paths should not use source-directory absolute paths, and they must not override user-defined `initOptions.backend.loadPath/addPath` from runtime config.

### Solution

- Extracted locale detection into `src/cli/locales.ts` and centralized support for:
  - `config/public/locales`
  - root-level `locales`
  - custom `server.publicDir`
- Auto-detection now generates both:
  - browser public URLs, e.g. `/locales/{{lng}}/{{ns}}.json`
  - SSR Node FS backend paths relative to the built server output, e.g. `./public/locales/{{lng}}/{{ns}}.json`
- Node `convertBackendOptions` uses detected `serverLoadPath/serverAddPath` only when the current path is still the auto-detected path, so user runtime overrides are preserved.
- Browser `convertBackendOptions` strips server-only/internal fields before backend config is used.
- Added tests for detection priority, SSR path conversion, runtime path overrides, and browser-side field cleanup.

### 背景 / 问题

`@modern-js/plugin-i18n` 在自动检测本地 `locales` 目录并启用 backend 时，CSR 和 SSR 对资源路径的处理存在不一致：

1. 浏览器端的本地语言资源请求会受到 `assetPrefix` 影响，导致 `/locales/{{lng}}/{{ns}}.json` 这类 public 资源路径被错误拼接。
2. SSR 端默认会把 `/locales/...` 转成 `./locales/...`，但当实际资源位于 `config/public/locales` 或自定义 `server.publicDir` 下时，Node FS backend 会读取错误目录。
3. 自动注入的 SSR backend 路径需要避免使用源码目录的绝对路径，同时不能覆盖用户在 runtime 中显式配置的 `initOptions.backend.loadPath/addPath`。

### 解决方案

- 将 locales 自动检测逻辑抽到 `src/cli/locales.ts`，统一处理：
  - `config/public/locales`
  - 项目根目录 `locales`
  - 自定义 `server.publicDir`
- 自动检测时同时生成：
  - 浏览器使用的 public URL：如 `/locales/{{lng}}/{{ns}}.json`
  - SSR Node FS backend 使用的构建产物相对路径：如 `./public/locales/{{lng}}/{{ns}}.json`
- Node 端 `convertBackendOptions` 优先使用自动检测到的 `serverLoadPath/serverAddPath`，但仅在当前 path 仍是自动检测值时生效，避免覆盖用户 runtime 配置。
- 浏览器端 `convertBackendOptions` 会移除 server-only/internal 字段，避免这些字段参与浏览器 backend 配置。
- 补充单测覆盖自动检测优先级、SSR 路径转换、runtime path override 和浏览器字段清理。
